### PR TITLE
feat: CDC limit reached flow

### DIFF
--- a/src/components/CustomerQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuotaCard.tsx
@@ -115,7 +115,7 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
       const categoryName = policy?.name ?? category;
       const formattedDate = format(lastTransactionTime, "hh:mm a, do MMMM");
       itemTransactions.push({
-        itemHeader: `• ${categoryName} (${formattedDate})`,
+        itemHeader: `${categoryName} (${formattedDate})`,
         itemDetail:
           identifiers && identifiers.length > 0
             ? `${identifiers[0].value} — ${

--- a/src/components/CustomerQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuotaCard.tsx
@@ -19,21 +19,21 @@ const styles = StyleSheet.create({
     alignItems: "baseline"
   },
   itemHeader: {
-    marginTop: size(1),
+    marginTop: size(1.5),
     lineHeight: 1.5 * fontSize(0),
-    marginBottom: -size(2)
+    marginBottom: -size(2),
+    fontFamily: "brand-bold"
   },
-  itemSubheaderWrapper: {
-    flexDirection: "row",
-    marginTop: size(0.5)
+  itemDetailWrapper: {
+    flexDirection: "row"
   },
-  itemSubheaderBorder: {
+  itemDetailBorder: {
     borderLeftWidth: 1,
     borderLeftColor: color("grey", 30),
     marginLeft: size(1),
     marginRight: size(1)
   },
-  itemSubheaderText: {
+  itemDetail: {
     fontSize: fontSize(-1)
   }
 });
@@ -63,17 +63,17 @@ const RecentTransactionTitle: FunctionComponent<{
 );
 
 const ItemTransaction: FunctionComponent<{
-  header: string;
-  subheader: string;
-}> = ({ header, subheader }) => (
+  itemHeader: string;
+  itemDetail: string;
+}> = ({ itemHeader, itemDetail }) => (
   <>
     <View style={styles.itemRow}>
-      <AppText style={styles.itemHeader}>{header}</AppText>
+      <AppText style={styles.itemHeader}>{itemHeader}</AppText>
     </View>
-    {!!subheader && (
-      <View style={styles.itemSubheaderWrapper}>
-        <View style={styles.itemSubheaderBorder} />
-        <AppText style={styles.itemSubheaderText}>{subheader}</AppText>
+    {!!itemDetail && (
+      <View style={styles.itemDetailWrapper}>
+        <View style={styles.itemDetailBorder} />
+        <AppText style={styles.itemDetail}>{itemDetail}</AppText>
       </View>
     )}
   </>
@@ -101,18 +101,22 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
 }) => {
   const { getProduct } = useProductContext();
 
+  const policyType =
+    (cart.length > 0 && getProduct(cart[0].category)?.type) || "purchase";
+
   const sortedCart = cart.sort((item1, item2) =>
     compareDesc(item1.lastTransactionTime ?? 0, item2.lastTransactionTime ?? 0)
   );
 
-  const itemTransactions: { header: string; subheader: string }[] = [];
+  const itemTransactions: { itemHeader: string; itemDetail: string }[] = [];
   sortedCart.forEach(({ category, lastTransactionTime, identifiers }) => {
     if (lastTransactionTime) {
-      const categoryName = getProduct(category)?.name ?? category;
+      const policy = getProduct(category);
+      const categoryName = policy?.name ?? category;
       const formattedDate = format(lastTransactionTime, "hh:mm a, do MMMM");
       itemTransactions.push({
-        header: `• ${categoryName} (${formattedDate})`,
-        subheader:
+        itemHeader: `• ${categoryName} (${formattedDate})`,
+        itemDetail:
           identifiers && identifiers.length > 0
             ? `${identifiers[0].value} — ${
                 identifiers[identifiers.length - 1].value
@@ -156,16 +160,15 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
           </AppText>
           {itemTransactions.length > 0 && (
             <View>
-              <AppText>When limits were reached:</AppText>
+              <AppText style={{ marginBottom: size(1) }}>
+                Items {policyType === "redeem" ? "redeemed" : "purchased"}:
+              </AppText>
               {itemTransactions.map(
-                (
-                  { header, subheader }: { header: string; subheader: string },
-                  index: number
-                ) => (
+                ({ itemHeader, itemDetail }, index: number) => (
                   <ItemTransaction
                     key={index}
-                    header={header}
-                    subheader={subheader}
+                    itemHeader={itemHeader}
+                    itemDetail={itemDetail}
                   />
                 )
               )}

--- a/src/components/CustomerQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuotaCard.tsx
@@ -13,10 +13,28 @@ import { useProductContext } from "../../context/products";
 const DURATION_THRESHOLD_SECONDS = 60 * 10; // 10 minutes
 
 const styles = StyleSheet.create({
-  itemTransactions: {
+  itemRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline"
+  },
+  itemHeader: {
     marginTop: size(1),
     lineHeight: 1.5 * fontSize(0),
     marginBottom: -size(2)
+  },
+  itemSubheaderWrapper: {
+    flexDirection: "row",
+    marginTop: size(0.5)
+  },
+  itemSubheaderBorder: {
+    borderLeftWidth: 1,
+    borderLeftColor: color("grey", 30),
+    marginLeft: size(1),
+    marginRight: size(1)
+  },
+  itemSubheaderText: {
+    fontSize: fontSize(-1)
   }
 });
 
@@ -41,6 +59,23 @@ const RecentTransactionTitle: FunctionComponent<{
       {formatDistance(now, transactionTime)}
     </AppText>
     <AppText style={sharedStyles.statusTitle}> ago.</AppText>
+  </>
+);
+
+const ItemTransaction: FunctionComponent<{
+  header: string;
+  subheader: string;
+}> = ({ header, subheader }) => (
+  <>
+    <View style={styles.itemRow}>
+      <AppText style={styles.itemHeader}>{header}</AppText>
+    </View>
+    {!!subheader && (
+      <View style={styles.itemSubheaderWrapper}>
+        <View style={styles.itemSubheaderBorder} />
+        <AppText style={styles.itemSubheaderText}>{subheader}</AppText>
+      </View>
+    )}
   </>
 );
 
@@ -70,12 +105,20 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
     compareDesc(item1.lastTransactionTime ?? 0, item2.lastTransactionTime ?? 0)
   );
 
-  let itemTransactions = "";
-  sortedCart.forEach(({ category, lastTransactionTime }) => {
+  const itemTransactions: { header: string; subheader: string }[] = [];
+  sortedCart.forEach(({ category, lastTransactionTime, identifiers }) => {
     if (lastTransactionTime) {
       const categoryName = getProduct(category)?.name ?? category;
       const formattedDate = format(lastTransactionTime, "hh:mm a, do MMMM");
-      itemTransactions += `• ${categoryName} (${formattedDate})\n`;
+      itemTransactions.push({
+        header: `• ${categoryName} (${formattedDate})`,
+        subheader:
+          identifiers && identifiers.length > 0
+            ? `${identifiers[0].value} — ${
+                identifiers[identifiers.length - 1].value
+              }`
+            : ""
+      });
     }
   });
 
@@ -114,9 +157,18 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
           {itemTransactions.length > 0 && (
             <View>
               <AppText>When limits were reached:</AppText>
-              <AppText style={styles.itemTransactions}>
-                {itemTransactions}
-              </AppText>
+              {itemTransactions.map(
+                (
+                  { header, subheader }: { header: string; subheader: string },
+                  index: number
+                ) => (
+                  <ItemTransaction
+                    key={index}
+                    header={header}
+                    subheader={subheader}
+                  />
+                )
+              )}
             </View>
           )}
         </View>

--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -86,6 +86,25 @@ const mockQuotaResSingleId = {
     }
   ]
 };
+const mockQuotaResSingleIdWithIdentifiers = {
+  remainingQuota: [
+    {
+      category: "toilet-paper",
+      identifiers: [
+        { label: "first", value: "first identifier" },
+        { label: "last", value: "last identifier" }
+      ],
+      quantity: 1,
+      transactionTime
+    },
+    {
+      category: "chocolate",
+      identifiers: [],
+      quantity: 15,
+      transactionTime
+    }
+  ]
+};
 const mockQuotaResSingleIdNoQuota = {
   remainingQuota: [
     {
@@ -144,7 +163,7 @@ describe("useCart", () => {
   describe("fetch quota on initialisation", () => {
     it("should initialise the cart with the correct values", async () => {
       expect.assertions(3);
-      mockGetQuota.mockReturnValueOnce(mockQuotaResSingleId);
+      mockGetQuota.mockReturnValueOnce(mockQuotaResSingleIdWithIdentifiers);
 
       const ids = ["ID1"];
       const { result, waitForNextUpdate } = renderHook(
@@ -158,9 +177,12 @@ describe("useCart", () => {
       expect(result.current.cart).toStrictEqual([
         {
           category: "toilet-paper",
-          identifiers: [],
+          identifiers: [
+            { label: "first", value: "first identifier" },
+            { label: "last", value: "last identifier" }
+          ],
           lastTransactionTime: transactionTime,
-          maxQuantity: 2,
+          maxQuantity: 1,
           quantity: 1
         },
         {

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -65,23 +65,25 @@ const mergeWithCart = (
 
       return productOneOrder - productTwoOrder;
     })
-    .map(({ category, quantity: maxQuantity, transactionTime }) => {
-      const [existingItem] = getItem(cart, category);
+    .map(
+      ({ category, quantity: maxQuantity, transactionTime, identifiers }) => {
+        const [existingItem] = getItem(cart, category);
 
-      const product = getProduct(category);
-      const defaultQuantity = product?.quantity.default || 0;
+        const product = getProduct(category);
+        const defaultQuantity = product?.quantity.default || 0;
 
-      return {
-        category,
-        quantity: Math.min(
+        return {
+          category,
+          quantity: Math.min(
+            maxQuantity,
+            existingItem?.quantity || defaultQuantity
+          ),
           maxQuantity,
-          existingItem?.quantity || defaultQuantity
-        ),
-        maxQuantity,
-        lastTransactionTime: transactionTime,
-        identifiers: []
-      };
-    });
+          lastTransactionTime: transactionTime,
+          identifiers: identifiers || []
+        };
+      }
+    );
 };
 
 const hasNoQuota = (quota: Quota): boolean =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,8 @@ const ItemQuota = t.intersection([
     quantity: t.number
   }),
   t.partial({
-    transactionTime: DateFromNumber
+    transactionTime: DateFromNumber,
+    identifiers: t.array(PolicyIdentifierInput)
   })
 ]);
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/wtJhbXEM/72-cdc-flow-voucher-redemption) | [Figma screen](https://www.figma.com/proto/vYCze8TIVyrbvuF7IZliRP/SupplyAlly?node-id=1343%3A1131&scaling=min-zoom) | [Corresponding backend PR](https://github.com/rationally-app/backend-api/pull/31/files)

This MR adds the following modifications to the Limit reached screen (confirmed with Eida):
* Copy change of "When limit was reached:" to "Items redeemed:" (or purchased for when the policy type is purchase)
* Bold each bullet header under "Items redeemed:"
* Remove bullet for each header under "Items redeemed:"
* Display identifiers under each bullet whenever they exist
* Space out each component on the screen