### PR TITLE
fix: crash on single digit phone numbers

### DIFF
--- a/src/components/Login/utils.test.tsx
+++ b/src/components/Login/utils.test.tsx
@@ -43,8 +43,10 @@ describe("createFullNumber", () => {
 
 describe("mobileNumberValidator", () => {
   it("should return false for invalid numbers", () => {
-    expect.assertions(5);
+    expect.assertions(7);
     expect(mobileNumberValidator("+65", "12345678")).toBe(false);
+    expect(mobileNumberValidator("+65", "1")).toBe(false);
+    expect(mobileNumberValidator("+65", "12")).toBe(false);
     expect(mobileNumberValidator("+1", "91234567")).toBe(false);
     expect(mobileNumberValidator("+65", " ")).toBe(false);
     expect(mobileNumberValidator("+65", "")).toBe(false);

--- a/src/components/Login/utils.ts
+++ b/src/components/Login/utils.ts
@@ -33,7 +33,7 @@ export const mobileNumberValidator = (
   countryCode: string,
   number: string
 ): boolean => {
-  if (!/^\d*$/.test(number) || number.length === 0) {
+  if (!/^\d*$/.test(number) || number.length <= 1) {
     return false;
   }
   const phoneNumberUtil = new PhoneNumberUtil();


### PR DESCRIPTION
When phone number is 1 number, PhoneNumberUtil's parse throws an error that's unhandled