### PR TITLE
fix: content covered by status bar

### DIFF
--- a/src/navigation/Content.tsx
+++ b/src/navigation/Content.tsx
@@ -6,7 +6,7 @@ import {
 } from "react-navigation";
 import CustomerQuotaStack from "./CustomerQuotaStack";
 import MerchantPayoutStack from "./MerchantPayoutStack";
-import { StatusBar, View } from "react-native";
+import { StatusBar, View, Platform } from "react-native";
 import LoginScreen from "./LoginScreen";
 import { useAppState } from "../hooks/useAppState";
 import { useCheckUpdates } from "../hooks/useCheckUpdates";
@@ -48,7 +48,9 @@ export const Content = (): ReactElement => {
       <StatusBar />
       <View
         style={{
-          flex: 1
+          flex: 1,
+          paddingTop:
+            Platform.OS === "android" && !__DEV__ ? StatusBar.currentHeight : 0 // padding is used to prevent content from going behind the status bar on Android production builds
         }}
       >
         <AppContainer ref={navigatorRef} uriPrefix={prefix} />


### PR DESCRIPTION
This issue only occurs on Android production builds. So was using `expo build:android` to actually get the apk and install it on my device.

Have added back the check to add `paddingTop`.

Will need to relook this again when upgrading to a later version of Expo. Looks like it could be a react-native issue where SafeAreaView does not properly care about the height of the status bar