### PR TITLE
feat: improve logout flow

### DIFF
--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -28,6 +28,7 @@ import * as Sentry from "sentry-expo";
 import { HelpModalContext } from "../../context/help";
 import { HelpButton } from "../Layout/Buttons/HelpButton";
 import { FeatureToggler } from "../FeatureToggler/FeatureToggler";
+import { useValidateExpiry } from "../../hooks/useValidateExpiry";
 import { Banner } from "../Layout/Banner";
 import { ImportantMessageContentContext } from "../../context/importantMessage";
 
@@ -72,6 +73,11 @@ export const CustomerQuotaScreen: FunctionComponent<NavigationProps> = ({
       message: "CustomerQuotaScreen"
     });
   }, []);
+
+  const validateTokenExpiry = useValidateExpiry(navigation.dispatch);
+  useEffect(() => {
+    validateTokenExpiry();
+  }, [validateTokenExpiry]);
 
   const messageContent = useContext(ImportantMessageContentContext);
   const { config } = useConfigContext();

--- a/src/hooks/useLogout.tsx
+++ b/src/hooks/useLogout.tsx
@@ -1,0 +1,51 @@
+import { useContext, useState, useCallback } from "react";
+import { ImportantMessageSetterContext } from "../context/importantMessage";
+import { useAuthenticationContext } from "../context/auth";
+import { useProductContext } from "../context/products";
+import { Alert } from "react-native";
+import { NavigationDispatch, NavigationActions } from "react-navigation";
+
+type AlertProps = {
+  title: string;
+  description?: string;
+};
+
+interface LogoutHook {
+  isLoggingOut: boolean;
+  logout: (navigationDispatch?: NavigationDispatch, alert?: AlertProps) => void;
+}
+
+export const useLogout = (): LogoutHook => {
+  const setMessageContent = useContext(ImportantMessageSetterContext);
+  const { clearAuthInfo } = useAuthenticationContext();
+  const { setProducts } = useProductContext();
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  const logout: LogoutHook["logout"] = useCallback(
+    async (navigationDispatch, alert) => {
+      if (!navigationDispatch) {
+        return;
+      }
+      setIsLoggingOut(true);
+      await clearAuthInfo();
+      setProducts([]);
+      setMessageContent(null);
+      setIsLoggingOut(false);
+      navigationDispatch?.(
+        NavigationActions.navigate({
+          routeName: "LoginScreen"
+        })
+      );
+      if (alert) {
+        const { title, description } = alert;
+        Alert.alert(title, description);
+      }
+    },
+    [clearAuthInfo, setMessageContent, setProducts]
+  );
+
+  return {
+    isLoggingOut,
+    logout
+  };
+};

--- a/src/hooks/useValidateExpiry.tsx
+++ b/src/hooks/useValidateExpiry.tsx
@@ -5,8 +5,8 @@ import { ImportantMessageSetterContext } from "../context/importantMessage";
 import { useAuthenticationContext } from "../context/auth";
 import { useLogout } from "./useLogout";
 
