### PR TITLE
feat: add support for deeplinks

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,6 +7,7 @@
     "platforms": ["ios", "android", "web"],
     "version": "3.3.0",
     "orientation": "portrait",
+    "scheme": "supplyally",
     "icon": "./assets/icon.png",
     "splash": {
       "image": "./assets/splashscreen.png",

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -92,6 +92,16 @@ export const InitialisationContainer: FunctionComponent<NavigationProps> = ({
     }
   }, [endpoint, navigation, token]);
 
+  useEffect(() => {
+    const navKey = navigation.getParam("key", "");
+    const navEndpoint = navigation.getParam("endpoint", "");
+    if (navKey && navEndpoint) {
+      setCodeKey(navKey);
+      setEndpointTemp(navEndpoint);
+      setLoginStage("MOBILE_NUMBER");
+    }
+  }, [navigation]);
+
   const onToggleAppMode = (): void => {
     if (!ALLOW_MODE_CHANGE) return;
     const nextMode =

--- a/src/navigation/Content.tsx
+++ b/src/navigation/Content.tsx
@@ -11,6 +11,7 @@ import { useAppState } from "../hooks/useAppState";
 import { useCheckUpdates } from "../hooks/useCheckUpdates";
 import { useValidateExpiry } from "../hooks/useValidateExpiry";
 import { Linking } from "expo";
+import { AppText } from "../components/Layout/AppText";
 
 const SwitchNavigator = createSwitchNavigator(
   {
@@ -51,6 +52,12 @@ export const Content = (): ReactElement => {
         }}
       >
         <AppContainer ref={navigatorRef} uriPrefix={prefix} />
+        <AppText style={{ position: "absolute", bottom: 120 }}>
+          {prefix}
+        </AppText>
+        <AppText style={{ position: "absolute", bottom: 80 }}>
+          {Linking.makeUrl("/", { key: "key", endpoint: "endpoint" })}
+        </AppText>
       </View>
     </>
   );

--- a/src/navigation/Content.tsx
+++ b/src/navigation/Content.tsx
@@ -11,7 +11,6 @@ import { useAppState } from "../hooks/useAppState";
 import { useCheckUpdates } from "../hooks/useCheckUpdates";
 import { useValidateExpiry } from "../hooks/useValidateExpiry";
 import { Linking } from "expo";
-import { AppText } from "../components/Layout/AppText";
 
 const SwitchNavigator = createSwitchNavigator(
   {
@@ -52,12 +51,6 @@ export const Content = (): ReactElement => {
         }}
       >
         <AppContainer ref={navigatorRef} uriPrefix={prefix} />
-        <AppText style={{ position: "absolute", bottom: 120 }}>
-          {prefix}
-        </AppText>
-        <AppText style={{ position: "absolute", bottom: 80 }}>
-          {Linking.makeUrl("/", { key: "key", endpoint: "endpoint" })}
-        </AppText>
       </View>
     </>
   );

--- a/src/navigation/Content.tsx
+++ b/src/navigation/Content.tsx
@@ -10,10 +10,11 @@ import LoginScreen from "./LoginScreen";
 import { useAppState } from "../hooks/useAppState";
 import { useCheckUpdates } from "../hooks/useCheckUpdates";
 import { useValidateExpiry } from "../hooks/useValidateExpiry";
+import { Linking } from "expo";
 
 const SwitchNavigator = createSwitchNavigator(
   {
-    LoginScreen: { screen: LoginScreen },
+    LoginScreen: { screen: LoginScreen, path: "login" },
     StackNavigator
   },
   { initialRouteName: "LoginScreen" }
@@ -24,6 +25,7 @@ const AppContainer = createAppContainer(SwitchNavigator);
 export const Content = (): ReactElement => {
   const navigatorRef = useRef<NavigationContainerComponent>(null);
   const appState = useAppState();
+  const prefix = Linking.makeUrl("/");
 
   const checkUpdates = useCheckUpdates();
   useEffect(() => {
@@ -48,7 +50,7 @@ export const Content = (): ReactElement => {
           paddingTop: Platform.OS === "android" ? StatusBar.currentHeight : 0
         }}
       >
-        <AppContainer ref={navigatorRef} />
+        <AppContainer ref={navigatorRef} uriPrefix={prefix} />
       </View>
     </>
   );


### PR DESCRIPTION
Add support for links to open in SupplyAlly. Once published, a link will look like this:
```
supplyally://login?key=1234&endpoint=https://endpoint.com
```

To test, create a link with your key and endpoint. I've created a simple site to generate the link: https://kitkm.csb.app/
```
exp://exp.host/@musket/rationally/--/login?release-channel=48&key=KEY&endpoint=ENDPOINT
```

