### PR TITLE
feat: no negative quota

### DIFF
--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -338,8 +338,8 @@ describe("useCart", () => {
           category: "toilet-paper",
           identifierInputs: [],
           lastTransactionTime: transactionTime,
-          maxQuantity: -1,
-          quantity: -1
+          maxQuantity: 0,
+          quantity: 0
         },
         {
           category: "chocolate",

--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -184,6 +184,24 @@ const mockQuotaResSingleIdNoQuota: Quota = {
     }
   ]
 };
+
+const mockQuotaResSingleIdNegativeQuota: Quota = {
+  remainingQuota: [
+    {
+      category: "toilet-paper",
+      identifierInputs: [],
+      quantity: -1,
+      transactionTime
+    },
+    {
+      category: "chocolate",
+      identifierInputs: [],
+      quantity: 15,
+      transactionTime
+    }
+  ]
+};
+
 const mockQuotaResMultipleIds: Quota = {
   remainingQuota: [
     {
@@ -302,7 +320,36 @@ describe("useCart", () => {
         }
       ]);
     });
+    it("should have cart state be NO_QUOTA when negative quota is received", async () => {
+      expect.assertions(3);
+      mockGetQuota.mockReturnValueOnce(mockQuotaResSingleIdNegativeQuota);
 
+      const ids = ["ID1"];
+      const { result, waitForNextUpdate } = renderHook(
+        () => useCart(ids, key, endpoint),
+        { wrapper: Wrapper }
+      );
+      expect(result.current.cartState).toBe("FETCHING_QUOTA");
+
+      await waitForNextUpdate();
+      expect(result.current.cartState).toBe("NO_QUOTA");
+      expect(result.current.cart).toStrictEqual([
+        {
+          category: "toilet-paper",
+          identifierInputs: [],
+          lastTransactionTime: transactionTime,
+          maxQuantity: -1,
+          quantity: -1
+        },
+        {
+          category: "chocolate",
+          identifierInputs: [],
+          lastTransactionTime: transactionTime,
+          maxQuantity: 15,
+          quantity: 0
+        }
+      ]);
+    });
     it("should set cart state to be NOT_ELIGIBLE when NotEligibleError is thrown, and would not continue with fetching quota", async () => {
       expect.assertions(1);
 

--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -185,7 +185,7 @@ const mockQuotaResSingleIdNoQuota: Quota = {
   ]
 };
 
-const mockQuotaResSingleIdNegativeQuota: Quota = {
+const mockQuotaResSingleIdInvalidQuota: Quota = {
   remainingQuota: [
     {
       category: "toilet-paper",
@@ -320,9 +320,9 @@ describe("useCart", () => {
         }
       ]);
     });
-    it("should have cart state be NO_QUOTA when negative quota is received", async () => {
+    it("should have cart state be NO_QUOTA when quota received is invalid", async () => {
       expect.assertions(3);
-      mockGetQuota.mockReturnValueOnce(mockQuotaResSingleIdNegativeQuota);
+      mockGetQuota.mockReturnValueOnce(mockQuotaResSingleIdInvalidQuota);
 
       const ids = ["ID1"];
       const { result, waitForNextUpdate } = renderHook(

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -109,16 +109,16 @@ const mergeWithCart = (
 };
 
 const hasNoQuota = (quota: Quota): boolean => {
-  let result = true;
+  let [result, hasNegative] = [true, false];
   for (const item of quota.remainingQuota) {
     // The negative quantity case should never occur but if it does, we send an error to Sentry and set state to NO_QUOTA
     if (item.quantity < 0) {
       Sentry.captureException("Negative Quota Received");
       item.quantity = 0;
-      return true;
+      hasNegative = true;
     } else result = result && item.quantity === 0;
   }
-  return result;
+  return result || hasNegative;
 };
 
 export const useCart = (

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -152,7 +152,9 @@ export const useCart = (
           setCartState("NO_QUOTA");
         } else if (hasNoQuota(quotaResponse)) {
           setCartState("NO_QUOTA");
-        } else setCartState("DEFAULT");
+        } else {
+          setCartState("DEFAULT");
+        }
         setQuotaResponse(quotaResponse);
       } catch (e) {
         if (e instanceof NotEligibleError) {

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -143,7 +143,7 @@ export const useCart = (
       try {
         const quotaResponse = await getQuota(ids, authKey, endpoint);
         if (hasNegativeQuota(quotaResponse)) {
-          Sentry.captureException(new Error("Negative Quota Received"));
+          Sentry.captureException("Negative Quota Received");
           setCartState("NO_QUOTA");
         } else if (hasNoQuota(quotaResponse)) {
           setCartState("NO_QUOTA");

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -111,15 +111,9 @@ const mergeWithCart = (
 const hasNoQuota = (quota: Quota): boolean =>
   quota.remainingQuota.every(item => item.quantity === 0);
 
-<<<<<<< HEAD
-=======
 const hasNegativeQuota = (quota: Quota): boolean =>
   quota.remainingQuota.some(item => item.quantity < 0);
 
-const isUniqueList = (list: string[]): boolean =>
-  new Set(list).size === list.length;
-
->>>>>>> feat: show limit reached on receiving negative quota
 export const useCart = (
   ids: string[],
   authKey: string,

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import * as Sentry from "sentry-expo";
 import {
   getQuota,
   postTransaction,
@@ -110,6 +111,15 @@ const mergeWithCart = (
 const hasNoQuota = (quota: Quota): boolean =>
   quota.remainingQuota.every(item => item.quantity === 0);
 
+<<<<<<< HEAD
+=======
+const hasNegativeQuota = (quota: Quota): boolean =>
+  quota.remainingQuota.some(item => item.quantity < 0);
+
+const isUniqueList = (list: string[]): boolean =>
+  new Set(list).size === list.length;
+
+>>>>>>> feat: show limit reached on receiving negative quota
 export const useCart = (
   ids: string[],
   authKey: string,
@@ -138,7 +148,10 @@ export const useCart = (
       setCartState("FETCHING_QUOTA");
       try {
         const quotaResponse = await getQuota(ids, authKey, endpoint);
-        if (hasNoQuota(quotaResponse)) {
+        if (hasNegativeQuota(quotaResponse)) {
+          Sentry.captureException(new Error("Negative Quota Received"));
+          setCartState("NO_QUOTA");
+        } else if (hasNoQuota(quotaResponse)) {
           setCartState("NO_QUOTA");
         } else {
           setCartState("DEFAULT");

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -97,10 +97,10 @@ const mergeWithCart = (
         return {
           category,
           quantity: Math.min(
-            maxQuantity < 0 ? 0 : maxQuantity,
+            Math.max(maxQuantity, 0),
             existingItem?.quantity || defaultQuantity
           ),
-          maxQuantity: maxQuantity < 0 ? 0 : maxQuantity,
+          maxQuantity: Math.max(maxQuantity, 0),
           lastTransactionTime: transactionTime,
           identifierInputs: identifierInputs || defaultIdentifierInputs
         };
@@ -144,7 +144,11 @@ export const useCart = (
       try {
         const quotaResponse = await getQuota(ids, authKey, endpoint);
         if (hasInvalidQuota(quotaResponse)) {
-          Sentry.captureException("Negative Quota Received");
+          Sentry.captureException(
+            `Negative Quota Received: ${JSON.stringify(
+              quotaResponse.remainingQuota
+            )}`
+          );
           setCartState("NO_QUOTA");
         } else if (hasNoQuota(quotaResponse)) {
           setCartState("NO_QUOTA");


### PR DESCRIPTION
[Trello](https://trello.com/c/1p4FC27Q/192-ensure-app-doesnt-show-a-cart-with-negative-quantity)
Features:
- Check for negative quota received and display the limit reached screen if there are
- Sends a Sentry error ([without stacktrace](https://docs.sentry.io/error-reporting/capturing/?platform=javascript#capturing-errors--exceptions))
- Added tests for this case
