### PR TITLE
feat: hide identifier inputs when no quota left

### DIFF
--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -40,7 +40,7 @@ export const Item: FunctionComponent<{
       ) : (
         <ItemStepper cartItem={cartItem} updateCart={updateCart} />
       )}
-      {identifiers && identifiers.length > 0 && (
+      {cartItem.maxQuantity > 0 && identifiers && identifiers.length > 0 && (
         <ItemIdentifiersCard
           cartItem={cartItem}
           identifierInputs={identifierInputs}

--- a/src/components/CustomerQuota/ItemsSelection/ItemNoQuota.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemNoQuota.tsx
@@ -31,7 +31,8 @@ export const ItemNoQuota: FunctionComponent<{
 }> = ({ cartItem }) => {
   const { category, maxQuantity } = cartItem;
   const { getProduct } = useProductContext();
-  const { name = category, description, quantity } = getProduct(category) || {};
+  const { name = category, description, quantity, type } =
+    getProduct(category) || {};
 
   return (
     <View style={[sharedStyles.wrapper, sharedStyles.wrapperDefault]}>
@@ -44,7 +45,9 @@ export const ItemNoQuota: FunctionComponent<{
         />
       </View>
       <View style={styles.feedbackWrapper}>
-        <AppText style={styles.feedbackText}>Cannot{"\n"}purchase</AppText>
+        <AppText style={styles.feedbackText}>
+          {type === "redeem" ? "Not\neligible" : "Cannot\npurchase"}
+        </AppText>
       </View>
     </View>
   );

--- a/src/components/CustomerQuota/ItemsSelection/ItemNoQuota.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemNoQuota.tsx
@@ -46,7 +46,7 @@ export const ItemNoQuota: FunctionComponent<{
       </View>
       <View style={styles.feedbackWrapper}>
         <AppText style={styles.feedbackText}>
-          {type === "redeem" ? "Not\neligible" : "Cannot\npurchase"}
+          {type === "redeem" ? "Not eligible" : "Cannot\npurchase"}
         </AppText>
       </View>
     </View>


### PR DESCRIPTION
[Trello card](https://trello.com/c/XEUVzOrt/100-hide-identifier-inputs-when-there-is-no-quota-left-for-a-product)

As the title suggests 😆  Also includes copy change of "Cannot purchase" > "Not eligible" when the item has already been redeemed