-const ABOUT_TO_EXPIRE_SECONDS = 60;
-const MAX_INTERVAL_SECONDS = 60;
+const ABOUT_TO_EXPIRE_SECONDS = 30 * 60;
+const MAX_INTERVAL_SECONDS = 60; // refreshes countdown at most every minute
 let timeout = 0;
 
 export const useValidateExpiry = (

--- a/src/hooks/useValidateExpiry.tsx
+++ b/src/hooks/useValidateExpiry.tsx
@@ -1,0 +1,75 @@
+import { differenceInSeconds } from "date-fns";
+import { useCallback, useContext } from "react";
+import { NavigationDispatch } from "react-navigation";
+import { ImportantMessageSetterContext } from "../context/importantMessage";
+import { useAuthenticationContext } from "../context/auth";
+import { useLogout } from "./useLogout";
+
+const ABOUT_TO_EXPIRE_SECONDS = 60;
+const MAX_INTERVAL_SECONDS = 60;
+let timeout = 0;
+
+export const useValidateExpiry = (
+  navigationDispatch: NavigationDispatch | undefined
+): (() => void) => {
+  const setMessageContent = useContext(ImportantMessageSetterContext);
+  const { expiry } = useAuthenticationContext();
+  const { isLoggingOut, logout } = useLogout();
+
+  const onExpired = useCallback(() => {
+    logout(navigationDispatch, {
+      title: "Session expired",
+      description: "You have been logged out"
+    });
+  }, [logout, navigationDispatch]);
+
+  const onAboutToExpire = useCallback(
+    secondsLeft => {
+      const duration =
+        secondsLeft > 60
+          ? `less than ${Math.ceil(secondsLeft / 60)} minutes`
+          : `${secondsLeft} second${secondsLeft > 1 ? "s" : ""}`;
+      setMessageContent({
+        title: `Session ends in ${duration}`,
+        description:
+          "You will need to login with a new QR code when it expires",
+        featherIconName: "clock",
+        action: {
+          callback: () => logout(),
+          label: "Logout"
+        }
+      });
+    },
+    [logout, setMessageContent]
+  );
+
+  const validate = useCallback(async (): Promise<void> => {
+    clearTimeout(timeout);
+
+    if (expiry === "" || isLoggingOut) {
+      return;
+    }
+    const diffInSeconds = Math.max(
+      0,
+      differenceInSeconds(Number(expiry), Date.now())
+    );
+    if (diffInSeconds === 0) {
+      onExpired();
+    } else if (diffInSeconds <= ABOUT_TO_EXPIRE_SECONDS) {
+      onAboutToExpire(diffInSeconds);
+      let durationInSeconds = MAX_INTERVAL_SECONDS;
+      if (diffInSeconds > MAX_INTERVAL_SECONDS) {
+        if (diffInSeconds % MAX_INTERVAL_SECONDS > 0) {
+          durationInSeconds = diffInSeconds % MAX_INTERVAL_SECONDS;
+        }
+      } else {
+        durationInSeconds = 1;
+      }
+      timeout = setTimeout(() => {
+        validate();
+      }, durationInSeconds * 1000);
+    }
+  }, [expiry, isLoggingOut, onAboutToExpire, onExpired]);
+
+  return validate;
+};

--- a/src/hooks/useValidateExpiry.tsx
+++ b/src/hooks/useValidateExpiry.tsx
@@ -49,20 +49,22 @@ export const useValidateExpiry = (
     if (expiry === "" || isLoggingOut) {
       return;
     }
-    const diffInSeconds = Math.max(
-      0,
-      differenceInSeconds(Number(expiry), Date.now())
-    );
-    if (diffInSeconds === 0) {
+
+    const diffInSeconds = differenceInSeconds(Number(expiry), Date.now());
+    if (diffInSeconds <= 0) {
       onExpired();
     } else if (diffInSeconds <= ABOUT_TO_EXPIRE_SECONDS) {
       onAboutToExpire(diffInSeconds);
       let durationInSeconds = MAX_INTERVAL_SECONDS;
       if (diffInSeconds > MAX_INTERVAL_SECONDS) {
         if (diffInSeconds % MAX_INTERVAL_SECONDS > 0) {
+          // set timeout to the nearest interval first.
+          // e.g. when max interval is 60s, with 2min 20s left,
+          // 1st timeout will be after 20s, 2nd timeout will be after another 60s.
           durationInSeconds = diffInSeconds % MAX_INTERVAL_SECONDS;
         }
       } else {
+        // countdown once there's less than 1 minute left
         durationInSeconds = 1;
       }
       timeout = setTimeout(() => {

--- a/src/navigation/Content.tsx
+++ b/src/navigation/Content.tsx
@@ -9,6 +9,7 @@ import { StatusBar, View, Platform } from "react-native";
 import LoginScreen from "./LoginScreen";
 import { useAppState } from "../hooks/useAppState";
 import { useCheckUpdates } from "../hooks/useCheckUpdates";
+import { useValidateExpiry } from "../hooks/useValidateExpiry";
 
 const SwitchNavigator = createSwitchNavigator(
   {
@@ -23,13 +24,20 @@ const AppContainer = createAppContainer(SwitchNavigator);
 export const Content = (): ReactElement => {
   const navigatorRef = useRef<NavigationContainerComponent>(null);
   const appState = useAppState();
-  const checkUpdates = useCheckUpdates();
 
+  const checkUpdates = useCheckUpdates();
   useEffect(() => {
     if (appState === "active") {
       checkUpdates();
     }
   }, [appState, checkUpdates]);
+
+  const validateTokenExpiry = useValidateExpiry(navigatorRef.current?.dispatch);
+  useEffect(() => {
+    if (appState === "active") {
+      validateTokenExpiry();
+    }
+  }, [appState, validateTokenExpiry]);
 
   return (
     <>


### PR DESCRIPTION
- When app is freshly opened / became in focus
    - If token is expired, logout immediately
    - If token is about to expire (60mins), show banner
- When app has been kept open
    - Whenever an NRIC is scanned, if about to expire (60mins), show banner 
    - Once countdown reaches 0, logout immediately

| Countdown updates every minute | When less than a minute, changes every second | Automatic logout |
| --- | --- | --- |
|![Simulator Screen Shot - iPhone 11 Pro - 2020-04-20 at 16 24 41](https://user-images.githubusercontent.com/577802/79731111-641e7380-8324-11ea-9ddb-9b3bf264eca9.png)| ![Simulator Screen Shot - iPhone 11 Pro - 2020-04-20 at 16 29 22](https://user-images.githubusercontent.com/577802/79731106-61bc1980-8324-11ea-8ab2-28a1d3e4fb3b.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2020-04-20 at 16 30 15](https://user-images.githubusercontent.com/577802/79731067-55d05780-8324-11ea-8842-c2a97efe41b0.png)|

