### PR TITLE
fix: improve disabling of camera when screen not focused

### DIFF
--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -8,7 +8,6 @@ import {
   ActivityIndicator
 } from "react-native";
 import { Feather } from "@expo/vector-icons";
-import { NavigationProps } from "../../types";
 import { DarkButton } from "../Layout/Buttons/DarkButton";
 import { SecondaryButton } from "../Layout/Buttons/SecondaryButton";
 import { fontSize, size, color } from "../../common/styles";
@@ -24,6 +23,10 @@ import { AppText } from "../Layout/AppText";
 import { TopBackground } from "../Layout/TopBackground";
 import { Credits } from "../Credits";
 import { useConfigContext } from "../../context/config";
+import {
+  withNavigationFocus,
+  NavigationFocusInjectedProps
+} from "react-navigation";
 
 const styles = StyleSheet.create({
   content: {
@@ -82,8 +85,9 @@ const styles = StyleSheet.create({
   }
 });
 
-export const CollectCustomerDetailsScreen: FunctionComponent<NavigationProps> = ({
-  navigation
+const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedProps> = ({
+  navigation,
+  isFocused
 }) => {
   const { authKey, endpoint } = useAuthenticationContext();
   const [hasCameraPermission, setHasCameraPermission] = useState(false);
@@ -100,19 +104,6 @@ export const CollectCustomerDetailsScreen: FunctionComponent<NavigationProps> = 
   useEffect(() => {
     askForCameraPermission();
   }, []);
-
-  useEffect(() => {
-    const willBlurSubscription = navigation.addListener("willBlur", () => {
-      setScanningEnabled(false);
-    });
-    const willFocusSubscription = navigation.addListener("willFocus", () => {
-      setScanningEnabled(true);
-    });
-    return () => {
-      willBlurSubscription.remove();
-      willFocusSubscription.remove();
-    };
-  }, [navigation]);
 
   const onCheck = async (input: string): Promise<void> => {
     try {
@@ -146,7 +137,7 @@ export const CollectCustomerDetailsScreen: FunctionComponent<NavigationProps> = 
   };
 
   const onBarCodeScanned = (event: BarCodeScanningResult): void => {
-    if (scanningEnabled && !isLoading && event.data) {
+    if (isFocused && scanningEnabled && !isLoading && event.data) {
       onCheck(event.data);
     }
   };
@@ -249,3 +240,7 @@ export const CollectCustomerDetailsScreen: FunctionComponent<NavigationProps> = 
     </>
   );
 };
+
+export const CollectCustomerDetailsScreenContainer = withNavigationFocus(
+  CollectCustomerDetailsScreen
+);

--- a/src/navigation/StackNavigator/CollectCustomerDetailsScreen.tsx
+++ b/src/navigation/StackNavigator/CollectCustomerDetailsScreen.tsx
@@ -1,3 +1,3 @@
-import { CollectCustomerDetailsScreen } from "../../components/CustomerDetails/CollectCustomerDetailsScreen";
+import { CollectCustomerDetailsScreenContainer } from "../../components/CustomerDetails/CollectCustomerDetailsScreen";
 
-export default CollectCustomerDetailsScreen;
+export default CollectCustomerDetailsScreenContainer;


### PR DESCRIPTION
There were reports of people who have not redeemed anything seeing that they don't have any quota left. I noticed this firsthand, and it occurs when a batch (household) of IDs were being scanned.

I managed to reproduce it several times when combined with a throttled network and on slower devices. For example, given 2 IDs, A and B, by scanning in quick succession, there are times when the quota of B is recorded when the user thinks A's quota is being recorded. So when scanning B, it correctly shows that B does not have quota left. If the user scans A again, he'll notice that there's quota available for A.

The issue stems from the camera on the scanning ID screen not being turned off properly after an ID was identified. So just before navigating to the quota available screen, the camera could pick up on the next ID (that has been placed in view of the camera). This causes the 2nd ID's quota to be shown. Since everyone's quota is the same, it's difficult to discern the differences in ID.

I've used React navigation's `withNavigationFocus` rather than relying on the event listeners. I've tested several times and it effectively stops the camera from scanning.