### PR TITLE
feat: text input UI for identifiers v2

### DIFF
--- a/src/components/CustomerQuota/CheckoutSuccess/RedeemedItem.tsx
+++ b/src/components/CustomerQuota/CheckoutSuccess/RedeemedItem.tsx
@@ -18,7 +18,7 @@ export const RedeemedItem: FunctionComponent<{
       <View style={sharedStyles.itemRow}>
         <AppText style={sharedStyles.itemHeaderText}>{categoryName}</AppText>
       </View>
-      {identifierInputs && identifierInputs.length > 0 && (
+      {identifierInputs && identifierInputs.length > 1 && (
         <View style={sharedStyles.quantitiesWrapper}>
           <View style={sharedStyles.quantitiesBorder} />
           <AppText style={sharedStyles.quantityByIdText}>

--- a/src/components/CustomerQuota/CheckoutSuccess/RedeemedItem.tsx
+++ b/src/components/CustomerQuota/CheckoutSuccess/RedeemedItem.tsx
@@ -13,18 +13,28 @@ export const RedeemedItem: FunctionComponent<{
   const { getProduct } = useProductContext();
   const { category, identifierInputs } = itemQuantities;
   const categoryName = getProduct(category)?.name ?? category;
+
+  let identifierInputDisplay = "";
+  if (identifierInputs) {
+    if (identifierInputs.length === 1) {
+      identifierInputDisplay = identifierInputs[0].value;
+    } else if (identifierInputs.length > 1) {
+      identifierInputDisplay = `${identifierInputs[0].value} — ${
+        identifierInputs[identifierInputs.length - 1].value
+      }`;
+    }
+  }
+
   return (
     <View style={{ marginBottom: size(1.5) }}>
       <View style={sharedStyles.itemRow}>
         <AppText style={sharedStyles.itemHeaderText}>{categoryName}</AppText>
       </View>
-      {identifierInputs && identifierInputs.length > 1 && (
+      {identifierInputDisplay && (
         <View style={sharedStyles.quantitiesWrapper}>
           <View style={sharedStyles.quantitiesBorder} />
           <AppText style={sharedStyles.quantityByIdText}>
-            {`${identifierInputs[0].value} — ${
-              identifierInputs[identifierInputs.length - 1].value
-            }`}
+            {identifierInputDisplay}
           </AppText>
         </View>
       )}

--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -2,12 +2,11 @@ import { ItemNoQuota } from "./ItemNoQuota";
 import { ItemCheckbox } from "./ItemCheckbox";
 import { ItemStepper } from "./ItemStepper";
 import { StyleSheet, View } from "react-native";
-import React, { FunctionComponent, useState } from "react";
+import React, { FunctionComponent } from "react";
 import { CartHook, CartItem } from "../../../hooks/useCart/useCart";
 import { size } from "../../../common/styles";
 import { useProductContext } from "../../../context/products";
 import { ItemIdentifiersCard } from "./ItemIdentifiersCard";
-import { IdentifierInput } from "../../../types";
 
 const styles = StyleSheet.create({
   cartItemComponent: {
@@ -23,29 +22,20 @@ export const Item: FunctionComponent<{
   const { getProduct } = useProductContext();
   const identifiers = getProduct(cartItem.category)?.identifiers || [];
 
-  const [identifierInputs, setIdentifierInputs] = useState<IdentifierInput[]>(
-    cartItem.identifierInputs
-  );
-
   return (
     <View style={styles.cartItemComponent}>
       {cartItem.maxQuantity === 0 ? (
         <ItemNoQuota cartItem={cartItem} />
       ) : cartItem.maxQuantity === 1 ? (
-        <ItemCheckbox
-          cartItem={cartItem}
-          updateCart={updateCart}
-          identifierInputs={identifierInputs}
-        />
+        <ItemCheckbox cartItem={cartItem} updateCart={updateCart} />
       ) : (
         <ItemStepper cartItem={cartItem} updateCart={updateCart} />
       )}
       {cartItem.maxQuantity > 0 && identifiers.length > 0 && (
         <ItemIdentifiersCard
           cartItem={cartItem}
-          identifierInputs={identifierInputs}
-          setIdentifierInputs={setIdentifierInputs}
           updateCart={updateCart}
+          identifiers={identifiers}
         />
       )}
     </View>

--- a/src/components/CustomerQuota/ItemsSelection/ItemCheckbox.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemCheckbox.tsx
@@ -3,13 +3,11 @@ import { Checkbox } from "../../Layout/Checkbox";
 import { ItemContent } from "./ItemContent";
 import { CartItem, CartHook } from "../../../hooks/useCart/useCart";
 import { useProductContext } from "../../../context/products";
-import { IdentifierInput } from "../../../types";
 
 export const ItemCheckbox: FunctionComponent<{
   cartItem: CartItem;
   updateCart: CartHook["updateCart"];
-  identifierInputs: IdentifierInput[];
-}> = ({ cartItem, updateCart, identifierInputs }) => {
+}> = ({ cartItem, updateCart }) => {
   const { category, quantity, maxQuantity } = cartItem;
   const { getProduct } = useProductContext();
   const { name = category, description, quantity: productQuantity } =
@@ -26,9 +24,7 @@ export const ItemCheckbox: FunctionComponent<{
         />
       }
       isChecked={quantity > 0}
-      onToggle={() =>
-        updateCart(category, quantity > 0 ? 0 : maxQuantity, identifierInputs)
-      }
+      onToggle={() => updateCart(category, quantity > 0 ? 0 : maxQuantity)}
     />
   );
 };

--- a/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
@@ -11,11 +11,15 @@ import { PolicyIdentifier } from "../../../types";
 const styles = StyleSheet.create({
   inputAndButtonWrapper: {
     flexDirection: "row",
-    alignItems: "flex-end"
+    justifyContent: "center",
+    alignItems: "flex-end",
+    width: "100%"
   },
   inputWrapper: {
-    flex: 1,
-    marginRight: size(1)
+    flex: 2
+  },
+  buttonWrapper: {
+    flex: 1
   }
 });
 
@@ -58,29 +62,37 @@ export const ItemIdentifier: FunctionComponent<{
   return (
     <>
       <View style={styles.inputAndButtonWrapper}>
-        <View style={styles.inputWrapper}>
-          {textInput.visible && (
+        {textInput.visible && (
+          <View
+            style={[
+              styles.inputWrapper,
+              ...(scanButton.visible ? [{ marginRight: size(1) }] : [])
+            ]}
+          >
             <InputWithLabel
               label={label}
               value={voucherCodeInput}
               editable={!textInput.disabled}
               onChange={({ nativeEvent: { text } }) => onManualInput(text)}
             />
-          )}
-        </View>
+          </View>
+        )}
         {scanButton.visible && (
-          <DarkButton
-            text="Scan"
-            icon={
-              <Feather
-                name="maximize"
-                size={size(2)}
-                color={color("grey", 0)}
-              />
-            }
-            disabled={scanButton.disabled}
-            onPress={() => setShouldShowCamera(true)}
-          />
+          <View style={styles.buttonWrapper}>
+            <DarkButton
+              text={scanButton.text || "Scan"}
+              icon={
+                <Feather
+                  name="maximize"
+                  size={size(2)}
+                  color={color("grey", 0)}
+                />
+              }
+              disabled={scanButton.disabled}
+              fullWidth={!textInput.visible}
+              onPress={() => setShouldShowCamera(true)}
+            />
+          </View>
         )}
       </View>
       {shouldShowCamera && (
@@ -93,7 +105,9 @@ export const ItemIdentifier: FunctionComponent<{
           <IdScanner
             onBarCodeScanned={onBarCodeScanned}
             onCancel={() => setShouldShowCamera(false)}
-            cancelButtonText={"Enter Voucher manually"}
+            cancelButtonText={
+              textInput.disabled ? "Back" : "Enter Voucher manually" // TODO: check copy
+            }
           />
         </Modal>
       )}

--- a/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState, useEffect } from "react";
+import React, { FunctionComponent, useState } from "react";
 import { InputWithLabel } from "../../Layout/InputWithLabel";
 import { DarkButton } from "../../Layout/Buttons/DarkButton";
 import { View, StyleSheet, Alert, Modal } from "react-native";

--- a/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
@@ -15,7 +15,8 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "center",
     alignItems: "flex-end",
-    width: "100%"
+    width: "100%",
+    marginTop: size(2)
   },
   inputWrapper: {
     flex: 2
@@ -30,21 +31,21 @@ const IdentifierPhoneNumberInput: FunctionComponent<{
   onPhoneNumberChange: (text: string) => void;
 }> = ({ label, onPhoneNumberChange }) => {
   const [countryCodeValue, setCountryCodeValue] = useState("+65");
-  const [mobileNumber, setMobileNumber] = useState("");
+  const [phoneNumber, setPhoneNumber] = useState("");
 
   useEffect(() => {
-    onPhoneNumberChange(createFullNumber(countryCodeValue, mobileNumber));
+    onPhoneNumberChange(createFullNumber(countryCodeValue, phoneNumber));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [countryCodeValue, mobileNumber]);
+  }, [countryCodeValue, phoneNumber]);
 
   return (
     <View style={[styles.inputWrapper]}>
       <PhoneNumberInput
         countryCodeValue={countryCodeValue}
         label={label}
-        mobileNumberValue={mobileNumber}
+        mobileNumberValue={phoneNumber}
         onChangeCountryCode={(text: string) => setCountryCodeValue(text)}
-        onChangeMobileNumber={(text: string) => setMobileNumber(text)}
+        onChangeMobileNumber={(text: string) => setPhoneNumber(text)}
       />
     </View>
   );

--- a/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from "react";
+import React, { FunctionComponent, useState, useEffect } from "react";
 import { InputWithLabel } from "../../Layout/InputWithLabel";
 import { DarkButton } from "../../Layout/Buttons/DarkButton";
 import { View, StyleSheet, Alert, Modal } from "react-native";
@@ -24,6 +24,36 @@ const styles = StyleSheet.create({
   }
 });
 
+const IdentifierPhoneNumberInput: FunctionComponent<{
+  label: string;
+  onPhoneNumberChange: (text: string) => void;
+}> = ({ label, onPhoneNumberChange }) => {
+  const [countryCodeValue, setCountryCodeValue] = useState("+65");
+  const [mobileNumber, setMobileNumber] = useState("");
+
+  const onChangeCountryCode = (text: string): void => {
+    setCountryCodeValue(text);
+    onPhoneNumberChange(text + mobileNumber);
+  };
+
+  const onMobileNumberChange = (text: string): void => {
+    setMobileNumber(text);
+    onPhoneNumberChange(countryCodeValue + text);
+  };
+
+  return (
+    <View style={[styles.inputWrapper]}>
+      <PhoneNumberInput
+        countryCodeValue={countryCodeValue}
+        label={label}
+        mobileNumberValue={mobileNumber}
+        onChangeCountryCode={onChangeCountryCode}
+        onChangeMobileNumber={onMobileNumberChange}
+      />
+    </View>
+  );
+};
+
 const IdentifierTextInput: FunctionComponent<{
   addMarginRight: boolean;
   editable: boolean;
@@ -38,15 +68,30 @@ const IdentifierTextInput: FunctionComponent<{
       ...(addMarginRight ? [{ marginRight: size(1) }] : [])
     ]}
   >
-    {type === "PHONE_NUMBER" ? null : (
-      <InputWithLabel
-        label={label}
-        value={value}
-        editable={editable}
-        onChange={({ nativeEvent: { text } }) => onChange(text)}
-        keyboardType={type === "NUMBER" ? "phone-pad" : "default"}
-      />
-    )}
+    <InputWithLabel
+      label={label}
+      value={value}
+      editable={editable}
+      onChange={({ nativeEvent: { text } }) => onChange(text)}
+      keyboardType={type === "NUMBER" ? "phone-pad" : "default"}
+    />
+  </View>
+);
+
+const IdentifierScanButton: FunctionComponent<{
+  disabled: boolean;
+  fullWidth: boolean;
+  onPress: () => void;
+  text: string | undefined;
+}> = ({ disabled, fullWidth, onPress, text }) => (
+  <View style={styles.buttonWrapper}>
+    <DarkButton
+      text={text || "Scan"}
+      icon={<Feather name="maximize" size={size(2)} color={color("grey", 0)} />}
+      disabled={disabled}
+      fullWidth={fullWidth}
+      onPress={onPress}
+    />
   </View>
 );
 
@@ -56,13 +101,13 @@ export const ItemIdentifier: FunctionComponent<{
   updateIdentifierValue: (index: number, value: string) => void;
 }> = ({ index, identifier, updateIdentifierValue }) => {
   const [shouldShowCamera, setShouldShowCamera] = useState(false);
-  const [voucherCodeInput, setVoucherCodeInput] = useState("");
+  const [inputValue, setInputValue] = useState("");
 
   const { label, textInput, scanButton } = identifier;
 
   const onCheck = async (input: string): Promise<void> => {
     try {
-      setVoucherCodeInput(input);
+      setInputValue(input);
       updateIdentifierValue(index, input);
       setShouldShowCamera(false);
     } catch (e) {
@@ -82,39 +127,36 @@ export const ItemIdentifier: FunctionComponent<{
   };
 
   const onManualInput = (input: string): void => {
-    setVoucherCodeInput(input);
+    setInputValue(input);
     updateIdentifierValue(index, input);
   };
 
   return (
     <>
       <View style={styles.inputAndButtonWrapper}>
-        {textInput.visible && (
-          <IdentifierTextInput
-            addMarginRight={scanButton.visible}
-            editable={!textInput.disabled}
-            label={label}
-            onChange={onManualInput}
-            type={textInput.type}
-            value={voucherCodeInput}
-          />
-        )}
-        {scanButton.visible && (
-          <View style={styles.buttonWrapper}>
-            <DarkButton
-              text={scanButton.text || "Scan"}
-              icon={
-                <Feather
-                  name="maximize"
-                  size={size(2)}
-                  color={color("grey", 0)}
-                />
-              }
-              disabled={scanButton.disabled}
-              fullWidth={!textInput.visible}
-              onPress={() => setShouldShowCamera(true)}
+        {textInput.visible &&
+          (textInput.type === "PHONE_NUMBER" ? (
+            <IdentifierPhoneNumberInput
+              label={label}
+              onPhoneNumberChange={onManualInput}
             />
-          </View>
+          ) : (
+            <IdentifierTextInput
+              addMarginRight={scanButton.visible}
+              editable={!textInput.disabled}
+              label={label}
+              onChange={onManualInput}
+              type={textInput.type}
+              value={inputValue}
+            />
+          ))}
+        {scanButton.visible && (
+          <IdentifierScanButton
+            disabled={scanButton.disabled}
+            fullWidth={!textInput.visible}
+            onPress={() => setShouldShowCamera(true)}
+            text={scanButton.text}
+          />
         )}
       </View>
       {shouldShowCamera && (

--- a/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState } from "react";
+import React, { FunctionComponent, useState, useEffect } from "react";
 import { InputWithLabel } from "../../Layout/InputWithLabel";
 import { DarkButton } from "../../Layout/Buttons/DarkButton";
 import { View, StyleSheet, Alert, Modal } from "react-native";
@@ -8,6 +8,7 @@ import { BarCodeScannedCallback } from "expo-barcode-scanner";
 import { IdScanner } from "../../IdScanner/IdScanner";
 import { PolicyIdentifier, TextInputType } from "../../../types";
 import { PhoneNumberInput } from "../../Layout/PhoneNumberInput";
+import { createFullNumber } from "../../../utils/validatePhoneNumbers";
 
 const styles = StyleSheet.create({
   inputAndButtonWrapper: {
@@ -31,15 +32,10 @@ const IdentifierPhoneNumberInput: FunctionComponent<{
   const [countryCodeValue, setCountryCodeValue] = useState("+65");
   const [mobileNumber, setMobileNumber] = useState("");
 
-  const onChangeCountryCode = (text: string): void => {
-    setCountryCodeValue(text);
-    onPhoneNumberChange(text + mobileNumber);
-  };
-
-  const onMobileNumberChange = (text: string): void => {
-    setMobileNumber(text);
-    onPhoneNumberChange(countryCodeValue + text);
-  };
+  useEffect(() => {
+    onPhoneNumberChange(createFullNumber(countryCodeValue, mobileNumber));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [countryCodeValue, mobileNumber]);
 
   return (
     <View style={[styles.inputWrapper]}>
@@ -47,8 +43,8 @@ const IdentifierPhoneNumberInput: FunctionComponent<{
         countryCodeValue={countryCodeValue}
         label={label}
         mobileNumberValue={mobileNumber}
-        onChangeCountryCode={onChangeCountryCode}
-        onChangeMobileNumber={onMobileNumberChange}
+        onChangeCountryCode={(text: string) => setCountryCodeValue(text)}
+        onChangeMobileNumber={(text: string) => setMobileNumber(text)}
       />
     </View>
   );

--- a/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
@@ -7,6 +7,7 @@ import { Feather } from "@expo/vector-icons";
 import { BarCodeScannedCallback } from "expo-barcode-scanner";
 import { IdScanner } from "../../IdScanner/IdScanner";
 import { PolicyIdentifier, TextInputType } from "../../../types";
+import { PhoneNumberInput } from "../../Layout/PhoneNumberInput";
 
 const styles = StyleSheet.create({
   inputAndButtonWrapper: {
@@ -43,6 +44,7 @@ const IdentifierTextInput: FunctionComponent<{
         value={value}
         editable={editable}
         onChange={({ nativeEvent: { text } }) => onChange(text)}
+        keyboardType={type === "NUMBER" ? "phone-pad" : "default"}
       />
     )}
   </View>
@@ -89,7 +91,7 @@ export const ItemIdentifier: FunctionComponent<{
       <View style={styles.inputAndButtonWrapper}>
         {textInput.visible && (
           <IdentifierTextInput
-            addMarginRight={!scanButton.visible}
+            addMarginRight={scanButton.visible}
             editable={!textInput.disabled}
             label={label}
             onChange={onManualInput}
@@ -125,9 +127,7 @@ export const ItemIdentifier: FunctionComponent<{
           <IdScanner
             onBarCodeScanned={onBarCodeScanned}
             onCancel={() => setShouldShowCamera(false)}
-            cancelButtonText={
-              textInput.disabled ? "Back" : "Enter manually" // TODO: check copy
-            }
+            cancelButtonText={textInput.disabled ? "Back" : "Enter manually"}
           />
         </Modal>
       )}

--- a/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
@@ -6,6 +6,7 @@ import { size, color } from "../../../common/styles";
 import { Feather } from "@expo/vector-icons";
 import { BarCodeScannedCallback } from "expo-barcode-scanner";
 import { IdScanner } from "../../IdScanner/IdScanner";
+import { PolicyIdentifier } from "../../../types";
 
 const styles = StyleSheet.create({
   inputAndButtonWrapper: {
@@ -20,11 +21,13 @@ const styles = StyleSheet.create({
 
 export const ItemIdentifier: FunctionComponent<{
   index: number;
-  label: string;
+  identifier: PolicyIdentifier;
   updateIdentifierValue: (index: number, value: string) => void;
-}> = ({ index, label, updateIdentifierValue }) => {
+}> = ({ index, identifier, updateIdentifierValue }) => {
   const [shouldShowCamera, setShouldShowCamera] = useState(false);
   const [voucherCodeInput, setVoucherCodeInput] = useState("");
+
+  const { label, textInput, scanButton } = identifier;
 
   const onCheck = async (input: string): Promise<void> => {
     try {
@@ -56,20 +59,29 @@ export const ItemIdentifier: FunctionComponent<{
     <>
       <View style={styles.inputAndButtonWrapper}>
         <View style={styles.inputWrapper}>
-          <InputWithLabel
-            label={label}
-            value={voucherCodeInput}
-            onChange={({ nativeEvent: { text } }) => onManualInput(text)}
-          />
+          {textInput.visible && (
+            <InputWithLabel
+              label={label}
+              value={voucherCodeInput}
+              editable={!textInput.disabled}
+              onChange={({ nativeEvent: { text } }) => onManualInput(text)}
+            />
+          )}
         </View>
-
-        <DarkButton
-          text="Scan"
-          icon={
-            <Feather name="maximize" size={size(2)} color={color("grey", 0)} />
-          }
-          onPress={() => setShouldShowCamera(true)}
-        />
+        {scanButton.visible && (
+          <DarkButton
+            text="Scan"
+            icon={
+              <Feather
+                name="maximize"
+                size={size(2)}
+                color={color("grey", 0)}
+              />
+            }
+            disabled={scanButton.disabled}
+            onPress={() => setShouldShowCamera(true)}
+          />
+        )}
       </View>
       {shouldShowCamera && (
         <Modal

--- a/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
@@ -6,7 +6,7 @@ import { size, color } from "../../../common/styles";
 import { Feather } from "@expo/vector-icons";
 import { BarCodeScannedCallback } from "expo-barcode-scanner";
 import { IdScanner } from "../../IdScanner/IdScanner";
-import { PolicyIdentifier } from "../../../types";
+import { PolicyIdentifier, TextInputType } from "../../../types";
 
 const styles = StyleSheet.create({
   inputAndButtonWrapper: {
@@ -22,6 +22,31 @@ const styles = StyleSheet.create({
     flex: 1
   }
 });
+
+const IdentifierTextInput: FunctionComponent<{
+  addMarginRight: boolean;
+  editable: boolean;
+  label: string;
+  onChange: (text: string) => void;
+  type: TextInputType | undefined;
+  value: string;
+}> = ({ addMarginRight, editable, label, onChange, type, value }) => (
+  <View
+    style={[
+      styles.inputWrapper,
+      ...(addMarginRight ? [{ marginRight: size(1) }] : [])
+    ]}
+  >
+    {type === "PHONE_NUMBER" ? null : (
+      <InputWithLabel
+        label={label}
+        value={value}
+        editable={editable}
+        onChange={({ nativeEvent: { text } }) => onChange(text)}
+      />
+    )}
+  </View>
+);
 
 export const ItemIdentifier: FunctionComponent<{
   index: number;
@@ -63,19 +88,14 @@ export const ItemIdentifier: FunctionComponent<{
     <>
       <View style={styles.inputAndButtonWrapper}>
         {textInput.visible && (
-          <View
-            style={[
-              styles.inputWrapper,
-              ...(scanButton.visible ? [{ marginRight: size(1) }] : [])
-            ]}
-          >
-            <InputWithLabel
-              label={label}
-              value={voucherCodeInput}
-              editable={!textInput.disabled}
-              onChange={({ nativeEvent: { text } }) => onManualInput(text)}
-            />
-          </View>
+          <IdentifierTextInput
+            addMarginRight={!scanButton.visible}
+            editable={!textInput.disabled}
+            label={label}
+            onChange={onManualInput}
+            type={textInput.type}
+            value={voucherCodeInput}
+          />
         )}
         {scanButton.visible && (
           <View style={styles.buttonWrapper}>
@@ -106,7 +126,7 @@ export const ItemIdentifier: FunctionComponent<{
             onBarCodeScanned={onBarCodeScanned}
             onCancel={() => setShouldShowCamera(false)}
             cancelButtonText={
-              textInput.disabled ? "Back" : "Enter Voucher manually" // TODO: check copy
+              textInput.disabled ? "Back" : "Enter manually" // TODO: check copy
             }
           />
         </Modal>

--- a/src/components/CustomerQuota/ItemsSelection/ItemIdentifiersCard.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemIdentifiersCard.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent, useEffect } from "react";
-import { IdentifierInput } from "../../../types";
+import React, { FunctionComponent, useEffect, useState } from "react";
+import { IdentifierInput, PolicyIdentifier } from "../../../types";
 import { CartHook, CartItem } from "../../../hooks/useCart/useCart";
 import { ItemIdentifier } from "./ItemIdentifier";
 import { View, StyleSheet } from "react-native";
@@ -16,10 +16,13 @@ const styles = StyleSheet.create({
 
 export const ItemIdentifiersCard: FunctionComponent<{
   cartItem: CartItem;
-  identifierInputs: IdentifierInput[];
-  setIdentifierInputs: (input: IdentifierInput[]) => void;
   updateCart: CartHook["updateCart"];
-}> = ({ cartItem, identifierInputs, setIdentifierInputs, updateCart }) => {
+  identifiers: PolicyIdentifier[];
+}> = ({ cartItem, updateCart, identifiers }) => {
+  const [identifierInputs, setIdentifierInputs] = useState<IdentifierInput[]>(
+    cartItem.identifierInputs
+  );
+
   const updateIdentifierValue = (index: number, value: string): void => {
     setIdentifierInputs([
       ...identifierInputs.slice(0, index),
@@ -35,11 +38,11 @@ export const ItemIdentifiersCard: FunctionComponent<{
 
   return (
     <View style={styles.content}>
-      {identifierInputs.map((identifier, index) => (
+      {identifiers.map((identifier, index) => (
         <ItemIdentifier
           key={index}
           index={index}
-          label={identifier.label}
+          identifier={identifier}
           updateIdentifierValue={updateIdentifierValue}
         />
       ))}

--- a/src/components/CustomerQuota/ItemsSelection/ItemStepper.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemStepper.tsx
@@ -21,7 +21,6 @@ export const ItemStepper: FunctionComponent<{
 
   useEffect(() => {
     if (stepperValue !== quantity) {
-      // No support for policies with identifiers of limit > 1
       updateCart(category, stepperValue);
     }
   }, [category, quantity, stepperValue, updateCart]);

--- a/src/components/Layout/InputWithLabel.tsx
+++ b/src/components/Layout/InputWithLabel.tsx
@@ -23,14 +23,16 @@ const styles = StyleSheet.create({
 
 interface InputWithLabel extends TextInputProps {
   label: string;
+  editable: boolean;
 }
 
 export const InputWithLabel: FunctionComponent<InputWithLabel> = ({
   label,
+  editable,
   ...props
 }) => (
   <View>
     <AppText style={styles.label}>{label}</AppText>
-    <TextInput style={styles.input} {...props} />
+    <TextInput style={styles.input} editable={editable} {...props} />
   </View>
 );

--- a/src/components/Layout/InputWithLabel.tsx
+++ b/src/components/Layout/InputWithLabel.tsx
@@ -11,13 +11,20 @@ const styles = StyleSheet.create({
     minHeight: size(6),
     paddingHorizontal: size(1),
     marginTop: size(1),
-    backgroundColor: color("grey", 0),
     borderWidth: 1,
     borderRadius: borderRadius(2),
-    borderColor: color("grey", 40),
     fontFamily: "brand-regular",
-    fontSize: fontSize(0),
+    fontSize: fontSize(0)
+  },
+  inputEditable: {
+    backgroundColor: color("grey", 0),
+    borderColor: color("grey", 40),
     color: color("blue", 50)
+  },
+  inputNotEditable: {
+    backgroundColor: color("grey", 30),
+    borderColor: color("grey", 30),
+    color: color("grey", 0)
   }
 });
 
@@ -28,11 +35,18 @@ interface InputWithLabel extends TextInputProps {
 
 export const InputWithLabel: FunctionComponent<InputWithLabel> = ({
   label,
-  editable,
+  editable = true,
   ...props
 }) => (
   <View>
     <AppText style={styles.label}>{label}</AppText>
-    <TextInput style={styles.input} editable={editable} {...props} />
+    <TextInput
+      style={[
+        styles.input,
+        ...(editable ? [styles.inputEditable] : [styles.inputNotEditable])
+      ]}
+      editable={editable}
+      {...props}
+    />
   </View>
 );

--- a/src/components/Layout/PhoneNumberInput.tsx
+++ b/src/components/Layout/PhoneNumberInput.tsx
@@ -1,0 +1,73 @@
+import React, { FunctionComponent } from "react";
+import { View, TextInput, StyleSheet } from "react-native";
+import { AppText } from "./AppText";
+import { size, color, borderRadius, fontSize } from "../../common/styles";
+
+const styles = StyleSheet.create({
+  inputsWrapper: {
+    flexDirection: "row",
+    alignItems: "center"
+  },
+  countryCode: {
+    minHeight: size(6),
+    paddingHorizontal: size(1),
+    marginTop: size(1),
+    backgroundColor: color("grey", 0),
+    borderWidth: 1,
+    borderRadius: borderRadius(2),
+    borderColor: color("grey", 40),
+    fontSize: fontSize(0),
+    color: color("blue", 50),
+    minWidth: size(7)
+  },
+  numberInput: {
+    flex: 1,
+    minHeight: size(6),
+    paddingHorizontal: size(1),
+    marginTop: size(1),
+    backgroundColor: color("grey", 0),
+    borderWidth: 1,
+    borderRadius: borderRadius(2),
+    borderColor: color("grey", 40),
+    fontSize: fontSize(0),
+    color: color("blue", 50)
+  },
+  hyphen: {
+    marginRight: size(1),
+    marginLeft: size(1),
+    fontSize: fontSize(3)
+  }
+});
+
+export const PhoneNumberInput: FunctionComponent<{
+  countryCodeValue: string;
+  mobileNumberValue: string;
+  onChangeCountryCode: (text: string) => void;
+  onChangeMobileNumber: (text: string) => void;
+  onSubmit: () => void;
+}> = ({
+  countryCodeValue,
+  mobileNumberValue,
+  onChangeCountryCode,
+  onChangeMobileNumber,
+  onSubmit
+}) => {
+  return (
+    <View style={styles.inputsWrapper}>
+      <TextInput
+        style={styles.countryCode}
+        keyboardType="phone-pad"
+        value={countryCodeValue}
+        onChange={({ nativeEvent: { text } }) => onChangeCountryCode(text)}
+      />
+      <AppText style={styles.hyphen}>-</AppText>
+      <TextInput
+        style={styles.numberInput}
+        keyboardType="phone-pad"
+        value={mobileNumberValue}
+        onChange={({ nativeEvent: { text } }) => onChangeMobileNumber(text)}
+        onSubmitEditing={onSubmit}
+      />
+    </View>
+  );
+};

--- a/src/components/Layout/PhoneNumberInput.tsx
+++ b/src/components/Layout/PhoneNumberInput.tsx
@@ -36,38 +36,50 @@ const styles = StyleSheet.create({
     marginRight: size(1),
     marginLeft: size(1),
     fontSize: fontSize(3)
+  },
+  numberWrapper: {
+    marginBottom: size(2)
+  },
+  label: {
+    fontFamily: "brand-bold"
   }
 });
 
 export const PhoneNumberInput: FunctionComponent<{
   countryCodeValue: string;
+  label: string;
   mobileNumberValue: string;
   onChangeCountryCode: (text: string) => void;
   onChangeMobileNumber: (text: string) => void;
-  onSubmit: () => void;
+  onSubmit?: () => void;
 }> = ({
   countryCodeValue,
+  label,
   mobileNumberValue,
   onChangeCountryCode,
   onChangeMobileNumber,
-  onSubmit
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onSubmit = () => {}
 }) => {
   return (
-    <View style={styles.inputsWrapper}>
-      <TextInput
-        style={styles.countryCode}
-        keyboardType="phone-pad"
-        value={countryCodeValue}
-        onChange={({ nativeEvent: { text } }) => onChangeCountryCode(text)}
-      />
-      <AppText style={styles.hyphen}>-</AppText>
-      <TextInput
-        style={styles.numberInput}
-        keyboardType="phone-pad"
-        value={mobileNumberValue}
-        onChange={({ nativeEvent: { text } }) => onChangeMobileNumber(text)}
-        onSubmitEditing={onSubmit}
-      />
+    <View style={styles.numberWrapper}>
+      <AppText style={styles.label}>{label}</AppText>
+      <View style={styles.inputsWrapper}>
+        <TextInput
+          style={styles.countryCode}
+          keyboardType="phone-pad"
+          value={countryCodeValue}
+          onChange={({ nativeEvent: { text } }) => onChangeCountryCode(text)}
+        />
+        <AppText style={styles.hyphen}>-</AppText>
+        <TextInput
+          style={styles.numberInput}
+          keyboardType="phone-pad"
+          value={mobileNumberValue}
+          onChange={({ nativeEvent: { text } }) => onChangeMobileNumber(text)}
+          onSubmitEditing={onSubmit}
+        />
+      </View>
     </View>
   );
 };

--- a/src/components/Login/LoginMobileNumberCard.tsx
+++ b/src/components/Login/LoginMobileNumberCard.tsx
@@ -21,12 +21,6 @@ import { PhoneNumberInput } from "../Layout/PhoneNumberInput";
 const styles = StyleSheet.create({
   inputAndButtonWrapper: {
     marginTop: size(3)
-  },
-  numberWrapper: {
-    marginBottom: size(2)
-  },
-  label: {
-    fontFamily: "brand-bold"
   }
 });
 
@@ -88,16 +82,14 @@ export const LoginMobileNumberCard: FunctionComponent<LoginMobileNumberCard> = (
         Please enter your mobile phone number to receive a one-time password.
       </AppText>
       <View style={styles.inputAndButtonWrapper}>
-        <View style={styles.numberWrapper}>
-          <AppText style={styles.label}>Mobile phone number</AppText>
-          <PhoneNumberInput
-            countryCodeValue={countryCode}
-            mobileNumberValue={mobileNumberValue}
-            onChangeCountryCode={onChangeCountryCode}
-            onChangeMobileNumber={onChangeMobileNumber}
-            onSubmit={onSubmitMobileNumber}
-          />
-        </View>
+        <PhoneNumberInput
+          countryCodeValue={countryCode}
+          label="Mobile phone number"
+          mobileNumberValue={mobileNumberValue}
+          onChangeCountryCode={onChangeCountryCode}
+          onChangeMobileNumber={onChangeMobileNumber}
+          onSubmit={onSubmitMobileNumber}
+        />
 
         <DarkButton
           text="Send OTP"

--- a/src/components/Login/LoginMobileNumberCard.tsx
+++ b/src/components/Login/LoginMobileNumberCard.tsx
@@ -11,12 +11,12 @@ import { Card } from "../Layout/Card";
 import { AppText } from "../Layout/AppText";
 import { LoginStage } from "./types";
 import { requestOTP } from "../../services/auth";
-import {
-  mobileNumberValidator,
-  countryCodeValidator,
-  createFullNumber
-} from "./utils";
 import { PhoneNumberInput } from "../Layout/PhoneNumberInput";
+import {
+  createFullNumber,
+  countryCodeValidator,
+  mobileNumberValidator
+} from "../../utils/validatePhoneNumbers";
 
 const styles = StyleSheet.create({
   inputAndButtonWrapper: {

--- a/src/components/Login/LoginMobileNumberCard.tsx
+++ b/src/components/Login/LoginMobileNumberCard.tsx
@@ -4,9 +4,9 @@ import React, {
   Dispatch,
   SetStateAction
 } from "react";
-import { View, StyleSheet, TextInput } from "react-native";
+import { View, StyleSheet } from "react-native";
 import { DarkButton } from "../Layout/Buttons/DarkButton";
-import { size, color, borderRadius, fontSize } from "../../common/styles";
+import { size } from "../../common/styles";
 import { Card } from "../Layout/Card";
 import { AppText } from "../Layout/AppText";
 import { LoginStage } from "./types";
@@ -16,6 +16,7 @@ import {
   countryCodeValidator,
   createFullNumber
 } from "./utils";
+import { PhoneNumberInput } from "../Layout/PhoneNumberInput";
 
 const styles = StyleSheet.create({
   inputAndButtonWrapper: {
@@ -26,39 +27,6 @@ const styles = StyleSheet.create({
   },
   label: {
     fontFamily: "brand-bold"
-  },
-  inputsWrapper: {
-    flexDirection: "row",
-    alignItems: "center"
-  },
-  countryCode: {
-    minHeight: size(6),
-    paddingHorizontal: size(1),
-    marginTop: size(1),
-    backgroundColor: color("grey", 0),
-    borderWidth: 1,
-    borderRadius: borderRadius(2),
-    borderColor: color("grey", 40),
-    fontSize: fontSize(0),
-    color: color("blue", 50),
-    minWidth: size(7)
-  },
-  numberInput: {
-    flex: 1,
-    minHeight: size(6),
-    paddingHorizontal: size(1),
-    marginTop: size(1),
-    backgroundColor: color("grey", 0),
-    borderWidth: 1,
-    borderRadius: borderRadius(2),
-    borderColor: color("grey", 40),
-    fontSize: fontSize(0),
-    color: color("blue", 50)
-  },
-  hyphen: {
-    marginRight: size(1),
-    marginLeft: size(1),
-    fontSize: fontSize(3)
   }
 });
 
@@ -122,27 +90,15 @@ export const LoginMobileNumberCard: FunctionComponent<LoginMobileNumberCard> = (
       <View style={styles.inputAndButtonWrapper}>
         <View style={styles.numberWrapper}>
           <AppText style={styles.label}>Mobile phone number</AppText>
-          <View style={styles.inputsWrapper}>
-            <TextInput
-              style={styles.countryCode}
-              keyboardType="phone-pad"
-              value={countryCode}
-              onChange={({ nativeEvent: { text } }) =>
-                onChangeCountryCode(text)
-              }
-            />
-            <AppText style={styles.hyphen}>-</AppText>
-            <TextInput
-              style={styles.numberInput}
-              keyboardType="phone-pad"
-              value={mobileNumberValue}
-              onChange={({ nativeEvent: { text } }) =>
-                onChangeMobileNumber(text)
-              }
-              onSubmitEditing={onSubmitMobileNumber}
-            />
-          </View>
+          <PhoneNumberInput
+            countryCodeValue={countryCode}
+            mobileNumberValue={mobileNumberValue}
+            onChangeCountryCode={onChangeCountryCode}
+            onChangeMobileNumber={onChangeMobileNumber}
+            onSubmit={onSubmitMobileNumber}
+          />
         </View>
+
         <DarkButton
           text="Send OTP"
           onPress={onSubmitMobileNumber}

--- a/src/components/Login/utils.test.tsx
+++ b/src/components/Login/utils.test.tsx
@@ -1,9 +1,4 @@
-import {
-  decodeQr,
-  createFullNumber,
-  mobileNumberValidator,
-  countryCodeValidator
-} from "./utils";
+import { decodeQr } from "./utils";
 
 describe("decodeQr", () => {
   it("should fail for old QR codes", () => {
@@ -29,50 +24,5 @@ describe("decodeQr", () => {
 
     const missingEndpoint = `{"key": "1e4457bc-f7d0-4329-a344-f0e3c75d8dd4","endpointed": "https://somewhere.com"}`;
     expect(() => decodeQr(missingEndpoint)).toThrow("No endpoint specified");
-  });
-});
-
-describe("createFullNumber", () => {
-  it("should combine the 2 params properly to create a full phone number without spaces", () => {
-    expect.assertions(3);
-    expect(createFullNumber("+65", "98765432")).toBe("+6598765432");
-    expect(createFullNumber("+6 5", "98765432")).toBe("+6598765432");
-    expect(createFullNumber("+65", "987654 32")).toBe("+6598765432");
-  });
-});
-
-describe("mobileNumberValidator", () => {
-  it("should return false for invalid numbers", () => {
-    expect.assertions(7);
-    expect(mobileNumberValidator("+65", "12345678")).toBe(false);
-    expect(mobileNumberValidator("+65", "1")).toBe(false);
-    expect(mobileNumberValidator("+65", "12")).toBe(false);
-    expect(mobileNumberValidator("+1", "91234567")).toBe(false);
-    expect(mobileNumberValidator("+65", " ")).toBe(false);
-    expect(mobileNumberValidator("+65", "")).toBe(false);
-    expect(mobileNumberValidator("+1", "asicdbaoisb")).toBe(false);
-  });
-
-  it("should return true for valid numbers", () => {
-    expect.assertions(3);
-    expect(mobileNumberValidator("+65", "96247612")).toBe(true);
-    expect(mobileNumberValidator("+65", "98261749")).toBe(true);
-    expect(mobileNumberValidator("+65", "98219374")).toBe(true);
-  });
-});
-
-describe("countryCodeValidator", () => {
-  it("should return false for invalid country codes", () => {
-    expect.assertions(2);
-    expect(countryCodeValidator("65")).toBe(false);
-    expect(countryCodeValidator("+900")).toBe(false);
-  });
-
-  it("should return true for valid country codes", () => {
-    expect.assertions(4);
-    expect(countryCodeValidator("+65")).toBe(true);
-    expect(countryCodeValidator("+1")).toBe(true);
-    expect(countryCodeValidator("+61")).toBe(true);
-    expect(countryCodeValidator("+370")).toBe(true);
   });
 });

--- a/src/components/Login/utils.ts
+++ b/src/components/Login/utils.ts
@@ -1,5 +1,3 @@
-import { PhoneNumberUtil } from "google-libphonenumber";
-
 interface QrCode {
   version: string;
   endpoint: string;
@@ -24,31 +22,4 @@ export const decodeQr = (code: string): DecodedQrResponse => {
       );
     throw e;
   }
-};
-
-export const createFullNumber = (countryCode: string, number: string): string =>
-  `${countryCode}${number}`.replace(/\s/g, "");
-
-export const mobileNumberValidator = (
-  countryCode: string,
-  number: string
-): boolean => {
-  if (!/^\d*$/.test(number) || number.length <= 1) {
-    return false;
-  }
-  const phoneNumberUtil = new PhoneNumberUtil();
-  const parsedNumber = phoneNumberUtil.parse(
-    createFullNumber(countryCode, number)
-  );
-  const regionCode = phoneNumberUtil.getRegionCodeForNumber(parsedNumber);
-  return phoneNumberUtil.isValidNumberForRegion(parsedNumber, regionCode);
-};
-
-export const countryCodeValidator = (code: string): boolean => {
-  const phoneNumberUtil = new PhoneNumberUtil();
-  const regions = phoneNumberUtil.getSupportedRegions();
-  const countryCodesList = regions.map(region =>
-    phoneNumberUtil.getCountryCodeForRegion(region).toString()
-  );
-  return code[0] === "+" && countryCodesList.includes(code.substring(1));
 };

--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -896,6 +896,73 @@ describe("useCart", () => {
       ]);
     });
 
+    it("should set error when there is an invalid mobile number", async () => {
+      expect.assertions(3);
+      mockGetQuota.mockReturnValueOnce({
+        remainingQuota: [mockQuotaResSingleId.remainingQuota[0]]
+      });
+      const ids = ["ID1"];
+      const MobileNumberIdentifierProductWrapper: FunctionComponent = ({
+        children
+      }) => (
+        <Wrapper
+          products={[
+            {
+              ...defaultProducts[0],
+              identifiers: [
+                {
+                  label: "code",
+                  textInput: {
+                    visible: true,
+                    disabled: false,
+                    type: "PHONE_NUMBER"
+                  },
+                  scanButton: {
+                    visible: false,
+                    disabled: true
+                  }
+                }
+              ]
+            }
+          ]}
+        >
+          {children}
+        </Wrapper>
+      );
+      const { result } = renderHook(() => useCart(ids, key, endpoint), {
+        wrapper: MobileNumberIdentifierProductWrapper
+      });
+
+      await wait(() => {
+        result.current.updateCart("toilet-paper", 1, [
+          {
+            value: "+659",
+            label: "code",
+            textInputType: "PHONE_NUMBER"
+          }
+        ]);
+        result.current.checkoutCart();
+      });
+
+      expect(result.current.error?.message).toBe("Invalid mobile phone number");
+      expect(result.current.cartState).toBe("DEFAULT");
+      expect(result.current.cart).toStrictEqual([
+        {
+          category: "toilet-paper",
+          identifierInputs: [
+            {
+              value: "+659",
+              label: "code",
+              textInputType: "PHONE_NUMBER"
+            }
+          ],
+          lastTransactionTime: transactionTime,
+          maxQuantity: 2,
+          quantity: 1
+        }
+      ]);
+    });
+
     it("should set error when transaction does not succeed", async () => {
       expect.assertions(3);
       mockGetQuota.mockReturnValueOnce(mockQuotaResSingleId);

--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -944,7 +944,7 @@ describe("useCart", () => {
         result.current.checkoutCart();
       });
 
-      expect(result.current.error?.message).toBe("Invalid mobile phone number");
+      expect(result.current.error?.message).toBe("Invalid contact number");
       expect(result.current.cartState).toBe("DEFAULT");
       expect(result.current.cart).toStrictEqual([
         {

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -290,7 +290,7 @@ export const useCart = (
             .map(identifierInput => identifierInput.value)
         )
       ) {
-        setError(new Error("Invalid mobile phone number"));
+        setError(new Error("Invalid contact number"));
         setCartState("DEFAULT");
         return;
       }

--- a/src/services/envVersion/index.ts
+++ b/src/services/envVersion/index.ts
@@ -45,6 +45,7 @@ const mockGetEnvVersion = async (
         name: "🧻 Toilet Paper",
         description: "1 ply / 2 ply / 3 ply",
         order: 1,
+        type: "REDEEM",
         quantity: {
           period: 7,
           limit: 2,
@@ -59,6 +60,7 @@ const mockGetEnvVersion = async (
         name: "🍜 Instant Noodles",
         description: "Indomee",
         order: 2,
+        type: "REDEEM",
         quantity: {
           period: 30,
           limit: 1,
@@ -73,6 +75,7 @@ const mockGetEnvVersion = async (
         name: "🍫 Chocolate",
         description: "Dark / White / Assorted",
         order: 3,
+        type: "REDEEM",
         quantity: {
           period: 14,
           limit: 30,
@@ -87,6 +90,7 @@ const mockGetEnvVersion = async (
         category: "vouchers",
         name: "Vouchers",
         order: 4,
+        type: "REDEEM",
         quantity: { period: 1, limit: 1, default: 1 },
         identifiers: [
           {
@@ -94,6 +98,16 @@ const mockGetEnvVersion = async (
             textInput: { visible: true, disabled: true, type: "STRING" },
             scanButton: {
               visible: true,
+              disabled: false,
+              type: "BARCODE",
+              text: "Scan"
+            }
+          },
+          {
+            label: "Phone number",
+            textInput: { visible: true, disabled: true, type: "PHONE_NUMBER" },
+            scanButton: {
+              visible: false,
               disabled: false,
               type: "BARCODE",
               text: "Scan"

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,14 @@ const PolicyQuantity = t.intersection([
   })
 ]);
 
+const TextInputType = t.union([
+  t.literal("STRING"),
+  t.literal("NUMBER"),
+  t.literal("PHONE_NUMBER")
+]);
+
+const ScanButtonType = t.union([t.literal("QR"), t.literal("BARCODE")]);
+
 const PolicyIdentifier = t.type({
   label: t.string,
   textInput: t.intersection([
@@ -40,11 +48,7 @@ const PolicyIdentifier = t.type({
       disabled: t.boolean
     }),
     t.partial({
-      type: t.union([
-        t.literal("STRING"),
-        t.literal("NUMBER"),
-        t.literal("PHONE_NUMBER")
-      ])
+      type: TextInputType
     })
   ]),
   scanButton: t.intersection([
@@ -53,7 +57,7 @@ const PolicyIdentifier = t.type({
       disabled: t.boolean
     }),
     t.partial({
-      type: t.union([t.literal("QR"), t.literal("BARCODE")]),
+      type: ScanButtonType,
       text: t.string
     })
   ])
@@ -65,8 +69,8 @@ const IdentifierInput = t.intersection([
     value: t.string
   }),
   t.partial({
-    textInputType: t.string,
-    scanButtonType: t.string
+    textInputType: TextInputType,
+    scanButtonType: ScanButtonType
   })
 ]);
 
@@ -95,6 +99,8 @@ export const EnvVersion = t.type({
   features: Feature
 });
 
+export type TextInputType = t.TypeOf<typeof TextInputType>;
+export type ScanButtonType = t.TypeOf<typeof ScanButtonType>;
 export type IdentifierInput = t.TypeOf<typeof IdentifierInput>;
 export type PolicyIdentifier = t.TypeOf<typeof PolicyIdentifier>;
 export type Policy = t.TypeOf<typeof Policy>;

--- a/src/utils/validatePhoneNumbers.test.tsx
+++ b/src/utils/validatePhoneNumbers.test.tsx
@@ -2,7 +2,7 @@ import {
   createFullNumber,
   mobileNumberValidator,
   countryCodeValidator,
-  fullMobileNumberValidator,
+  fullPhoneNumberValidator,
   validatePhoneNumbers
 } from "./validatePhoneNumbers";
 
@@ -51,18 +51,18 @@ describe("countryCodeValidator", () => {
   });
 });
 
-describe("fullMobileNumberValidator", () => {
+describe("fullPhoneNumberValidator", () => {
   it("should return false for invalid phone numbers", () => {
     expect.assertions(2);
-    expect(fullMobileNumberValidator("+659")).toBe(false);
-    expect(fullMobileNumberValidator("+191234567")).toBe(false);
+    expect(fullPhoneNumberValidator("+659")).toBe(false);
+    expect(fullPhoneNumberValidator("+191234567")).toBe(false);
   });
 
   it("should return true for valid phone numbers", () => {
     expect.assertions(3);
-    expect(fullMobileNumberValidator("+6596247612")).toBe(true);
-    expect(fullMobileNumberValidator("+6598261749")).toBe(true);
-    expect(fullMobileNumberValidator("+6598219374")).toBe(true);
+    expect(fullPhoneNumberValidator("+6596247612")).toBe(true);
+    expect(fullPhoneNumberValidator("+6598261749")).toBe(true);
+    expect(fullPhoneNumberValidator("+6598219374")).toBe(true);
   });
 });
 

--- a/src/utils/validatePhoneNumbers.test.tsx
+++ b/src/utils/validatePhoneNumbers.test.tsx
@@ -2,7 +2,8 @@ import {
   createFullNumber,
   mobileNumberValidator,
   countryCodeValidator,
-  fullMobileNumberValidator
+  fullMobileNumberValidator,
+  validatePhoneNumbers
 } from "./validatePhoneNumbers";
 
 describe("createFullNumber", () => {
@@ -62,5 +63,19 @@ describe("fullMobileNumberValidator", () => {
     expect(fullMobileNumberValidator("+6596247612")).toBe(true);
     expect(fullMobileNumberValidator("+6598261749")).toBe(true);
     expect(fullMobileNumberValidator("+6598219374")).toBe(true);
+  });
+});
+
+describe("validatePhoneNumbers", () => {
+  it("should return false if there is an invalid phone number", () => {
+    expect.assertions(1);
+    expect(validatePhoneNumbers(["+659", "+6596247612"])).toBe(false);
+  });
+
+  it("should return true for valid phone numbers", () => {
+    expect.assertions(1);
+    expect(
+      validatePhoneNumbers(["+6596247612", "+6598261749", "+6598219374"])
+    ).toBe(true);
   });
 });

--- a/src/utils/validatePhoneNumbers.test.tsx
+++ b/src/utils/validatePhoneNumbers.test.tsx
@@ -1,0 +1,66 @@
+import {
+  createFullNumber,
+  mobileNumberValidator,
+  countryCodeValidator,
+  fullMobileNumberValidator
+} from "./validatePhoneNumbers";
+
+describe("createFullNumber", () => {
+  it("should combine the 2 params properly to create a full phone number without spaces", () => {
+    expect.assertions(3);
+    expect(createFullNumber("+65", "98765432")).toBe("+6598765432");
+    expect(createFullNumber("+6 5", "98765432")).toBe("+6598765432");
+    expect(createFullNumber("+65", "987654 32")).toBe("+6598765432");
+  });
+});
+
+describe("mobileNumberValidator", () => {
+  it("should return false for invalid numbers", () => {
+    expect.assertions(7);
+    expect(mobileNumberValidator("+65", "12345678")).toBe(false);
+    expect(mobileNumberValidator("+65", "1")).toBe(false);
+    expect(mobileNumberValidator("+65", "12")).toBe(false);
+    expect(mobileNumberValidator("+1", "91234567")).toBe(false);
+    expect(mobileNumberValidator("+65", " ")).toBe(false);
+    expect(mobileNumberValidator("+65", "")).toBe(false);
+    expect(mobileNumberValidator("+1", "asicdbaoisb")).toBe(false);
+  });
+
+  it("should return true for valid numbers", () => {
+    expect.assertions(3);
+    expect(mobileNumberValidator("+65", "96247612")).toBe(true);
+    expect(mobileNumberValidator("+65", "98261749")).toBe(true);
+    expect(mobileNumberValidator("+65", "98219374")).toBe(true);
+  });
+});
+
+describe("countryCodeValidator", () => {
+  it("should return false for invalid country codes", () => {
+    expect.assertions(2);
+    expect(countryCodeValidator("65")).toBe(false);
+    expect(countryCodeValidator("+900")).toBe(false);
+  });
+
+  it("should return true for valid country codes", () => {
+    expect.assertions(4);
+    expect(countryCodeValidator("+65")).toBe(true);
+    expect(countryCodeValidator("+1")).toBe(true);
+    expect(countryCodeValidator("+61")).toBe(true);
+    expect(countryCodeValidator("+370")).toBe(true);
+  });
+});
+
+describe("fullMobileNumberValidator", () => {
+  it("should return false for invalid phone numbers", () => {
+    expect.assertions(2);
+    expect(fullMobileNumberValidator("+659")).toBe(false);
+    expect(fullMobileNumberValidator("+191234567")).toBe(false);
+  });
+
+  it("should return true for valid phone numbers", () => {
+    expect.assertions(3);
+    expect(fullMobileNumberValidator("+6596247612")).toBe(true);
+    expect(fullMobileNumberValidator("+6598261749")).toBe(true);
+    expect(fullMobileNumberValidator("+6598219374")).toBe(true);
+  });
+});

--- a/src/utils/validatePhoneNumbers.tsx
+++ b/src/utils/validatePhoneNumbers.tsx
@@ -1,0 +1,44 @@
+import { PhoneNumberUtil } from "google-libphonenumber";
+import { IdentifierInput } from "../types";
+
+export const createFullNumber = (countryCode: string, number: string): string =>
+  `${countryCode}${number}`.replace(/\s/g, "");
+
+export const fullMobileNumberValidator = (fullNumber: string): boolean => {
+  try {
+    const phoneNumberUtil = new PhoneNumberUtil();
+    const parsedNumber = phoneNumberUtil.parse(fullNumber);
+    const regionCode = phoneNumberUtil.getRegionCodeForNumber(parsedNumber);
+    return phoneNumberUtil.isValidNumberForRegion(parsedNumber, regionCode);
+  } catch (error) {
+    return false;
+  }
+};
+
+export const mobileNumberValidator = (
+  countryCode: string,
+  number: string
+): boolean => {
+  if (!/^\d*$/.test(number) || number.length <= 1) {
+    return false;
+  }
+  return fullMobileNumberValidator(createFullNumber(countryCode, number));
+};
+
+export const countryCodeValidator = (code: string): boolean => {
+  const phoneNumberUtil = new PhoneNumberUtil();
+  const regions = phoneNumberUtil.getSupportedRegions();
+  const countryCodesList = regions.map(region =>
+    phoneNumberUtil.getCountryCodeForRegion(region).toString()
+  );
+  return code[0] === "+" && countryCodesList.includes(code.substring(1));
+};
+
+export const validatePhoneNumbers = (phoneNumbers: string[]): boolean => {
+  for (const phoneNumber of phoneNumbers) {
+    if (!fullMobileNumberValidator(phoneNumber)) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/src/utils/validatePhoneNumbers.tsx
+++ b/src/utils/validatePhoneNumbers.tsx
@@ -3,7 +3,7 @@ import { PhoneNumberUtil } from "google-libphonenumber";
 export const createFullNumber = (countryCode: string, number: string): string =>
   `${countryCode}${number}`.replace(/\s/g, "");
 
-export const fullMobileNumberValidator = (fullNumber: string): boolean => {
+export const fullPhoneNumberValidator = (fullNumber: string): boolean => {
   try {
     const phoneNumberUtil = new PhoneNumberUtil();
     const parsedNumber = phoneNumberUtil.parse(fullNumber);
@@ -21,7 +21,7 @@ export const mobileNumberValidator = (
   if (!/^\d*$/.test(number) || number.length <= 1) {
     return false;
   }
-  return fullMobileNumberValidator(createFullNumber(countryCode, number));
+  return fullPhoneNumberValidator(createFullNumber(countryCode, number));
 };
 
 export const countryCodeValidator = (code: string): boolean => {
@@ -35,7 +35,7 @@ export const countryCodeValidator = (code: string): boolean => {
 
 export const validatePhoneNumbers = (phoneNumbers: string[]): boolean => {
   for (const phoneNumber of phoneNumbers) {
-    if (!fullMobileNumberValidator(phoneNumber)) {
+    if (!fullPhoneNumberValidator(phoneNumber)) {
       return false;
     }
   }

--- a/src/utils/validatePhoneNumbers.tsx
+++ b/src/utils/validatePhoneNumbers.tsx
@@ -1,5 +1,4 @@
 import { PhoneNumberUtil } from "google-libphonenumber";
-import { IdentifierInput } from "../types";
 
 export const createFullNumber = (countryCode: string, number: string): string =>
   `${countryCode}${number}`.replace(/\s/g, "");


### PR DESCRIPTION
[Trello card](https://trello.com/c/SvdJlgy9/87-ui-tt-token-quota-screen)

This PR adds
* Support for `visible` and `disabled` attributes for text/scan inputs for identifiers
* Support for `STRING`/`NUMBER`/`PHONE_NUMBER` for identifiers' text input type
* Validation of phone numbers before checking out
* Hide identifier input display on Checkout screen if less than 2 identifiers
* Minor copy changes

Assumptions:
* We will never have an identifier with `textInput.type === "PHONE_NUMBER"` and scan button is also visible/enabled

Will add support for different scanner types in a different PR so this doesn't become too large!