### PR TITLE
feat: improved keyboard avoiding view

### DIFF
--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -7,13 +7,10 @@ import React, {
 import {
   View,
   StyleSheet,
-  ScrollView,
   Keyboard,
-  KeyboardAvoidingView,
   Alert,
   Vibration,
-  BackHandler,
-  Platform
+  BackHandler
 } from "react-native";
 import { size } from "../../common/styles";
 import { Card } from "../Layout/Card";
@@ -37,6 +34,7 @@ import { FeatureToggler } from "../FeatureToggler/FeatureToggler";
 import { Banner } from "../Layout/Banner";
 import { ImportantMessageContentContext } from "../../context/importantMessage";
 import { useCheckUpdates } from "../../hooks/useCheckUpdates";
+import { KeyboardAvoidingScrollView } from "../Layout/KeyboardAvoidingScrollView";
 
 const styles = StyleSheet.create({
   content: {
@@ -143,39 +141,33 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
   return (
     <>
       <Credits style={{ bottom: size(3) }} />
-      <KeyboardAvoidingView behavior={Platform.select({ ios: "padding" })}>
-        <ScrollView
-          contentContainerStyle={{ alignItems: "center" }}
-          scrollIndicatorInsets={{ right: 1 }}
-          keyboardShouldPersistTaps="handled"
-        >
-          <TopBackground mode={config.appMode} />
-          <View style={styles.content}>
-            <View style={styles.headerText}>
-              <AppHeader mode={config.appMode} />
-            </View>
-            {messageContent && (
-              <View style={styles.bannerWrapper}>
-                <Banner {...messageContent} />
-              </View>
-            )}
-            <Card>
-              <AppText>
-                Check the number of item(s) eligible for redemption
-              </AppText>
-              <InputNricSection
-                openCamera={() => setShouldShowCamera(true)}
-                nricInput={nricInput}
-                setNricInput={setNricInput}
-                submitNric={() => onCheck(nricInput)}
-              />
-            </Card>
-            <FeatureToggler feature="HELP_MODAL">
-              <HelpButton onPress={showHelpModal} />
-            </FeatureToggler>
+      <KeyboardAvoidingScrollView>
+        <TopBackground mode={config.appMode} />
+        <View style={styles.content}>
+          <View style={styles.headerText}>
+            <AppHeader mode={config.appMode} />
           </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
+          {messageContent && (
+            <View style={styles.bannerWrapper}>
+              <Banner {...messageContent} />
+            </View>
+          )}
+          <Card>
+            <AppText>
+              Check the number of item(s) eligible for redemption
+            </AppText>
+            <InputNricSection
+              openCamera={() => setShouldShowCamera(true)}
+              nricInput={nricInput}
+              setNricInput={setNricInput}
+              submitNric={() => onCheck(nricInput)}
+            />
+          </Card>
+          <FeatureToggler feature="HELP_MODAL">
+            <HelpButton onPress={showHelpModal} />
+          </FeatureToggler>
+        </View>
+      </KeyboardAvoidingScrollView>
       {shouldShowCamera && (
         <IdScanner
           isScanningEnabled={isScanningEnabled}

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -12,7 +12,8 @@ import {
   KeyboardAvoidingView,
   Alert,
   Vibration,
-  BackHandler
+  BackHandler,
+  Platform
 } from "react-native";
 import { size } from "../../common/styles";
 import { Card } from "../Layout/Card";
@@ -141,13 +142,14 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
 
   return (
     <>
-      <ScrollView
-        contentContainerStyle={{ alignItems: "center" }}
-        scrollIndicatorInsets={{ right: 1 }}
-        keyboardShouldPersistTaps="handled"
-      >
-        <TopBackground mode={config.appMode} />
-        <KeyboardAvoidingView behavior="position">
+      <Credits style={{ bottom: size(3) }} />
+      <KeyboardAvoidingView behavior={Platform.select({ ios: "padding" })}>
+        <ScrollView
+          contentContainerStyle={{ alignItems: "center" }}
+          scrollIndicatorInsets={{ right: 1 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          <TopBackground mode={config.appMode} />
           <View style={styles.content}>
             <View style={styles.headerText}>
               <AppHeader mode={config.appMode} />
@@ -172,9 +174,8 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
               <HelpButton onPress={showHelpModal} />
             </FeatureToggler>
           </View>
-        </KeyboardAvoidingView>
-      </ScrollView>
-      <Credits style={{ bottom: size(3) }} />
+        </ScrollView>
+      </KeyboardAvoidingView>
       {shouldShowCamera && (
         <IdScanner
           isScanningEnabled={isScanningEnabled}

--- a/src/components/CustomerQuota/AddUserModal.tsx
+++ b/src/components/CustomerQuota/AddUserModal.tsx
@@ -8,7 +8,8 @@ import {
   TouchableWithoutFeedback,
   ScrollView,
   KeyboardAvoidingView,
-  Vibration
+  Vibration,
+  Platform
 } from "react-native";
 import { InputNricSection } from "../CustomerDetails/InputNricSection";
 import { IdScanner } from "../IdScanner/IdScanner";
@@ -156,7 +157,9 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
             <View style={styles.background} />
           </TouchableWithoutFeedback>
           <View style={styles.cardWrapper}>
-            <KeyboardAvoidingView behavior="position">
+            <KeyboardAvoidingView
+              behavior={Platform.select({ ios: "position" })}
+            >
               <Card style={styles.card}>
                 <View style={styles.cardHeader}>
                   <AppText style={{ flex: 1 }}>

--- a/src/components/CustomerQuota/AddUserModal.tsx
+++ b/src/components/CustomerQuota/AddUserModal.tsx
@@ -148,18 +148,16 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
           />
         </View>
       ) : (
-        <ScrollView
-          contentContainerStyle={styles.scrollWrapper}
-          scrollIndicatorInsets={{ right: 1 }}
-          keyboardShouldPersistTaps="handled"
-        >
-          <TouchableWithoutFeedback onPress={() => setIsVisible(false)}>
-            <View style={styles.background} />
-          </TouchableWithoutFeedback>
-          <View style={styles.cardWrapper}>
-            <KeyboardAvoidingView
-              behavior={Platform.select({ ios: "position" })}
-            >
+        <KeyboardAvoidingView behavior={Platform.select({ ios: "padding" })}>
+          <ScrollView
+            contentContainerStyle={styles.scrollWrapper}
+            scrollIndicatorInsets={{ right: 1 }}
+            keyboardShouldPersistTaps="handled"
+          >
+            <TouchableWithoutFeedback onPress={() => setIsVisible(false)}>
+              <View style={styles.background} />
+            </TouchableWithoutFeedback>
+            <View style={styles.cardWrapper}>
               <Card style={styles.card}>
                 <View style={styles.cardHeader}>
                   <AppText style={{ flex: 1 }}>
@@ -176,9 +174,9 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
                   submitNric={() => onCheck(nricInput)}
                 />
               </Card>
-            </KeyboardAvoidingView>
-          </View>
-        </ScrollView>
+            </View>
+          </ScrollView>
+        </KeyboardAvoidingView>
       )}
     </Modal>
   );

--- a/src/components/CustomerQuota/AddUserModal.tsx
+++ b/src/components/CustomerQuota/AddUserModal.tsx
@@ -6,10 +6,7 @@ import {
   Modal,
   TouchableOpacity,
   TouchableWithoutFeedback,
-  ScrollView,
-  KeyboardAvoidingView,
-  Vibration,
-  Platform
+  Vibration
 } from "react-native";
 import { InputNricSection } from "../CustomerDetails/InputNricSection";
 import { IdScanner } from "../IdScanner/IdScanner";
@@ -19,6 +16,7 @@ import { color, size } from "../../common/styles";
 import { Card } from "../Layout/Card";
 import { AppText } from "../Layout/AppText";
 import { Feather } from "@expo/vector-icons";
+import { KeyboardAvoidingScrollView } from "../Layout/KeyboardAvoidingScrollView";
 
 const styles = StyleSheet.create({
   background: {
@@ -148,35 +146,31 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
           />
         </View>
       ) : (
-        <KeyboardAvoidingView behavior={Platform.select({ ios: "padding" })}>
-          <ScrollView
-            contentContainerStyle={styles.scrollWrapper}
-            scrollIndicatorInsets={{ right: 1 }}
-            keyboardShouldPersistTaps="handled"
-          >
-            <TouchableWithoutFeedback onPress={() => setIsVisible(false)}>
-              <View style={styles.background} />
-            </TouchableWithoutFeedback>
-            <View style={styles.cardWrapper}>
-              <Card style={styles.card}>
-                <View style={styles.cardHeader}>
-                  <AppText style={{ flex: 1 }}>
-                    Add another NRIC to combine customer quotas
-                  </AppText>
-                  <View style={{ marginLeft: size(1) }}>
-                    <CloseButton onPress={() => setIsVisible(false)} />
-                  </View>
+        <KeyboardAvoidingScrollView
+          scrollViewContentContainerStyle={styles.scrollWrapper}
+        >
+          <TouchableWithoutFeedback onPress={() => setIsVisible(false)}>
+            <View style={styles.background} />
+          </TouchableWithoutFeedback>
+          <View style={styles.cardWrapper}>
+            <Card style={styles.card}>
+              <View style={styles.cardHeader}>
+                <AppText style={{ flex: 1 }}>
+                  Add another NRIC to combine customer quotas
+                </AppText>
+                <View style={{ marginLeft: size(1) }}>
+                  <CloseButton onPress={() => setIsVisible(false)} />
                 </View>
-                <InputNricSection
-                  openCamera={() => setShouldShowCamera(true)}
-                  nricInput={nricInput}
-                  setNricInput={setNricInput}
-                  submitNric={() => onCheck(nricInput)}
-                />
-              </Card>
-            </View>
-          </ScrollView>
-        </KeyboardAvoidingView>
+              </View>
+              <InputNricSection
+                openCamera={() => setShouldShowCamera(true)}
+                nricInput={nricInput}
+                setNricInput={setNricInput}
+                submitNric={() => onCheck(nricInput)}
+              />
+            </Card>
+          </View>
+        </KeyboardAvoidingScrollView>
       )}
     </Modal>
   );

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -11,7 +11,8 @@ import {
   Alert,
   ScrollView,
   ActivityIndicator,
-  KeyboardAvoidingView
+  KeyboardAvoidingView,
+  Platform
 } from "react-native";
 import { NavigationProps } from "../../types";
 import { color, size } from "../../common/styles";
@@ -140,7 +141,10 @@ export const CustomerQuotaScreen: FunctionComponent<NavigationProps> = ({
       keyboardShouldPersistTaps="handled"
     >
       <TopBackground mode={config.appMode} />
-      <KeyboardAvoidingView behavior="position">
+      <KeyboardAvoidingView
+        behavior={Platform.select({ ios: "position" })}
+        keyboardVerticalOffset={Platform.select({ ios: -100 })}
+      >
         <View style={styles.content}>
           <View style={styles.headerText}>
             <AppHeader mode={config.appMode} />

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -10,7 +10,8 @@ import {
   StyleSheet,
   Alert,
   ScrollView,
-  ActivityIndicator
+  ActivityIndicator,
+  KeyboardAvoidingView
 } from "react-native";
 import { NavigationProps } from "../../types";
 import { color, size } from "../../common/styles";
@@ -139,42 +140,44 @@ export const CustomerQuotaScreen: FunctionComponent<NavigationProps> = ({
       keyboardShouldPersistTaps="handled"
     >
       <TopBackground mode={config.appMode} />
-      <View style={styles.content}>
-        <View style={styles.headerText}>
-          <AppHeader mode={config.appMode} />
-        </View>
-
-        {messageContent && (
-          <View style={styles.bannerWrapper}>
-            <Banner {...messageContent} />
+      <KeyboardAvoidingView behavior="position">
+        <View style={styles.content}>
+          <View style={styles.headerText}>
+            <AppHeader mode={config.appMode} />
           </View>
-        )}
 
-        {cartState === "PURCHASED" ? (
-          <CheckoutSuccessCard
-            nrics={nrics}
-            onCancel={onCancel}
-            checkoutResult={checkoutResult}
-          />
-        ) : cartState === "NO_QUOTA" ? (
-          <NoQuotaCard nrics={nrics} cart={cart} onCancel={onCancel} />
-        ) : cartState === "NOT_ELIGIBLE" ? (
-          <NotEligibleCard nrics={nrics} onCancel={onCancel} />
-        ) : (
-          <ItemsSelectionCard
-            nrics={nrics}
-            addNric={addNric}
-            isLoading={cartState === "CHECKING_OUT"}
-            checkoutCart={checkoutCart}
-            onCancel={onCancel}
-            cart={cart}
-            updateCart={updateCart}
-          />
-        )}
-        <FeatureToggler feature="HELP_MODAL">
-          <HelpButton onPress={showHelpModal} />
-        </FeatureToggler>
-      </View>
+          {messageContent && (
+            <View style={styles.bannerWrapper}>
+              <Banner {...messageContent} />
+            </View>
+          )}
+
+          {cartState === "PURCHASED" ? (
+            <CheckoutSuccessCard
+              nrics={nrics}
+              onCancel={onCancel}
+              checkoutResult={checkoutResult}
+            />
+          ) : cartState === "NO_QUOTA" ? (
+            <NoQuotaCard nrics={nrics} cart={cart} onCancel={onCancel} />
+          ) : cartState === "NOT_ELIGIBLE" ? (
+            <NotEligibleCard nrics={nrics} onCancel={onCancel} />
+          ) : (
+            <ItemsSelectionCard
+              nrics={nrics}
+              addNric={addNric}
+              isLoading={cartState === "CHECKING_OUT"}
+              checkoutCart={checkoutCart}
+              onCancel={onCancel}
+              cart={cart}
+              updateCart={updateCart}
+            />
+          )}
+          <FeatureToggler feature="HELP_MODAL">
+            <HelpButton onPress={showHelpModal} />
+          </FeatureToggler>
+        </View>
+      </KeyboardAvoidingView>
     </ScrollView>
   );
 };

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -5,15 +5,7 @@ import React, {
   useCallback,
   useContext
 } from "react";
-import {
-  View,
-  StyleSheet,
-  Alert,
-  ScrollView,
-  ActivityIndicator,
-  KeyboardAvoidingView,
-  Platform
-} from "react-native";
+import { View, StyleSheet, Alert, ActivityIndicator } from "react-native";
 import { NavigationProps } from "../../types";
 import { color, size } from "../../common/styles";
 import { useAuthenticationContext } from "../../context/auth";
@@ -34,6 +26,7 @@ import { useValidateExpiry } from "../../hooks/useValidateExpiry";
 import { Banner } from "../Layout/Banner";
 import { ImportantMessageContentContext } from "../../context/importantMessage";
 import { NotEligibleCard } from "./NotEligibleCard";
+import { KeyboardAvoidingScrollView } from "../Layout/KeyboardAvoidingScrollView";
 
 const styles = StyleSheet.create({
   loadingWrapper: {
@@ -135,51 +128,45 @@ export const CustomerQuotaScreen: FunctionComponent<NavigationProps> = ({
       </Card>
     </View>
   ) : (
-    <KeyboardAvoidingView behavior={Platform.select({ ios: "padding" })}>
-      <ScrollView
-        contentContainerStyle={{ alignItems: "center" }}
-        scrollIndicatorInsets={{ right: 1 }}
-        keyboardShouldPersistTaps="handled"
-      >
-        <TopBackground mode={config.appMode} />
+    <KeyboardAvoidingScrollView>
+      <TopBackground mode={config.appMode} />
 
-        <View style={styles.content}>
-          <View style={styles.headerText}>
-            <AppHeader mode={config.appMode} />
-          </View>
-
-          {messageContent && (
-            <View style={styles.bannerWrapper}>
-              <Banner {...messageContent} />
-            </View>
-          )}
-
-          {cartState === "PURCHASED" ? (
-            <CheckoutSuccessCard
-              nrics={nrics}
-              onCancel={onCancel}
-              checkoutResult={checkoutResult}
-            />
-          ) : cartState === "NO_QUOTA" ? (
-            <NoQuotaCard nrics={nrics} cart={cart} onCancel={onCancel} />
-          ) : cartState === "NOT_ELIGIBLE" ? (
-            <NotEligibleCard nrics={nrics} onCancel={onCancel} />
-          ) : (
-            <ItemsSelectionCard
-              nrics={nrics}
-              addNric={addNric}
-              isLoading={cartState === "CHECKING_OUT"}
-              checkoutCart={checkoutCart}
-              onCancel={onCancel}
-              cart={cart}
-              updateCart={updateCart}
-            />
-          )}
-          <FeatureToggler feature="HELP_MODAL">
-            <HelpButton onPress={showHelpModal} />
-          </FeatureToggler>
+      <View style={styles.content}>
+        <View style={styles.headerText}>
+          <AppHeader mode={config.appMode} />
         </View>
-      </ScrollView>
-    </KeyboardAvoidingView>
+
+        {messageContent && (
+          <View style={styles.bannerWrapper}>
+            <Banner {...messageContent} />
+          </View>
+        )}
+
+        {cartState === "PURCHASED" ? (
+          <CheckoutSuccessCard
+            nrics={nrics}
+            onCancel={onCancel}
+            checkoutResult={checkoutResult}
+          />
+        ) : cartState === "NO_QUOTA" ? (
+          <NoQuotaCard nrics={nrics} cart={cart} onCancel={onCancel} />
+        ) : cartState === "NOT_ELIGIBLE" ? (
+          <NotEligibleCard nrics={nrics} onCancel={onCancel} />
+        ) : (
+          <ItemsSelectionCard
+            nrics={nrics}
+            addNric={addNric}
+            isLoading={cartState === "CHECKING_OUT"}
+            checkoutCart={checkoutCart}
+            onCancel={onCancel}
+            cart={cart}
+            updateCart={updateCart}
+          />
+        )}
+        <FeatureToggler feature="HELP_MODAL">
+          <HelpButton onPress={showHelpModal} />
+        </FeatureToggler>
+      </View>
+    </KeyboardAvoidingScrollView>
   );
 };

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -135,16 +135,14 @@ export const CustomerQuotaScreen: FunctionComponent<NavigationProps> = ({
       </Card>
     </View>
   ) : (
-    <ScrollView
-      contentContainerStyle={{ alignItems: "center" }}
-      scrollIndicatorInsets={{ right: 1 }}
-      keyboardShouldPersistTaps="handled"
-    >
-      <TopBackground mode={config.appMode} />
-      <KeyboardAvoidingView
-        behavior={Platform.select({ ios: "position" })}
-        keyboardVerticalOffset={Platform.select({ ios: -100 })}
+    <KeyboardAvoidingView behavior={Platform.select({ ios: "padding" })}>
+      <ScrollView
+        contentContainerStyle={{ alignItems: "center" }}
+        scrollIndicatorInsets={{ right: 1 }}
+        keyboardShouldPersistTaps="handled"
       >
+        <TopBackground mode={config.appMode} />
+
         <View style={styles.content}>
           <View style={styles.headerText}>
             <AppHeader mode={config.appMode} />
@@ -181,7 +179,7 @@ export const CustomerQuotaScreen: FunctionComponent<NavigationProps> = ({
             <HelpButton onPress={showHelpModal} />
           </FeatureToggler>
         </View>
-      </KeyboardAvoidingView>
-    </ScrollView>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 };

--- a/src/components/Layout/KeyboardAvoidingScrollView.tsx
+++ b/src/components/Layout/KeyboardAvoidingScrollView.tsx
@@ -1,0 +1,32 @@
+import React, { FunctionComponent } from "react";
+import {
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollViewProps,
+  KeyboardAvoidingViewProps
+} from "react-native";
+
+interface KeyboardAvoidingScrollView {
+  keyboardAvoidingViewStyle?: KeyboardAvoidingViewProps["style"];
+  scrollViewContentContainerStyle?: ScrollViewProps["contentContainerStyle"];
+}
+
+export const KeyboardAvoidingScrollView: FunctionComponent<KeyboardAvoidingScrollView> = ({
+  keyboardAvoidingViewStyle = {},
+  scrollViewContentContainerStyle = { alignItems: "center" },
+  children
+}) => (
+  <KeyboardAvoidingView
+    behavior={Platform.select({ ios: "padding" })}
+    style={keyboardAvoidingViewStyle}
+  >
+    <ScrollView
+      contentContainerStyle={scrollViewContentContainerStyle}
+      scrollIndicatorInsets={{ right: 1 }}
+      keyboardShouldPersistTaps="handled"
+    >
+      {children}
+    </ScrollView>
+  </KeyboardAvoidingView>
+);

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -208,7 +208,7 @@ export const InitialisationContainer: FunctionComponent<NavigationProps> = ({
       >
         <KeyboardAvoidingView
           style={{ alignItems: "center" }}
-          behavior="padding"
+          behavior={Platform.select({ ios: "padding" })}
         >
           <TopBackground
             style={{ height: "50%", maxHeight: "auto" }}

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -48,7 +48,6 @@ const ALLOW_MODE_CHANGE = false;
 const styles = StyleSheet.create({
   content: {
     padding: size(2),
-    marginTop: -size(3),
     width: 512,
     maxWidth: "100%",
     height: "100%",
@@ -203,13 +202,16 @@ export const InitialisationContainer: FunctionComponent<NavigationProps> = ({
 
   return (
     <>
-      <ScrollView
-        contentContainerStyle={{ flex: 1 }}
-        keyboardShouldPersistTaps="handled"
-      >
-        <KeyboardAvoidingView
-          style={{ alignItems: "center" }}
-          behavior={Platform.select({ ios: "padding" })}
+      <Credits style={{ bottom: size(10) }} />
+      <KeyboardAvoidingView behavior={Platform.select({ ios: "padding" })}>
+        <ScrollView
+          contentContainerStyle={{
+            minHeight: "100%",
+            alignItems: "center",
+            paddingBottom: size(8)
+          }}
+          scrollIndicatorInsets={{ right: 1 }}
+          keyboardShouldPersistTaps="handled"
         >
           <TopBackground
             style={{ height: "50%", maxHeight: "auto" }}
@@ -267,9 +269,8 @@ export const InitialisationContainer: FunctionComponent<NavigationProps> = ({
               <HelpButton onPress={showHelpModal} />
             </FeatureToggler>
           </View>
-        </KeyboardAvoidingView>
-      </ScrollView>
-      <Credits style={{ bottom: size(3) }} />
+        </ScrollView>
+      </KeyboardAvoidingView>
       {shouldShowCamera && (
         <IdScanner
           onBarCodeScanned={onBarCodeScanned}

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -9,12 +9,9 @@ import React, {
 import {
   View,
   StyleSheet,
-  KeyboardAvoidingView,
   TouchableWithoutFeedback,
-  ScrollView,
   Vibration,
-  BackHandler,
-  Platform
+  BackHandler
 } from "react-native";
 import { NavigationProps } from "../../types";
 import { DangerButton } from "../Layout/Buttons/DangerButton";
@@ -40,6 +37,7 @@ import { Banner } from "../Layout/Banner";
 import { getEnvVersion, EnvVersionError } from "../../services/envVersion";
 import { useProductContext } from "../../context/products";
 import { useLogout } from "../../hooks/useLogout";
+import { KeyboardAvoidingScrollView } from "../Layout/KeyboardAvoidingScrollView";
 
 const TIME_HELD_TO_CHANGE_APP_MODE = 5 * 1000;
 
@@ -204,77 +202,71 @@ export const InitialisationContainer: FunctionComponent<NavigationProps> = ({
   return (
     <>
       <Credits style={{ bottom: size(10) }} />
-      <KeyboardAvoidingView
-        behavior={Platform.select({ ios: "padding" })}
-        style={{ flex: 1 }}
+      <KeyboardAvoidingScrollView
+        keyboardAvoidingViewStyle={{ flex: 1 }}
+        scrollViewContentContainerStyle={{
+          flexGrow: 1,
+          alignItems: "center",
+          paddingBottom: size(8)
+        }}
       >
-        <ScrollView
-          contentContainerStyle={{
-            flexGrow: 1,
-            alignItems: "center",
-            paddingBottom: size(8)
-          }}
-          scrollIndicatorInsets={{ right: 1 }}
-          keyboardShouldPersistTaps="handled"
-        >
-          <TopBackground
-            style={{ height: "50%", maxHeight: "auto" }}
-            mode={config.appMode}
-          />
-          <View style={styles.content}>
-            <TouchableWithoutFeedback
-              delayLongPress={TIME_HELD_TO_CHANGE_APP_MODE}
-              onLongPress={onToggleAppMode}
-            >
-              <View style={styles.headerText}>
-                <AppName mode={config.appMode} />
-              </View>
-            </TouchableWithoutFeedback>
-            {config.appMode !== AppMode.production && (
-              <View style={{ marginVertical: size(2.5) }}>
-                <DangerButton
-                  text="Exit Testing Mode"
-                  onPress={onToggleAppMode}
-                  fullWidth={true}
-                  isLoading={isLoading}
-                />
-              </View>
-            )}
-
-            {messageContent && (
-              <View style={styles.bannerWrapper}>
-                <Banner {...messageContent} />
-              </View>
-            )}
-
-            {loginStage === "SCAN" && (
-              <LoginScanCard
-                onToggleScanner={() => setShouldShowCamera(true)}
+        <TopBackground
+          style={{ height: "50%", maxHeight: "auto" }}
+          mode={config.appMode}
+        />
+        <View style={styles.content}>
+          <TouchableWithoutFeedback
+            delayLongPress={TIME_HELD_TO_CHANGE_APP_MODE}
+            onLongPress={onToggleAppMode}
+          >
+            <View style={styles.headerText}>
+              <AppName mode={config.appMode} />
+            </View>
+          </TouchableWithoutFeedback>
+          {config.appMode !== AppMode.production && (
+            <View style={{ marginVertical: size(2.5) }}>
+              <DangerButton
+                text="Exit Testing Mode"
+                onPress={onToggleAppMode}
+                fullWidth={true}
                 isLoading={isLoading}
               />
-            )}
-            {loginStage === "MOBILE_NUMBER" && (
-              <LoginMobileNumberCard
-                setLoginStage={setLoginStage}
-                setMobileNumber={setMobileNumber}
-                codeKey={codeKey}
-                endpoint={endpointTemp}
-              />
-            )}
-            {loginStage === "OTP" && (
-              <LoginOTPCard
-                resetStage={resetStage}
-                mobileNumber={mobileNumber}
-                codeKey={codeKey}
-                endpoint={endpointTemp}
-              />
-            )}
-            <FeatureToggler feature="HELP_MODAL">
-              <HelpButton onPress={showHelpModal} />
-            </FeatureToggler>
-          </View>
-        </ScrollView>
-      </KeyboardAvoidingView>
+            </View>
+          )}
+
+          {messageContent && (
+            <View style={styles.bannerWrapper}>
+              <Banner {...messageContent} />
+            </View>
+          )}
+
+          {loginStage === "SCAN" && (
+            <LoginScanCard
+              onToggleScanner={() => setShouldShowCamera(true)}
+              isLoading={isLoading}
+            />
+          )}
+          {loginStage === "MOBILE_NUMBER" && (
+            <LoginMobileNumberCard
+              setLoginStage={setLoginStage}
+              setMobileNumber={setMobileNumber}
+              codeKey={codeKey}
+              endpoint={endpointTemp}
+            />
+          )}
+          {loginStage === "OTP" && (
+            <LoginOTPCard
+              resetStage={resetStage}
+              mobileNumber={mobileNumber}
+              codeKey={codeKey}
+              endpoint={endpointTemp}
+            />
+          )}
+          <FeatureToggler feature="HELP_MODAL">
+            <HelpButton onPress={showHelpModal} />
+          </FeatureToggler>
+        </View>
+      </KeyboardAvoidingScrollView>
       {shouldShowCamera && (
         <IdScanner
           onBarCodeScanned={onBarCodeScanned}

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -54,6 +54,7 @@ const styles = StyleSheet.create({
     justifyContent: "center"
   },
   headerText: {
+    marginTop: size(3),
     marginBottom: size(4),
     textAlign: "center",
     alignSelf: "center"
@@ -203,10 +204,13 @@ export const InitialisationContainer: FunctionComponent<NavigationProps> = ({
   return (
     <>
       <Credits style={{ bottom: size(10) }} />
-      <KeyboardAvoidingView behavior={Platform.select({ ios: "padding" })}>
+      <KeyboardAvoidingView
+        behavior={Platform.select({ ios: "padding" })}
+        style={{ flex: 1 }}
+      >
         <ScrollView
           contentContainerStyle={{
-            minHeight: "100%",
+            flexGrow: 1,
             alignItems: "center",
             paddingBottom: size(8)
           }}

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -13,7 +13,8 @@ import {
   TouchableWithoutFeedback,
   ScrollView,
   Vibration,
-  BackHandler
+  BackHandler,
+  Platform
 } from "react-native";
 import { NavigationProps } from "../../types";
 import { DangerButton } from "../Layout/Buttons/DangerButton";

--- a/src/components/MerchantPayout/MerchantPayoutScreen.tsx
+++ b/src/components/MerchantPayout/MerchantPayoutScreen.tsx
@@ -9,12 +9,9 @@ import React, {
 import {
   View,
   StyleSheet,
-  KeyboardAvoidingView,
-  ScrollView,
   Alert,
   Vibration,
   BackHandler,
-  Platform,
   Keyboard
 } from "react-native";
 import { size, color } from "../../common/styles";
@@ -42,6 +39,7 @@ import { AllValidVouchersModal } from "./AllValidVouchersModal";
 import { useVoucher } from "../../hooks/useVoucher/useVoucher";
 import { useCheckVoucherValidity } from "../../hooks/useCheckVoucherValidity/useCheckVoucherValidity";
 import { useAuthenticationContext } from "../../context/auth";
+import { KeyboardAvoidingScrollView } from "../Layout/KeyboardAvoidingScrollView";
 
 const styles = StyleSheet.create({
   content: {
@@ -201,91 +199,85 @@ export const MerchantPayoutScreen: FunctionComponent<NavigationFocusInjectedProp
 
   return (
     <>
-      <KeyboardAvoidingView behavior={Platform.select({ ios: "padding" })}>
-        <ScrollView
-          contentContainerStyle={{ alignItems: "center" }}
-          scrollIndicatorInsets={{ right: 1 }}
-          keyboardShouldPersistTaps="handled"
-        >
-          <TopBackground mode={config.appMode} />
+      <KeyboardAvoidingScrollView>
+        <TopBackground mode={config.appMode} />
 
-          <View style={styles.content}>
-            <View style={styles.headerText}>
-              <AppHeader mode={config.appMode} />
+        <View style={styles.content}>
+          <View style={styles.headerText}>
+            <AppHeader mode={config.appMode} />
+          </View>
+          {messageContent && (
+            <View style={styles.bannerWrapper}>
+              <Banner {...messageContent} />
             </View>
-            {messageContent && (
-              <View style={styles.bannerWrapper}>
-                <Banner {...messageContent} />
-              </View>
-            )}
-            <Card>
-              <VoucherInputSection
-                vouchers={vouchers}
-                merchantCode={merchantCode}
-                setMerchantCode={setMerchantCode}
-                redeemVouchers={redeemVouchers}
-                openCamera={() => {
-                  Keyboard.dismiss();
-                  setShouldShowCamera(true);
-                }}
-                openAllValidVouchersModal={() =>
-                  setShowAllValidVouchersModal(true)
-                }
-              />
-            </Card>
-            {vouchers.length > 0 && (
-              <View style={styles.buttonsWrapper}>
-                <View style={styles.submitWrapper}>
-                  <DarkButton
-                    fullWidth={true}
-                    text="Checkout"
-                    icon={
-                      <Feather
-                        name="shopping-cart"
-                        size={size(2)}
-                        color={color("grey", 0)}
-                      />
-                    }
-                    onPress={redeemVouchers}
-                    isLoading={checkoutVouchersState !== "DEFAULT"}
-                  />
-                </View>
-                <SecondaryButton
-                  text="Cancel"
-                  onPress={() => {
-                    Alert.alert(
-                      "Discard transaction?",
-                      "This will clear all scanned items",
-                      [
-                        {
-                          text: "Cancel"
-                        },
-                        {
-                          text: "Discard",
-                          onPress: () => {
-                            setMerchantCode("");
-                            resetState();
-                          },
-                          style: "destructive"
-                        }
-                      ]
-                    );
-                  }}
+          )}
+          <Card>
+            <VoucherInputSection
+              vouchers={vouchers}
+              merchantCode={merchantCode}
+              setMerchantCode={setMerchantCode}
+              redeemVouchers={redeemVouchers}
+              openCamera={() => {
+                Keyboard.dismiss();
+                setShouldShowCamera(true);
+              }}
+              openAllValidVouchersModal={() =>
+                setShowAllValidVouchersModal(true)
+              }
+            />
+          </Card>
+          {vouchers.length > 0 && (
+            <View style={styles.buttonsWrapper}>
+              <View style={styles.submitWrapper}>
+                <DarkButton
+                  fullWidth={true}
+                  text="Checkout"
+                  icon={
+                    <Feather
+                      name="shopping-cart"
+                      size={size(2)}
+                      color={color("grey", 0)}
+                    />
+                  }
+                  onPress={redeemVouchers}
+                  isLoading={checkoutVouchersState !== "DEFAULT"}
                 />
               </View>
-            )}
-            <FeatureToggler feature="HELP_MODAL">
-              <HelpButton onPress={showHelpModal} />
-            </FeatureToggler>
-          </View>
-          <AllValidVouchersModal
-            vouchers={vouchers}
-            isVisible={showAllValidVouchersModal}
-            onVoucherCodeRemove={removeVoucher}
-            onExit={() => setShowAllValidVouchersModal(false)}
-          />
-        </ScrollView>
-      </KeyboardAvoidingView>
+              <SecondaryButton
+                text="Cancel"
+                onPress={() => {
+                  Alert.alert(
+                    "Discard transaction?",
+                    "This will clear all scanned items",
+                    [
+                      {
+                        text: "Cancel"
+                      },
+                      {
+                        text: "Discard",
+                        onPress: () => {
+                          setMerchantCode("");
+                          resetState();
+                        },
+                        style: "destructive"
+                      }
+                    ]
+                  );
+                }}
+              />
+            </View>
+          )}
+          <FeatureToggler feature="HELP_MODAL">
+            <HelpButton onPress={showHelpModal} />
+          </FeatureToggler>
+        </View>
+        <AllValidVouchersModal
+          vouchers={vouchers}
+          isVisible={showAllValidVouchersModal}
+          onVoucherCodeRemove={removeVoucher}
+          onExit={() => setShowAllValidVouchersModal(false)}
+        />
+      </KeyboardAvoidingScrollView>
 
       {shouldShowCamera && (
         <VoucherScanner

--- a/src/components/MerchantPayout/MerchantPayoutScreen.tsx
+++ b/src/components/MerchantPayout/MerchantPayoutScreen.tsx
@@ -201,16 +201,14 @@ export const MerchantPayoutScreen: FunctionComponent<NavigationFocusInjectedProp
 
   return (
     <>
-      <ScrollView
-        contentContainerStyle={{ alignItems: "center" }}
-        scrollIndicatorInsets={{ right: 1 }}
-        keyboardShouldPersistTaps="handled"
-      >
-        <TopBackground mode={config.appMode} />
-        <KeyboardAvoidingView
-          behavior={Platform.select({ ios: "position" })}
-          keyboardVerticalOffset={Platform.select({ ios: -80 })}
+      <KeyboardAvoidingView behavior={Platform.select({ ios: "padding" })}>
+        <ScrollView
+          contentContainerStyle={{ alignItems: "center" }}
+          scrollIndicatorInsets={{ right: 1 }}
+          keyboardShouldPersistTaps="handled"
         >
+          <TopBackground mode={config.appMode} />
+
           <View style={styles.content}>
             <View style={styles.headerText}>
               <AppHeader mode={config.appMode} />
@@ -286,8 +284,9 @@ export const MerchantPayoutScreen: FunctionComponent<NavigationFocusInjectedProp
             onVoucherCodeRemove={removeVoucher}
             onExit={() => setShowAllValidVouchersModal(false)}
           />
-        </KeyboardAvoidingView>
-      </ScrollView>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
       {shouldShowCamera && (
         <VoucherScanner
           vouchers={vouchers}

--- a/src/services/envVersion/index.ts
+++ b/src/services/envVersion/index.ts
@@ -88,7 +88,7 @@ const mockGetEnvVersion = async (
       },
       {
         category: "vouchers",
-        name: "Vouchers",
+        name: "Funfair Vouchers",
         order: 4,
         type: "REDEEM",
         quantity: { period: 1, limit: 1, default: 1 },
@@ -112,7 +112,16 @@ const mockGetEnvVersion = async (
               type: "QR",
               text: "Scan"
             }
-          },
+          }
+        ]
+      },
+      {
+        category: "voucher",
+        name: "🎟️ Golden Ticket",
+        order: 5,
+        type: "REDEEM",
+        quantity: { period: 1, limit: 1, default: 1 },
+        identifiers: [
           {
             label: "Phone number",
             textInput: { visible: true, disabled: true, type: "PHONE_NUMBER" },

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -57,6 +57,11 @@ export const mockGetQuota = async (
           transactionTime
         },
         {
+          category: "vouchers",
+          quantity: 1,
+          transactionTime
+        },
+        {
           category: "voucher",
           quantity: 1,
           transactionTime
@@ -78,7 +83,8 @@ export const mockGetQuota = async (
           category: "chocolate",
           quantity: 60
         },
-        { category: "vouchers", quantity: 1 }
+        { category: "vouchers", quantity: 1 },
+        { category: "voucher", quantity: 1 }
       ]
     };
   }


### PR DESCRIPTION
* Add use of KeyboardAvoidingView for quota screen
* KeyboardAvoidingView acts like a normal View but when the keyboard opens, it adds a bottom padding. By doing so, the view becomes shorter. When it wraps the scroll view, elements in the scroll view will still be able to be scrolled.
* Using `behavior="padding"` only on iOS makes it work properly. On android, specifying causes issues, leaving it undefined works fine