### PR TITLE
fix: block checkout without voucher codes

### DIFF
--- a/src/components/CustomerQuota/ItemsSelection/ItemStepper.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemStepper.tsx
@@ -22,7 +22,7 @@ export const ItemStepper: FunctionComponent<{
   useEffect(() => {
     if (stepperValue !== quantity) {
       // No support for policies with identifiers of limit > 1
-      updateCart(category, stepperValue, []);
+      updateCart(category, stepperValue);
     }
   }, [category, quantity, stepperValue, updateCart]);
 

--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -296,7 +296,7 @@ describe("useCart", () => {
       );
 
       await waitForNextUpdate();
-      await wait(() => result.current.updateCart("chocolate", 5, []));
+      await wait(() => result.current.updateCart("chocolate", 5));
       expect(result.current.cart).toStrictEqual([
         {
           category: "toilet-paper",
@@ -325,7 +325,7 @@ describe("useCart", () => {
       );
 
       await waitForNextUpdate();
-      await wait(() => result.current.updateCart("chocolate", 5, []));
+      await wait(() => result.current.updateCart("chocolate", 5));
       expect(result.current.cart).toStrictEqual([
         {
           category: "toilet-paper",
@@ -374,7 +374,7 @@ describe("useCart", () => {
       });
 
       await wait(() => {
-        result.current.updateCart("chocolate", -5, []);
+        result.current.updateCart("chocolate", -5);
       });
 
       expect(result.current.error?.message).toBe("Invalid quantity");
@@ -405,7 +405,7 @@ describe("useCart", () => {
       });
 
       await wait(() => {
-        result.current.updateCart("chocolate", 100, []);
+        result.current.updateCart("chocolate", 100);
       });
       expect(result.current.error?.message).toBe("Insufficient quota");
       expect(result.current.cart).toStrictEqual([
@@ -435,7 +435,7 @@ describe("useCart", () => {
       });
 
       await wait(() => {
-        result.current.updateCart("eggs", 1, []);
+        result.current.updateCart("eggs", 1);
       });
       expect(result.current.error?.message).toBe("Category does not exist");
       expect(result.current.cart).toStrictEqual([
@@ -467,8 +467,8 @@ describe("useCart", () => {
       });
 
       await wait(() => {
-        result.current.updateCart("toilet-paper", 2, []);
-        result.current.updateCart("chocolate", 5, []);
+        result.current.updateCart("toilet-paper", 2);
+        result.current.updateCart("chocolate", 5);
       });
 
       mockPostTransaction.mockReturnValueOnce(mockPostTransactionResult);
@@ -509,7 +509,7 @@ describe("useCart", () => {
       });
 
       await wait(() => {
-        result.current.updateCart("toilet-paper", 0, []);
+        result.current.updateCart("toilet-paper", 0);
         result.current.checkoutCart();
       });
 
@@ -720,8 +720,8 @@ describe("useCart", () => {
       });
 
       await wait(() => {
-        result.current.updateCart("toilet-paper", 2, []);
-        result.current.updateCart("chocolate", 5, []);
+        result.current.updateCart("toilet-paper", 2);
+        result.current.updateCart("chocolate", 5);
       });
 
       mockPostTransaction.mockRejectedValueOnce(

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -221,7 +221,7 @@ export const useCart = (
             numUnverifiedTransactions += 1;
           } else {
             identiferValues.push(
-              ...identifiers.map(idenfitier => idenfitier.value)
+              ...identifiers.map(identifier => identifier.value)
             );
           }
 

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -210,29 +210,26 @@ export const useCart = (
 
       let numUnverifiedTransactions = 0;
       let numIdentifiers = 0;
-      const identifierInputValues: string[] = [];
+      const identiferValues: string[] = [];
       const transactions = Object.values(cart)
         .filter(({ quantity }) => quantity)
-        .map(({ category, quantity, identifiers: identifierInputs }) => {
+        .map(({ category, quantity, identifiers }) => {
           if (
-            identifierInputs.length > 0 &&
-            identifierInputs.some(identifier => !identifier.value)
+            identifiers.length > 0 &&
+            identifiers.some(identifier => !identifier.value)
           ) {
             numUnverifiedTransactions += 1;
           } else {
-            identifierInputValues.push(
-              ...identifierInputs.map(idenfitier => idenfitier.value)
+            identiferValues.push(
+              ...identifiers.map(idenfitier => idenfitier.value)
             );
           }
 
-          numIdentifiers += identifierInputs.length;
-          return { category, quantity, identifiers: identifierInputs };
+          numIdentifiers += identifiers.length;
+          return { category, quantity, identifiers: identifiers };
         });
 
-      if (
-        numUnverifiedTransactions > 0 ||
-        !isUniqueList(identifierInputValues)
-      ) {
+      if (numUnverifiedTransactions > 0 || !isUniqueList(identiferValues)) {
         setError(
           new Error(
             `Please enter ${

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -37,7 +37,7 @@ export type CartHook = {
   updateCart: (
     category: string,
     quantity: number,
-    identifiers: PolicyIdentifierInput[]
+    identifiers?: PolicyIdentifierInput[]
   ) => void;
   checkoutCart: () => void;
   checkoutResult?: PostTransactionResult;
@@ -71,6 +71,11 @@ const mergeWithCart = (
 
         const product = getProduct(category);
         const defaultQuantity = product?.quantity.default || 0;
+        const defaultIdentifiers =
+          product?.identifiers?.map(identifier => ({
+            label: identifier.label,
+            value: ""
+          })) || [];
 
         return {
           category,
@@ -80,7 +85,7 @@ const mergeWithCart = (
           ),
           maxQuantity,
           lastTransactionTime: transactionTime,
-          identifiers: identifiers || []
+          identifiers: identifiers || defaultIdentifiers
         };
       }
     );
@@ -179,7 +184,7 @@ export const useCart = (
             {
               ...item,
               quantity,
-              identifiers
+              identifiers: identifiers || cart[itemIdx].identifiers
             },
             ...cart.slice(itemIdx + 1)
           ]);


### PR DESCRIPTION
[Trello card](https://trello.com/c/FOWlOnLO/119-bug-checkout-can-happen-without-voucher-code-input)

This MR fixes the bug where sometimes users could checkout without inputting voucher codes. See Trello card for steps to reproduce. 

Issue was in mergeWithCart, where the identifier inputs were being overwritten.

Also did a bit of refactoring for unique code validation because I think we were unnecessarily validating N times when we can do it only 1 time.

Also made identifiers an optional parameter for updateCart, because it was difficult to debug where we were accidentally replacing identifier inputs with an empty array.