### PR TITLE
fix: red cross is now red and not black!!

### DIFF
--- a/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
+++ b/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, Text } from "react-native";
 import { CustomerCard } from "../CustomerCard";
 import { AppText } from "../../Layout/AppText";
 import { sharedStyles } from "../sharedStyles";
@@ -50,7 +50,7 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
             sharedStyles.successfulResultWrapper
           ]}
         >
-          <AppText style={sharedStyles.emoji}>✅</AppText>
+          <Text style={sharedStyles.emoji}>✅</Text>
           <AppText style={sharedStyles.statusTitleWrapper}>
             <AppText style={sharedStyles.statusTitle}>{title}</AppText>
           </AppText>

--- a/src/components/CustomerQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuotaCard.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react";
 import { compareDesc } from "date-fns";
 import { differenceInSeconds, format, formatDistance } from "date-fns";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, Text } from "react-native";
 import { CustomerCard } from "./CustomerCard";
 import { AppText } from "../Layout/AppText";
 import { color, size, fontSize } from "../../common/styles";
@@ -141,7 +141,7 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
             sharedStyles.failureResultWrapper
           ]}
         >
-          <AppText style={sharedStyles.emoji}>❌</AppText>
+          <Text style={sharedStyles.emoji}>❌</Text>
           <AppText style={sharedStyles.statusTitleWrapper}>
             {secondsFromLatestTransaction > 0 ? (
               secondsFromLatestTransaction > DURATION_THRESHOLD_SECONDS ? (

--- a/src/components/CustomerQuota/sharedStyles.tsx
+++ b/src/components/CustomerQuota/sharedStyles.tsx
@@ -28,7 +28,7 @@ export const sharedStyles = StyleSheet.create({
   emoji: {
     fontSize: fontSize(3),
     marginBottom: size(2),
-    marginTop: size(1)
+    marginTop: size(2)
   },
   statusTitleWrapper: {
     marginBottom: size(2)


### PR DESCRIPTION
[Trello card](https://trello.com/c/M8cUhOGi/106-fix-cross-emoji-in-limit-reached-screen-haha)

Looks like the fix was simple :D

For those interested, the issue was the font-family styling in AppText. It caused the red cross to be rendered as a black one instead.

```
fontFamily: "brand-regular"
```