### PR TITLE
style: shorten id input label

### DIFF
--- a/src/components/CustomerDetails/InputNricSection.tsx
+++ b/src/components/CustomerDetails/InputNricSection.tsx
@@ -73,7 +73,7 @@ export const InputNricSection: FunctionComponent<InputNricSection> = ({
       <View style={styles.inputAndButtonWrapper}>
         <View style={styles.inputWrapper}>
           <InputWithLabel
-            label="Enter identification number"
+            label="Enter ID number"
             value={nricInput}
             onChange={({ nativeEvent: { text } }) => setNricInput(text)}
             onSubmitEditing={submitNric}

--- a/src/utils/validateNric.tsx
+++ b/src/utils/validateNric.tsx
@@ -52,8 +52,8 @@ export const validate = (nricInput: string): boolean => {
 
 export const validateAndCleanNric = (inputNric: string): string => {
   const isNricValid = validate(inputNric);
-  if (!isNricValid) throw new Error("Invalid identification number");
+  if (!isNricValid) throw new Error("Invalid ID number");
   const cleanedNric = inputNric.match(nricRegex)?.[0].toUpperCase();
-  if (!cleanedNric) throw new Error("Invalid identification number");
+  if (!cleanedNric) throw new Error("Invalid ID number");
   return cleanedNric;
 };


### PR DESCRIPTION
[trello](https://trello.com/c/m2p4SHmr)

Currently "Enter Identification number" label wraps, quick fix to shorten label.
"Enter ID number" working for edge case (Nexus One)