### PR TITLE
Fix issue where user cannot select "Next Customer" at the purchase screen

### DIFF
--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -107,11 +107,11 @@ const styles = StyleSheet.create({
     marginBottom: size(0.5)
   },
   ctaButtonsWrapper: {
-    marginTop: size(5)
+    marginTop: size(5),
+    paddingBottom: size(10)
   },
   buttonRow: {
-    flexDirection: "row",
-    paddingBottom: size(10)
+    flexDirection: "row"
   },
   submitButton: { flex: 1 }
 });

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -111,6 +111,7 @@ export const InitialisationContainer: FunctionComponent<NavigationProps> = ({
     setIsLoading(true);
     try {
       const authenticated = await authenticate(key, config.appMode);
+      console.log("GOT RESPONSE: ", authenticated);
       if (authenticated) {
         setAuthKey(key);
         setIsLoading(false);

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -111,7 +111,6 @@ export const InitialisationContainer: FunctionComponent<NavigationProps> = ({
     setIsLoading(true);
     try {
       const authenticated = await authenticate(key, config.appMode);
-      console.log("GOT RESPONSE: ", authenticated);
       if (authenticated) {
         setAuthKey(key);
         setIsLoading(false);

--- a/src/services/auth/index.tsx
+++ b/src/services/auth/index.tsx
@@ -7,6 +7,7 @@ export interface Policy {
   unit: string;
   quantityLimit: number; // Not needed now
   period: number; // Not needed now
+  order: number;
 }
 
 export interface AuthenticationResponse {
@@ -40,21 +41,24 @@ export const mockAuthenticate = async (
         name: "Toilet Paper",
         period: 7,
         quantityLimit: 1000,
-        unit: "piece"
+        unit: "piece",
+        order: 1
       },
       {
         category: "instant-noodles",
         name: "Instant Noodles",
         period: 30,
         quantityLimit: 60,
-        unit: "packs"
+        unit: "packs",
+        order: 2
       },
       {
         category: "chocolate",
         name: "Chocolate",
         period: 14,
         quantityLimit: 1,
-        unit: "grams"
+        unit: "grams",
+        order: 3
       }
     ]
   };


### PR DESCRIPTION
Found an edge case while doing testing. Let's say there's an example where a customer comes in and buys everything, at the Purchase screen, the "Next Customer" button will not be within the screen as the purchase list is too long. Hence the adding of the paddingBottom to all ctaButtons instead, rather than just for one.

Other stuff in this PR:
- There was some error reported by Policy, so I fixed it
- Adding a console log for the authenticated for the time being to monitor the bug ZY raised