### PR TITLE
feat: added new ci/cd process

### DIFF
--- a/.github/workflows/deploy_branch_preview.yml
+++ b/.github/workflows/deploy_branch_preview.yml
@@ -38,16 +38,12 @@ jobs:
   deploy_branch_preview:
     name: Deploy Branch Preview
     needs: test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
-        node: [10, 12, 13]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 12.x
       - uses: expo/expo-github-action@v5
         with:
           expo-packager: npm

--- a/.github/workflows/deploy_branch_preview.yml
+++ b/.github/workflows/deploy_branch_preview.yml
@@ -68,7 +68,7 @@ jobs:
         uses: mshick/add-pr-comment@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EXPO_PROJECT: "@justussoh/rationally"
+          EXPO_PROJECT: "@musket/rationally"
         with:
           message: |
             ## Application

--- a/.github/workflows/deploy_branch_preview.yml
+++ b/.github/workflows/deploy_branch_preview.yml
@@ -5,16 +5,12 @@ on: [pull_request]
 jobs:
   test:
     name: Lint & Test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
-        node: [10, 12, 13]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 12.x
       - name: Cache Node Modules
         uses: actions/cache@v2
         env:

--- a/.github/workflows/deploy_branch_preview.yml
+++ b/.github/workflows/deploy_branch_preview.yml
@@ -5,12 +5,16 @@ on: [pull_request]
 jobs:
   test:
     name: Lint & Test
-    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        node: [10, 12, 13]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: ${{ matrix.node }}
       - name: Cache Node Modules
         uses: actions/cache@v2
         env:

--- a/.github/workflows/deploy_branch_preview.yml
+++ b/.github/workflows/deploy_branch_preview.yml
@@ -4,14 +4,14 @@ on: [pull_request]
 
 jobs:
   test:
-    name: build and test
-    runs-on: ubuntu-latest
+    name: Lint & Test
+    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - name: Cache node modules
+      - name: Cache Node Modules
         uses: actions/cache@v2
         env:
           cache-name: cache-node-modules
@@ -23,30 +23,34 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-	
             ${{ runner.os }}-build-	
             ${{ runner.os }}-
-      - name: install
+      - name: Install Packages
         run: npm install
       # - name: Typecheck
       #   run: npx --no-install tsc --noEmit
-      - name: Lint
+      - name: Check Lint
         run: npm run lint
       - name: Test
         run: npm run test -- --coverage
   deploy_branch_preview:
     name: Deploy Branch Preview
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        node: [10, 12, 13]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: ${{ matrix.node }}
       - uses: expo/expo-github-action@v5
         with:
-          expo-version: 3.x
+          expo-packager: npm
           expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
           expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
           expo-cache: true
-      - name: Cache node modules
+      - name: Cache Node Modules
         uses: actions/cache@v2
         env:
           cache-name: cache-node-modules
@@ -58,13 +62,13 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - name: install
+      - name: Install Packages
         run: npm install
-      - name: expo_publish_channel
+      - name: Expo Publish Channel
         run: expo publish --non-interactive --release-channel pr${{ github.event.number }}
-      - name: expo_publish_storybook_channel
-        run: expo publish --non-interactive --release-channel storybook-${{ github.event.number }}
-      - name: Add comment to PR
+      - name: Expo Publish Storybook Channel
+        run: expo publish --non-interactive --release-channel storybook-pr${{ github.event.number }}
+      - name: Add Comment To PR
         uses: mshick/add-pr-comment@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -72,9 +76,8 @@ jobs:
         with:
           message: |
             ## Application
