### PR TITLE
feat: scan input for identifiers v2 

### DIFF
--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierPhoneNumberInput.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierPhoneNumberInput.tsx
@@ -1,0 +1,30 @@
+import React, { FunctionComponent, useState, useEffect } from "react";
+import { createFullNumber } from "../../../../utils/validatePhoneNumbers";
+import { View } from "react-native";
+import { PhoneNumberInput } from "../../../Layout/PhoneNumberInput";
+import { sharedStyles } from "./sharedStyles";
+
+export const IdentifierPhoneNumberInput: FunctionComponent<{
+  label: string;
+  onPhoneNumberChange: (text: string) => void;
+}> = ({ label, onPhoneNumberChange }) => {
+  const [countryCodeValue, setCountryCodeValue] = useState("+65");
+  const [phoneNumber, setPhoneNumber] = useState("");
+
+  useEffect(() => {
+    onPhoneNumberChange(createFullNumber(countryCodeValue, phoneNumber));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [countryCodeValue, phoneNumber]);
+
+  return (
+    <View style={[sharedStyles.inputWrapper]}>
+      <PhoneNumberInput
+        countryCodeValue={countryCodeValue}
+        label={label}
+        mobileNumberValue={phoneNumber}
+        onChangeCountryCode={(text: string) => setCountryCodeValue(text)}
+        onChangeMobileNumber={(text: string) => setPhoneNumber(text)}
+      />
+    </View>
+  );
+};

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanButton.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanButton.tsx
@@ -9,11 +9,11 @@ export const IdentifierScanButton: FunctionComponent<{
   disabled: boolean;
   fullWidth: boolean;
   onPress: () => void;
-  text: string | undefined;
+  text: string;
 }> = ({ disabled, fullWidth, onPress, text }) => (
   <View style={sharedStyles.buttonWrapper}>
     <DarkButton
-      text={text || "Scan"}
+      text={text}
       icon={<Feather name="maximize" size={size(2)} color={color("grey", 0)} />}
       disabled={disabled}
       fullWidth={fullWidth}

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanButton.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanButton.tsx
@@ -1,0 +1,23 @@
+import React, { FunctionComponent } from "react";
+import { View } from "react-native";
+import { DarkButton } from "../../../Layout/Buttons/DarkButton";
+import { size, color } from "../../../../common/styles";
+import { sharedStyles } from "./sharedStyles";
+import { Feather } from "@expo/vector-icons";
+
+export const IdentifierScanButton: FunctionComponent<{
+  disabled: boolean;
+  fullWidth: boolean;
+  onPress: () => void;
+  text: string | undefined;
+}> = ({ disabled, fullWidth, onPress, text }) => (
+  <View style={sharedStyles.buttonWrapper}>
+    <DarkButton
+      text={text || "Scan"}
+      icon={<Feather name="maximize" size={size(2)} color={color("grey", 0)} />}
+      disabled={disabled}
+      fullWidth={fullWidth}
+      onPress={onPress}
+    />
+  </View>
+);

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanModal.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanModal.tsx
@@ -3,6 +3,7 @@ import { Modal } from "react-native";
 import { IdScanner } from "../../../IdScanner/IdScanner";
 import { BarCodeScannedCallback, BarCodeScanner } from "expo-barcode-scanner";
 import { ScanButtonType } from "../../../../types";
+import { validateBarcode } from "./validateBarcode";
 
 export const IdentifierScanModal: FunctionComponent<{
   cancelButtonText: string;
@@ -19,7 +20,12 @@ export const IdentifierScanModal: FunctionComponent<{
 }) => {
   const onScan: BarCodeScannedCallback = event => {
     if (event.data) {
-      onScanInput(event.data);
+      if (validateBarcode(event.data)) {
+        onScanInput(event.data);
+      } else {
+        alert("Invalid code");
+        setShouldShowCamera(false);
+      }
     }
   };
 

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanModal.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanModal.tsx
@@ -1,0 +1,46 @@
+import React, { FunctionComponent } from "react";
+import { Modal } from "react-native";
+import { IdScanner } from "../../../IdScanner/IdScanner";
+import { BarCodeScannedCallback, BarCodeScanner } from "expo-barcode-scanner";
+import { ScanButtonType } from "../../../../types";
+
+export const IdentifierScanModal: FunctionComponent<{
+  cancelButtonText: string;
+  onScanInput: (input: string) => void;
+  setShouldShowCamera: (shouldShow: boolean) => void;
+  shouldShowCamera: boolean;
+  type: ScanButtonType;
+}> = ({
+  cancelButtonText,
+  onScanInput,
+  setShouldShowCamera,
+  shouldShowCamera,
+  type
+}) => {
+  const onScan: BarCodeScannedCallback = event => {
+    if (event.data) {
+      onScanInput(event.data);
+    }
+  };
+
+  const barcodeType =
+    type === "BARCODE"
+      ? BarCodeScanner.Constants.BarCodeType.code39
+      : BarCodeScanner.Constants.BarCodeType.qr;
+
+  return (
+    <Modal
+      visible={shouldShowCamera}
+      onRequestClose={() => setShouldShowCamera(false)}
+      transparent={true}
+      animationType="slide"
+    >
+      <IdScanner
+        onBarCodeScanned={onScan}
+        onCancel={() => setShouldShowCamera(false)}
+        cancelButtonText={cancelButtonText}
+        barCodeTypes={[barcodeType]}
+      />
+    </Modal>
+  );
+};

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierTextInput.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierTextInput.tsx
@@ -1,0 +1,30 @@
+import React, { FunctionComponent } from "react";
+import { TextInputType } from "../../../../types";
+import { View } from "react-native";
+import { size } from "../../../../common/styles";
+import { InputWithLabel } from "../../../Layout/InputWithLabel";
+import { sharedStyles } from "./sharedStyles";
+
+export const IdentifierTextInput: FunctionComponent<{
+  addMarginRight: boolean;
+  editable: boolean;
+  label: string;
+  onChange: (text: string) => void;
+  type: TextInputType | undefined;
+  value: string;
+}> = ({ addMarginRight, editable, label, onChange, type, value }) => (
+  <View
+    style={[
+      sharedStyles.inputWrapper,
+      ...(addMarginRight ? [{ marginRight: size(1) }] : [])
+    ]}
+  >
+    <InputWithLabel
+      label={label}
+      value={value}
+      editable={editable}
+      onChange={({ nativeEvent: { text } }) => onChange(text)}
+      keyboardType={type === "NUMBER" ? "phone-pad" : "default"}
+    />
+  </View>
+);

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/sharedStyles.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/sharedStyles.tsx
@@ -1,0 +1,18 @@
+import { StyleSheet } from "react-native";
+import { size } from "../../../../common/styles";
+
+export const sharedStyles = StyleSheet.create({
+  inputAndButtonWrapper: {
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "flex-end",
+    width: "100%",
+    marginTop: size(2)
+  },
+  inputWrapper: {
+    flex: 2
+  },
+  buttonWrapper: {
+    flex: 1
+  }
+});

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/validateBarcode.test.ts
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/validateBarcode.test.ts
@@ -1,0 +1,16 @@
+import { validateBarcode } from "./validateBarcode";
+
+describe("validateBarcode", () => {
+  it("should return true if barcode only has alphanumericals or :", () => {
+    expect.assertions(3);
+    expect(validateBarcode("AA:BB:CC:DD:EE:FF")).toBe(true);
+    expect(validateBarcode("V0001")).toBe(true);
+    expect(validateBarcode("202070000")).toBe(true);
+  });
+
+  it("should return false if barcode contains other special characters", () => {
+    expect.assertions(2);
+    expect(validateBarcode(`{barcode: "barcode"}`)).toBe(false);
+    expect(validateBarcode(") AND 1 = 1")).toBe(false);
+  });
+});

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/validateBarcode.ts
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/validateBarcode.ts
@@ -1,0 +1,3 @@
+export const validateBarcode = (barcode: string): boolean => {
+  return new RegExp(/^[0-9A-Za-z:]*$/).test(barcode);
+};

--- a/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
@@ -1,12 +1,11 @@
 import React, { FunctionComponent, useState } from "react";
-import { View, StyleSheet, Alert, Modal } from "react-native";
+import { View, StyleSheet, Alert } from "react-native";
 import { size } from "../../../common/styles";
-import { BarCodeScannedCallback } from "expo-barcode-scanner";
-import { IdScanner } from "../../IdScanner/IdScanner";
 import { PolicyIdentifier } from "../../../types";
 import { IdentifierPhoneNumberInput } from "./IdentifierLayout/IdentifierPhoneNumberInput";
 import { IdentifierTextInput } from "./IdentifierLayout/IdentifierTextInput";
 import { IdentifierScanButton } from "./IdentifierLayout/IdentifierScanButton";
+import { IdentifierScanModal } from "./IdentifierLayout/IdentifierScanModal";
 
 const styles = StyleSheet.create({
   inputAndButtonWrapper: {
@@ -34,7 +33,7 @@ export const ItemIdentifier: FunctionComponent<{
 
   const { label, textInput, scanButton } = identifier;
 
-  const onCheck = async (input: string): Promise<void> => {
+  const onScanInput = async (input: string): Promise<void> => {
     try {
       setInputValue(input);
       updateIdentifierValue(index, input);
@@ -46,12 +45,6 @@ export const ItemIdentifier: FunctionComponent<{
           text: "Dimiss"
         }
       ]);
-    }
-  };
-
-  const onBarCodeScanned: BarCodeScannedCallback = event => {
-    if (event.data) {
-      onCheck(event.data);
     }
   };
 
@@ -84,23 +77,18 @@ export const ItemIdentifier: FunctionComponent<{
             disabled={scanButton.disabled}
             fullWidth={!textInput.visible}
             onPress={() => setShouldShowCamera(true)}
-            text={scanButton.text}
+            text={scanButton.text || "Scan"}
           />
         )}
       </View>
       {shouldShowCamera && (
-        <Modal
-          visible={shouldShowCamera}
-          onRequestClose={() => setShouldShowCamera(false)}
-          transparent={true}
-          animationType="slide"
-        >
-          <IdScanner
-            onBarCodeScanned={onBarCodeScanned}
-            onCancel={() => setShouldShowCamera(false)}
-            cancelButtonText={textInput.disabled ? "Back" : "Enter manually"}
-          />
-        </Modal>
+        <IdentifierScanModal
+          cancelButtonText={textInput.disabled ? "Back" : "Enter manually"}
+          setShouldShowCamera={setShouldShowCamera}
+          shouldShowCamera={shouldShowCamera}
+          onScanInput={onScanInput}
+          type={scanButton.type || "BARCODE"}
+        />
       )}
     </>
   );

--- a/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
@@ -1,14 +1,12 @@
-import React, { FunctionComponent, useState, useEffect } from "react";
-import { InputWithLabel } from "../../Layout/InputWithLabel";
-import { DarkButton } from "../../Layout/Buttons/DarkButton";
+import React, { FunctionComponent, useState } from "react";
 import { View, StyleSheet, Alert, Modal } from "react-native";
-import { size, color } from "../../../common/styles";
-import { Feather } from "@expo/vector-icons";
+import { size } from "../../../common/styles";
 import { BarCodeScannedCallback } from "expo-barcode-scanner";
 import { IdScanner } from "../../IdScanner/IdScanner";
-import { PolicyIdentifier, TextInputType } from "../../../types";
-import { PhoneNumberInput } from "../../Layout/PhoneNumberInput";
-import { createFullNumber } from "../../../utils/validatePhoneNumbers";
+import { PolicyIdentifier } from "../../../types";
+import { IdentifierPhoneNumberInput } from "./IdentifierLayout/IdentifierPhoneNumberInput";
+import { IdentifierTextInput } from "./IdentifierLayout/IdentifierTextInput";
+import { IdentifierScanButton } from "./IdentifierLayout/IdentifierScanButton";
 
 const styles = StyleSheet.create({
   inputAndButtonWrapper: {
@@ -25,72 +23,6 @@ const styles = StyleSheet.create({
     flex: 1
   }
 });
-
-const IdentifierPhoneNumberInput: FunctionComponent<{
-  label: string;
-  onPhoneNumberChange: (text: string) => void;
-}> = ({ label, onPhoneNumberChange }) => {
-  const [countryCodeValue, setCountryCodeValue] = useState("+65");
-  const [phoneNumber, setPhoneNumber] = useState("");
-
-  useEffect(() => {
-    onPhoneNumberChange(createFullNumber(countryCodeValue, phoneNumber));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [countryCodeValue, phoneNumber]);
-
-  return (
-    <View style={[styles.inputWrapper]}>
-      <PhoneNumberInput
-        countryCodeValue={countryCodeValue}
-        label={label}
-        mobileNumberValue={phoneNumber}
-        onChangeCountryCode={(text: string) => setCountryCodeValue(text)}
-        onChangeMobileNumber={(text: string) => setPhoneNumber(text)}
-      />
-    </View>
-  );
-};
-
-const IdentifierTextInput: FunctionComponent<{
-  addMarginRight: boolean;
-  editable: boolean;
-  label: string;
-  onChange: (text: string) => void;
-  type: TextInputType | undefined;
-  value: string;
-}> = ({ addMarginRight, editable, label, onChange, type, value }) => (
-  <View
-    style={[
-      styles.inputWrapper,
-      ...(addMarginRight ? [{ marginRight: size(1) }] : [])
-    ]}
-  >
-    <InputWithLabel
-      label={label}
-      value={value}
-      editable={editable}
-      onChange={({ nativeEvent: { text } }) => onChange(text)}
-      keyboardType={type === "NUMBER" ? "phone-pad" : "default"}
-    />
-  </View>
-);
-
-const IdentifierScanButton: FunctionComponent<{
-  disabled: boolean;
-  fullWidth: boolean;
-  onPress: () => void;
-  text: string | undefined;
-}> = ({ disabled, fullWidth, onPress, text }) => (
-  <View style={styles.buttonWrapper}>
-    <DarkButton
-      text={text || "Scan"}
-      icon={<Feather name="maximize" size={size(2)} color={color("grey", 0)} />}
-      disabled={disabled}
-      fullWidth={fullWidth}
-      onPress={onPress}
-    />
-  </View>
-);
 
 export const ItemIdentifier: FunctionComponent<{
   index: number;

--- a/src/components/CustomerQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuotaCard.tsx
@@ -108,22 +108,28 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
   );
 
   const itemTransactions: { itemHeader: string; itemDetail: string }[] = [];
-  sortedCart.forEach(({ category, lastTransactionTime, identifierInputs }) => {
-    if (lastTransactionTime) {
-      const policy = getProduct(category);
-      const categoryName = policy?.name ?? category;
-      const formattedDate = format(lastTransactionTime, "hh:mm a, do MMMM");
-      itemTransactions.push({
-        itemHeader: `${categoryName} (${formattedDate})`,
-        itemDetail:
-          identifierInputs && identifierInputs.length > 0
-            ? `${identifierInputs[0].value} — ${
-                identifierInputs[identifierInputs.length - 1].value
-              }`
-            : ""
-      });
+  sortedCart.forEach(
+    ({ category, lastTransactionTime, identifierInputs = [] }) => {
+      if (lastTransactionTime) {
+        const policy = getProduct(category);
+        const categoryName = policy?.name ?? category;
+        const formattedDate = format(lastTransactionTime, "hh:mm a, do MMMM");
+        const filteredIdentifierInputs = identifierInputs.filter(
+          identifierInput => identifierInput.value
+        );
+        itemTransactions.push({
+          itemHeader: `${categoryName} (${formattedDate})`,
+          itemDetail:
+            filteredIdentifierInputs.length > 0
+              ? `${filteredIdentifierInputs[0].value} — ${
+                  filteredIdentifierInputs[filteredIdentifierInputs.length - 1]
+                    .value
+                }`
+              : ""
+        });
+      }
     }
-  });
+  );
 
   const now = new Date();
   const latestTransactionTime = sortedCart[0]?.lastTransactionTime ?? undefined;

--- a/src/services/envVersion/index.ts
+++ b/src/services/envVersion/index.ts
@@ -94,7 +94,7 @@ const mockGetEnvVersion = async (
         quantity: { period: 1, limit: 1, default: 1 },
         identifiers: [
           {
-            label: "Voucher code",
+            label: "Voucher",
             textInput: { visible: true, disabled: true, type: "STRING" },
             scanButton: {
               visible: true,
@@ -104,13 +104,21 @@ const mockGetEnvVersion = async (
             }
           },
           {
+            label: "Token",
+            textInput: { visible: true, disabled: true, type: "STRING" },
+            scanButton: {
+              visible: true,
+              disabled: false,
+              type: "QR",
+              text: "Scan"
+            }
+          },
+          {
             label: "Phone number",
             textInput: { visible: true, disabled: true, type: "PHONE_NUMBER" },
             scanButton: {
               visible: false,
-              disabled: false,
-              type: "BARCODE",
-              text: "Scan"
+              disabled: false
             }
           }
         ]

--- a/src/services/envVersion/index.ts
+++ b/src/services/envVersion/index.ts
@@ -95,7 +95,7 @@ const mockGetEnvVersion = async (
         identifiers: [
           {
             label: "Voucher",
-            textInput: { visible: true, disabled: true, type: "STRING" },
+            textInput: { visible: true, disabled: false, type: "STRING" },
             scanButton: {
               visible: true,
               disabled: false,


### PR DESCRIPTION
[Trello card](https://trello.com/c/SvdJlgy9/87-ui-tt-token-quota-screen)

This PR adds
* QR scanner option
* Validation of barcode and QR code scanned 
* Refactored the different types of identifier layouts into their own files
* (Extra) Fix for no quota screen to hide identifiers when they have no `value`. By right this case should never happen since we should have saved the identifiers to the db, but happened to find this, so just fix in case ah 😅 

Can test against [PR35](https://github.com/rationally-app/backend-api/pull/35)