### PR TITLE
feat: updated cache timeout to 10s

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,7 +15,7 @@
       "backgroundColor": "#F1FAFA"
     },
     "updates": {
-      "fallbackToCacheTimeout": 0
+      "fallbackToCacheTimeout": 10000
     },
     "assetBundlePatterns": ["**/*"],
     "ios": {


### PR DESCRIPTION
This PR contains the increase in time out duration to 4seconds for automatic updates over-the-air (OTA): https://docs.expo.io/guides/configuring-ota-updates/#automatic-updates

<img width="599" alt="Screenshot 2020-07-14 at 11 54 52 AM" src="https://user-images.githubusercontent.com/38589870/87382162-dd96cc80-c5c8-11ea-8e67-a387eed3c659.png">