-            ![Expo QR](https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=exp://exp.host/${{ env.EXPO_PROJECT }}?release-channel=${{ github.event.number }})
+            ![Expo QR](https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=exp://exp.host/${{ env.EXPO_PROJECT }}?release-channel=pr${{ github.event.number }})
             Published to https://exp.host/${{ env.EXPO_PROJECT }}?release-channel=pr${{ github.event.number }}
             ## Storybook
-            ![Expo QR](https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=exp://exp.host/${{ env.EXPO_PROJECT }}?release-channel=storybook-${{ github.event.number }})
-            Published to https://exp.host/${{ env.EXPO_PROJECT }}?release-channel=storybook-${{ github.event.number }}
-          allow-repeats: true
+            ![Expo QR](https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=exp://exp.host/${{ env.EXPO_PROJECT }}?release-channel=storybook-pr${{ github.event.number }})
+            Published to https://exp.host/${{ env.EXPO_PROJECT }}?release-channel=storybook-pr${{ github.event.number }}

--- a/.github/workflows/deploy_branch_preview.yml
+++ b/.github/workflows/deploy_branch_preview.yml
@@ -1,0 +1,80 @@
+name: Deploy Branch Preview
+
+on: [pull_request]
+
+jobs:
+  test:
+    name: build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-	
+            ${{ runner.os }}-build-	
+            ${{ runner.os }}-
+      - name: install
+        run: npm install
+      # - name: Typecheck
+      #   run: npx --no-install tsc --noEmit
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm run test -- --coverage
+  deploy_branch_preview:
+    name: Deploy Branch Preview
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-version: 3.x
+          expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
+          expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
+          expo-cache: true
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: install
+        run: npm install
+      - name: expo_publish_channel
+        run: expo publish --non-interactive --release-channel pr${{ github.event.number }}
+      - name: expo_publish_storybook_channel
+        run: expo publish --non-interactive --release-channel storybook-${{ github.event.number }}
+      - name: Add comment to PR
+        uses: mshick/add-pr-comment@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPO_PROJECT: "@justussoh/rationally"
+        with:
+          message: |
+            ## Application
+            ![Expo QR](https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=exp://exp.host/${{ env.EXPO_PROJECT }}?release-channel=${{ github.event.number }})
+            Published to https://exp.host/${{ env.EXPO_PROJECT }}?release-channel=pr${{ github.event.number }}
+            ## Storybook
+            ![Expo QR](https://api.qrserver.com/v1/create-qr-code/?size=250x250&data=exp://exp.host/${{ env.EXPO_PROJECT }}?release-channel=storybook-${{ github.event.number }})
+            Published to https://exp.host/${{ env.EXPO_PROJECT }}?release-channel=storybook-${{ github.event.number }}
+          allow-repeats: true

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -27,7 +27,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     outputs:
-      majorVersion: ${{ steps.get_major_version.outputs.majorVersion }}
+      majorVersion: ${{ steps.majorVersion.outputs.majorVersion }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -41,7 +41,7 @@ jobs:
           expo-cache: true
       - uses: rlespinasse/github-slug-action@v2.x
       - name: Parse Major Version
-        id: get_major_version
+        id: majorVersion
         run: |
           MAJOR_VERSION=$(echo ${{ env.GITHUB_REF_SLUG }} | sed -r 's/\.[0-9]+\.[0-9]+$//')
           echo "::set-output name=majorVersion::$MAJOR_VERSION"
@@ -54,8 +54,7 @@ jobs:
     needs: deploy_prod
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - uses: rlespinasse/github-slug-action@v2.x
       - name: Generate Changelog
         id: changelog

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Packages
         run: npm install
       - name: Expo Publish Channel
-        run: expo publish --non-interactive --release-channel=${{ steps.get_major_version.outputs.majorVersion }}
+        run: expo publish --non-interactive --release-channel=${{ steps.majorVersion.outputs.majorVersion }}
   create_release:
     name: Create Release
     needs: deploy_prod

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Lint & Test
-    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -25,7 +25,7 @@ jobs:
   deploy_prod:
     name: Deploy To Production
     needs: test
-    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ubuntu-latest
     outputs:
       majorVersion: ${{ steps.get_major_version.outputs.majorVersion }}
     steps:
@@ -52,7 +52,7 @@ jobs:
   create_release:
     name: Create Release
     needs: deploy_prod
-    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -74,7 +74,7 @@ jobs:
           allowUpdates: true
   build_android:
     needs: [deploy_prod, create_release]
-    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: rlespinasse/github-slug-action@v2.x
@@ -102,7 +102,7 @@ jobs:
           tag: ${{ github.ref }}
   build_ios:
     needs: [deploy_prod, create_release]
-    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: rlespinasse/github-slug-action@v2.x

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -6,26 +6,26 @@ on:
 
 jobs:
   test:
-    name: build and test
-    runs-on: ubuntu-latest
+    name: Lint & Test
+    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - name: install
+      - name: Install Packages
         run: npm install
       # Commented out as type checks are failing
       # - name: Typecheck
       #   run: npx --no-install tsc --noEmit
-      - name: Lint
+      - name: Check Lint
         run: npm run lint
       - name: Test
         run: npm run test -- --coverage
   deploy_prod:
-    name: deploy_prod
+    name: Deploy To Production
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
     outputs:
       majorVersion: ${{ steps.get_major_version.outputs.majorVersion }}
     steps:
@@ -35,34 +35,34 @@ jobs:
           node-version: 12.x
       - uses: expo/expo-github-action@v5
         with:
-          expo-version: 3.x
+          expo-packager: npm
           expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
           expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
           expo-cache: true
       - uses: rlespinasse/github-slug-action@v2.x
-      - name: Parse major Version
+      - name: Parse Major Version
         id: get_major_version
         run: |
-          MAJOR_RELEASE=$(echo ${{ env.GITHUB_REF_SLUG }} | sed -r 's/\.[0-9]+\.[0-9]+$//')
-          echo "::set-output name=majorVersion::$MAJOR_RELEASE"
-      - name: Install
+          MAJOR_VERSION=$(echo ${{ env.GITHUB_REF_SLUG }} | sed -r 's/\.[0-9]+\.[0-9]+$//')
+          echo "::set-output name=majorVersion::$MAJOR_VERSION"
+      - name: Install Packages
         run: npm install
-      - name: Publish application
+      - name: Expo Publish Channel
         run: expo publish --non-interactive --release-channel=${{ steps.get_major_version.outputs.majorVersion }}
   create_release:
     name: Create Release
     needs: deploy_prod
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v2
       - uses: rlespinasse/github-slug-action@v2.x
-      - name: Generate changelog
+      - name: Generate Changelog
         id: changelog
         uses: metcalfc/changelog-generator@v0.4.0
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
-          base-ref: "base-ref" #need a tag "base-ref for setup, please remove after setup"
+          base-ref: "prod-0" #need a tag "prod-0 for setup, please remove after setup"
       - name: Creating Release
         uses: ncipollo/release-action@v1
         with:
@@ -74,57 +74,57 @@ jobs:
           allowUpdates: true
   build_android:
     needs: [deploy_prod, create_release]
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
+      - uses: rlespinasse/github-slug-action@v2.x
       - uses: expo/expo-github-action@v5
         with:
-          expo-version: 3.x
+          expo-packager: npm
           expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
           expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
           expo-cache: true
-      - name: Install npm dependencies
-        run: |
-          npm install
+      - name: Install Packages
+        run: npm install
       - name: Build Android Release
         id: android
         run: |
-          OUTPUT="$(echo $(expo build:android) | tail | egrep -o 'https?://expo\.io/artifacts/[^ ]+')"
+          OUTPUT="$(echo $(expo build:android) | tail | grep -o 'https?://expo\.io/artifacts/[^ ]+')"
           echo "::set-output name=assetUrl::$OUTPUT"
-      - name: Download apk asset
-        run: wget -O android.apk ${{ steps.android.outputs.assetURL }}
+      - name: Download APK Asset
+        run: wget -O supplyally-${{ env.GITHUB_REF_SLUG }}.apk ${{ steps.android.outputs.assetURL }}
       - name: Upload Release Asset
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ./android.apk
-          asset_name: rationally-${{ needs.deploy_prod.outputs.majorVersion }}.apk
+          file: ./supplyally-${{ env.GITHUB_REF_SLUG }}.apk
+          asset_name: supplyally-${{ env.GITHUB_REF_SLUG }}.apk
           tag: ${{ github.ref }}
   build_ios:
     needs: [deploy_prod, create_release]
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
+      - uses: rlespinasse/github-slug-action@v2.x
       - uses: expo/expo-github-action@v5
         with:
-          expo-version: 3.x
+          expo-packager: npm
           expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
           expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
           expo-cache: true
-      - name: Install npm dependencies
-        run: |
-          npm install
+      - name: Install Packages
+        run: npm install
       - name: Build IOS Release
         id: ios
         run: |
-          OUTPUT="$(echo $(expo build:ios) | tail | egrep -o 'https?://expo\.io/artifacts/[^ ]+')"
+          OUTPUT="$(echo $(expo build:ios) | tail | grep -o 'https?://expo\.io/artifacts/[^ ]+')"
           echo "::set-output name=assetUrl::$OUTPUT"
-      - name: Download ipa asset
-        run: wget -O rationally.ipa ${{ steps.ios.outputs.assetURL }}
+      - name: Download IPA Asset
+        run: wget -O supplyally-${{ env.GITHUB_REF_SLUG }}.ipa ${{ steps.ios.outputs.assetURL }}
       - name: Upload Release Asset
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ././rationally.ipa
-          asset_name: rationally-${{ needs.deploy_prod.outputs.majorVersion }}.ipa
+          file: ./supplyally-${{ env.GITHUB_REF_SLUG }}.ipa
+          asset_name: supplyally-${{ env.GITHUB_REF_SLUG }}.ipa
           tag: ${{ github.ref }}

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -1,0 +1,130 @@
+name: Create Release
+on:
+  push:
+    tags:
+      - "prod-[1-9]+.[0-9]+.[0-9]+" # Push events to matching prod-*, i.e.prod-20.15.10
+
+jobs:
+  test:
+    name: build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: install
+        run: npm install
+      # Commented out as type checks are failing
+      # - name: Typecheck
+      #   run: npx --no-install tsc --noEmit
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm run test -- --coverage
+  deploy_prod:
+    name: deploy_prod
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      majorVersion: ${{ steps.get_major_version.outputs.majorVersion }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-version: 3.x
+          expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
+          expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
+          expo-cache: true
+      - uses: rlespinasse/github-slug-action@v2.x
+      - name: Parse major Version
+        id: get_major_version
+        run: |
+          MAJOR_RELEASE=$(echo ${{ env.GITHUB_REF_SLUG }} | sed -r 's/\.[0-9]+\.[0-9]+$//')
+          echo "::set-output name=majorVersion::$MAJOR_RELEASE"
+      - name: Install
+        run: npm install
+      - name: Publish application
+        run: expo publish --non-interactive --release-channel=${{ steps.get_major_version.outputs.majorVersion }}
+  create_release:
+    name: Create Release
+    needs: deploy_prod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - uses: rlespinasse/github-slug-action@v2.x
+      - name: Generate changelog
+        id: changelog
+        uses: metcalfc/changelog-generator@v0.4.0
+        with:
+          myToken: ${{ secrets.GITHUB_TOKEN }}
+          base-ref: "base-ref" #need a tag "base-ref for setup, please remove after setup"
+      - name: Creating Release
+        uses: ncipollo/release-action@v1
+        with:
+          body: |
+            Changes in this Release: 
+            ${{ steps.changelog.outputs.changelog }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Release ${{ env.GITHUB_REF_SLUG }}
+          allowUpdates: true
+  build_android:
+    needs: [deploy_prod, create_release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-version: 3.x
+          expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
+          expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
+          expo-cache: true
+      - name: Install npm dependencies
+        run: |
+          npm install
+      - name: Build Android Release
+        id: android
+        run: |
+          OUTPUT="$(echo $(expo build:android) | tail | egrep -o 'https?://expo\.io/artifacts/[^ ]+')"
+          echo "::set-output name=assetUrl::$OUTPUT"
+      - name: Download apk asset
+        run: wget -O android.apk ${{ steps.android.outputs.assetURL }}
+      - name: Upload Release Asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./android.apk
+          asset_name: rationally-${{ needs.deploy_prod.outputs.majorVersion }}.apk
+          tag: ${{ github.ref }}
+  build_ios:
+    needs: [deploy_prod, create_release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-version: 3.x
+          expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
+          expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
+          expo-cache: true
+      - name: Install npm dependencies
+        run: |
+          npm install
+      - name: Build IOS Release
+        id: ios
+        run: |
+          OUTPUT="$(echo $(expo build:ios) | tail | egrep -o 'https?://expo\.io/artifacts/[^ ]+')"
+          echo "::set-output name=assetUrl::$OUTPUT"
+      - name: Download ipa asset
+        run: wget -O rationally.ipa ${{ steps.ios.outputs.assetURL }}
+      - name: Upload Release Asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ././rationally.ipa
+          asset_name: rationally-${{ needs.deploy_prod.outputs.majorVersion }}.ipa
+          tag: ${{ github.ref }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Lint & Test
-    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   test:
-    name: build and test
-    runs-on: ubuntu-latest
+    name: Lint & Test
+    runs-on: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - name: Cache node modules
+      - name: Cache Node Modules
         uses: actions/cache@v2
         env:
           cache-name: cache-node-modules
@@ -26,16 +26,16 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-	
             ${{ runner.os }}-build-	
             ${{ runner.os }}-
-      - name: install
+      - name: Install Packages
         run: npm install
       # - name: Typecheck
       #   run: npx --no-install tsc --noEmit
-      - name: Lint
+      - name: Check Lint
         run: npm run lint
       - name: Test
         run: npm run test -- --coverage
   deploy_staging:
-    name: Deploy Staging
+    name: Deploy to Staging
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -45,13 +45,13 @@ jobs:
           node-version: 12.x
       - uses: expo/expo-github-action@v5
         with:
-          expo-version: 3.x
+          expo-packager: npm
           expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
           expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
           expo-cache: true
-      - name: install
+      - name: Install Packages
         run: npm install
-      - name: expo_publish_channel
+      - name: Expo Publish Channel
         run: expo publish --non-interactive --release-channel staging
-      - name: expo_publish_storybook_channel
+      - name: Expo Publish Storybook Channel
         run: expo publish --non-interactive --release-channel storybook-staging

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,0 +1,57 @@
+name: Deploy Staging
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-	
+            ${{ runner.os }}-build-	
+            ${{ runner.os }}-
+      - name: install
+        run: npm install
+      # - name: Typecheck
+      #   run: npx --no-install tsc --noEmit
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm run test -- --coverage
+  deploy_staging:
+    name: Deploy Staging
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - uses: expo/expo-github-action@v5
+        with:
+          expo-version: 3.x
+          expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
+          expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
+          expo-cache: true
+      - name: install
+        run: npm install
+      - name: expo_publish_channel
+        run: expo publish --non-interactive --release-channel staging
+      - name: expo_publish_storybook_channel
+        run: expo publish --non-interactive --release-channel storybook-staging

--- a/.github/workflows/test_development_environment.yml
+++ b/.github/workflows/test_development_environment.yml
@@ -1,4 +1,4 @@
-name: Deploy Branch Preview
+name: Test Different Development Environments
 
 on: [pull_request]
 

--- a/.github/workflows/test_development_environment.yml
+++ b/.github/workflows/test_development_environment.yml
@@ -1,0 +1,37 @@
+name: Deploy Branch Preview
+
+on: [pull_request]
+
+jobs:
+  test:
+    name: Lint & Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        node: [10, 12, 13]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Cache Node Modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-	
+            ${{ runner.os }}-build-	
+            ${{ runner.os }}-
+      - name: Install Packages
+        run: npm install
+      # - name: Typecheck
+      #   run: npx --no-install tsc --noEmit
+      - name: Check Lint
+        run: npm run lint
+      - name: Test
+        run: npm run test -- --coverage


### PR DESCRIPTION
This PR includes:
- new ci/cd process with github actions

For setup:
- add `EXPO_CLI_USERNAME` and `EXPO_CLI_PASSWORD` into secrets
- create a `base-ref` tag for first release reference to compare to
- Read the documentation on the notion of how to operate ([https://www.notion.so/CI-CD-Documentation-Front-end-2c95eafd9f0948c09d11db3bc2ad4534#03d3256825ac4d82a75c5a1fb7f71d72](url))