### PR TITLE
feat: using new feature flag to toggle id scanning type

### DIFF
--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -186,9 +186,9 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
           onCancel={() => setShouldShowCamera(false)}
           cancelButtonText="Enter ID manually"
           barCodeTypes={
-            features?.id.scannerType === "CODE_39"
-              ? [BarCodeScanner.Constants.BarCodeType.code39]
-              : [BarCodeScanner.Constants.BarCodeType.qr]
+            features?.id.scannerType === "QR"
+              ? [BarCodeScanner.Constants.BarCodeType.qr]
+              : [BarCodeScanner.Constants.BarCodeType.code39]
           }
         />
       )}

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -24,8 +24,7 @@ import {
 } from "react-navigation";
 import { IdScanner } from "../IdScanner/IdScanner";
 import { BarCodeScanner, BarCodeScannedCallback } from "expo-barcode-scanner";
-import { validateAndCleanNric } from "../../utils/validateNric";
-import { validateAndCleanId } from "../../utils/validateInputWithRegex";
+import { validateAndCleanId } from "../../utils/validateIdentification";
 import { InputIdSection } from "./InputIdSection";
 import { AppHeader } from "../Layout/AppHeader";
 import * as Sentry from "sentry-expo";
@@ -112,21 +111,13 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
   }, [shouldShowCamera]);
 
   const onCheck = async (input: string): Promise<void> => {
-    let id: string;
     try {
       setIsScanningEnabled(false);
-      switch (features?.id.validation) {
-        case "NRIC":
-          id = validateAndCleanNric(input);
-          break;
-        case "REGEX":
-          const idRegex = features?.id.validationRegex;
-          id = validateAndCleanId(input, idRegex);
-          break;
-        default:
-          // Remove validation
-          id = input;
-      }
+      const id = validateAndCleanId(
+        input,
+        features?.id.validation,
+        features?.id.validationRegex
+      );
       Vibration.vibrate(50);
       navigation.navigate("CustomerQuotaScreen", { id });
       setIdInput("");

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -26,7 +26,7 @@ import { IdScanner } from "../IdScanner/IdScanner";
 import { BarCodeScanner, BarCodeScannedCallback } from "expo-barcode-scanner";
 import { validateAndCleanNric } from "../../utils/validateNric";
 import { validateAndCleanId } from "../../utils/validateInputWithRegex";
-import { InputNricSection } from "./InputNricSection";
+import { InputIdSection } from "./InputIdSection";
 import { AppHeader } from "../Layout/AppHeader";
 import * as Sentry from "sentry-expo";
 import { HelpButton } from "../Layout/Buttons/HelpButton";
@@ -70,7 +70,7 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
   const messageContent = useContext(ImportantMessageContentContext);
   const [shouldShowCamera, setShouldShowCamera] = useState(false);
   const [isScanningEnabled, setIsScanningEnabled] = useState(true);
-  const [nricInput, setNricInput] = useState("");
+  const [idInput, setIdInput] = useState("");
   const { config } = useConfigContext();
   const showHelpModal = useContext(HelpModalContext);
   const checkUpdates = useCheckUpdates();
@@ -112,24 +112,24 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
   }, [shouldShowCamera]);
 
   const onCheck = async (input: string): Promise<void> => {
-    let nric: string;
+    let id: string;
     try {
       setIsScanningEnabled(false);
       switch (features?.id.validation) {
         case "NRIC":
-          nric = validateAndCleanNric(input);
+          id = validateAndCleanNric(input);
           break;
         case "REGEX":
           const idRegex = features?.id.validationRegex;
-          nric = validateAndCleanId(input, idRegex);
+          id = validateAndCleanId(input, idRegex);
           break;
         default:
           // Remove validation
-          nric = input;
+          id = input;
       }
       Vibration.vibrate(50);
-      navigation.navigate("CustomerQuotaScreen", { nric });
-      setNricInput("");
+      navigation.navigate("CustomerQuotaScreen", { id });
+      setIdInput("");
     } catch (e) {
       setIsScanningEnabled(false);
       if (e instanceof EnvVersionError) {
@@ -175,11 +175,11 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
             <AppText>
               Check the number of item(s) eligible for redemption
             </AppText>
-            <InputNricSection
+            <InputIdSection
               openCamera={() => setShouldShowCamera(true)}
-              nricInput={nricInput}
-              setNricInput={setNricInput}
-              submitNric={() => onCheck(nricInput)}
+              idInput={idInput}
+              setIdInput={setIdInput}
+              submitId={() => onCheck(idInput)}
             />
           </Card>
           <FeatureToggler feature="HELP_MODAL">

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -115,14 +115,17 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
     let nric: string;
     try {
       setIsScanningEnabled(false);
-      if (features?.id.validation === "NRIC") {
-        nric = validateAndCleanNric(input);
-      } else if (features?.id.validation === "REGEX") {
-        const idRegex = features?.id.validationRegex;
-        nric = validateAndCleanId(input, idRegex);
-      } else {
-        // Remove validation
-        nric = input;
+      switch (features?.id.validation) {
+        case "NRIC":
+          nric = validateAndCleanNric(input);
+          break;
+        case "REGEX":
+          const idRegex = features?.id.validationRegex;
+          nric = validateAndCleanId(input, idRegex);
+          break;
+        default:
+          // Remove validation
+          nric = input;
       }
       Vibration.vibrate(50);
       navigation.navigate("CustomerQuotaScreen", { nric });

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -34,11 +34,8 @@ import { FeatureToggler } from "../FeatureToggler/FeatureToggler";
 import { Banner } from "../Layout/Banner";
 import { ImportantMessageContentContext } from "../../context/importantMessage";
 import { useCheckUpdates } from "../../hooks/useCheckUpdates";
-<<<<<<< HEAD
 import { KeyboardAvoidingScrollView } from "../Layout/KeyboardAvoidingScrollView";
-=======
 import { useProductContext } from "../../context/products";
->>>>>>> c622c14... feat: add condition to toggle scanner typebetween code39 and qr
 
 const styles = StyleSheet.create({
   content: {

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -110,9 +110,15 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
   }, [shouldShowCamera]);
 
   const onCheck = async (input: string): Promise<void> => {
+    let nric: string;
     try {
       setIsScanningEnabled(false);
-      const nric = validateAndCleanNric(input);
+      if (features?.SCANNER.VALIDATION === "NRIC") {
+        nric = validateAndCleanNric(input);
+      } else {
+        // Remove validation
+        nric = input;
+      }
       Vibration.vibrate(50);
       navigation.navigate("CustomerQuotaScreen", { nric });
       setNricInput("");

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -171,6 +171,7 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
               idInput={idInput}
               setIdInput={setIdInput}
               submitId={() => onCheck(idInput)}
+              idType={features?.id.type}
             />
           </Card>
           <FeatureToggler feature="HELP_MODAL">

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -23,7 +23,7 @@ import {
   NavigationFocusInjectedProps
 } from "react-navigation";
 import { IdScanner } from "../IdScanner/IdScanner";
-import { BarCodeScannedCallback } from "expo-barcode-scanner";
+import { BarCodeScanner, BarCodeScannedCallback } from "expo-barcode-scanner";
 import { validateAndCleanNric } from "../../utils/validateNric";
 import { InputNricSection } from "./InputNricSection";
 import { AppHeader } from "../Layout/AppHeader";
@@ -34,7 +34,11 @@ import { FeatureToggler } from "../FeatureToggler/FeatureToggler";
 import { Banner } from "../Layout/Banner";
 import { ImportantMessageContentContext } from "../../context/importantMessage";
 import { useCheckUpdates } from "../../hooks/useCheckUpdates";
+<<<<<<< HEAD
 import { KeyboardAvoidingScrollView } from "../Layout/KeyboardAvoidingScrollView";
+=======
+import { useProductContext } from "../../context/products";
+>>>>>>> c622c14... feat: add condition to toggle scanner typebetween code39 and qr
 
 const styles = StyleSheet.create({
   content: {
@@ -71,6 +75,7 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
   const { config } = useConfigContext();
   const showHelpModal = useContext(HelpModalContext);
   const checkUpdates = useCheckUpdates();
+  const { features } = useProductContext();
 
   useEffect(() => {
     if (isFocused) {
@@ -174,6 +179,11 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
           onBarCodeScanned={onBarCodeScanned}
           onCancel={() => setShouldShowCamera(false)}
           cancelButtonText="Enter ID manually"
+          barCodeTypes={
+            features?.SCANNER.TYPE === "CODE39"
+              ? [BarCodeScanner.Constants.BarCodeType.code39]
+              : [BarCodeScanner.Constants.BarCodeType.qr]
+          }
         />
       )}
     </>

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -113,7 +113,7 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
     let nric: string;
     try {
       setIsScanningEnabled(false);
-      if (features?.SCANNER.VALIDATION === "NRIC") {
+      if (features?.id.validation === "NRIC") {
         nric = validateAndCleanNric(input);
       } else {
         // Remove validation
@@ -183,7 +183,7 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
           onCancel={() => setShouldShowCamera(false)}
           cancelButtonText="Enter ID manually"
           barCodeTypes={
-            features?.SCANNER.TYPE === "CODE39"
+            features?.id.scannerType === "CODE_39"
               ? [BarCodeScanner.Constants.BarCodeType.code39]
               : [BarCodeScanner.Constants.BarCodeType.qr]
           }

--- a/src/components/CustomerDetails/InputIdSection.tsx
+++ b/src/components/CustomerDetails/InputIdSection.tsx
@@ -44,13 +44,15 @@ interface InputIdSection {
   idInput: string;
   setIdInput: (id: string) => void;
   submitId: () => void;
+  idType: "STRING" | "NUMBER" | undefined;
 }
 
 export const InputIdSection: FunctionComponent<InputIdSection> = ({
   openCamera,
   idInput,
   setIdInput,
-  submitId
+  submitId,
+  idType
 }) => {
   return (
     <>
@@ -79,6 +81,7 @@ export const InputIdSection: FunctionComponent<InputIdSection> = ({
             onSubmitEditing={submitId}
             autoCompleteType="off"
             autoCorrect={false}
+            keyboardType={idType === "NUMBER" ? "numeric" : "default"}
           />
         </View>
         <SecondaryButton text="Check" onPress={submitId} />

--- a/src/components/CustomerDetails/InputIdSection.tsx
+++ b/src/components/CustomerDetails/InputIdSection.tsx
@@ -39,18 +39,18 @@ const styles = StyleSheet.create({
   }
 });
 
-interface InputNricSection {
+interface InputIdSection {
   openCamera: () => void;
-  nricInput: string;
-  setNricInput: (nric: string) => void;
-  submitNric: () => void;
+  idInput: string;
+  setIdInput: (id: string) => void;
+  submitId: () => void;
 }
 
-export const InputNricSection: FunctionComponent<InputNricSection> = ({
+export const InputIdSection: FunctionComponent<InputIdSection> = ({
   openCamera,
-  nricInput,
-  setNricInput,
-  submitNric
+  idInput,
+  setIdInput,
+  submitId
 }) => {
   return (
     <>
@@ -74,14 +74,14 @@ export const InputNricSection: FunctionComponent<InputNricSection> = ({
         <View style={styles.inputWrapper}>
           <InputWithLabel
             label="Enter ID number"
-            value={nricInput}
-            onChange={({ nativeEvent: { text } }) => setNricInput(text)}
-            onSubmitEditing={submitNric}
+            value={idInput}
+            onChange={({ nativeEvent: { text } }) => setIdInput(text)}
+            onSubmitEditing={submitId}
             autoCompleteType="off"
             autoCorrect={false}
           />
         </View>
-        <SecondaryButton text="Check" onPress={submitNric} />
+        <SecondaryButton text="Check" onPress={submitId} />
       </View>
     </>
   );

--- a/src/components/CustomerQuota/AddUserModal.tsx
+++ b/src/components/CustomerQuota/AddUserModal.tsx
@@ -10,8 +10,7 @@ import {
 } from "react-native";
 import { InputIdSection } from "../CustomerDetails/InputIdSection";
 import { IdScanner } from "../IdScanner/IdScanner";
-import { validateAndCleanNric } from "../../utils/validateNric";
-import { validateAndCleanId } from "../../utils/validateInputWithRegex";
+import { validateAndCleanId } from "../../utils/validateIdentification";
 import { BarCodeScanner, BarCodeScannedCallback } from "expo-barcode-scanner";
 import { color, size } from "../../common/styles";
 import { Card } from "../Layout/Card";
@@ -91,21 +90,13 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
   }, [isVisible]);
 
   const onCheck = async (input: string): Promise<void> => {
-    let id: string;
     try {
       setIsScanningEnabled(false);
-      switch (features?.id.validation) {
-        case "NRIC":
-          id = validateAndCleanNric(input);
-          break;
-        case "REGEX":
-          const idRegex = features?.id.validationRegex;
-          id = validateAndCleanId(input, idRegex);
-          break;
-        default:
-          // Remove validation
-          id = input;
-      }
+      const id = validateAndCleanId(
+        input,
+        features?.id.validation,
+        features?.id.validationRegex
+      );
       Vibration.vibrate(50);
       if (ids.indexOf(id) > -1) {
         throw new Error(

--- a/src/components/CustomerQuota/AddUserModal.tsx
+++ b/src/components/CustomerQuota/AddUserModal.tsx
@@ -8,7 +8,7 @@ import {
   TouchableWithoutFeedback,
   Vibration
 } from "react-native";
-import { InputNricSection } from "../CustomerDetails/InputNricSection";
+import { InputIdSection } from "../CustomerDetails/InputIdSection";
 import { IdScanner } from "../IdScanner/IdScanner";
 import { validateAndCleanNric } from "../../utils/validateNric";
 import { validateAndCleanId } from "../../utils/validateInputWithRegex";
@@ -69,19 +69,19 @@ const CloseButton: FunctionComponent<{ onPress: () => void }> = ({
 interface AddUserModal {
   isVisible: boolean;
   setIsVisible: (visible: boolean) => void;
-  nrics: string[];
-  addNric: (nric: string) => void;
+  ids: string[];
+  addId: (id: string) => void;
 }
 
 export const AddUserModal: FunctionComponent<AddUserModal> = ({
   isVisible,
   setIsVisible,
-  nrics,
-  addNric
+  ids,
+  addId
 }) => {
   const [shouldShowCamera, setShouldShowCamera] = useState(false);
   const [isScanningEnabled, setIsScanningEnabled] = useState(true);
-  const [nricInput, setNricInput] = useState("");
+  const [idInput, setIdInput] = useState("");
   const { features } = useProductContext();
 
   useEffect(() => {
@@ -91,30 +91,30 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
   }, [isVisible]);
 
   const onCheck = async (input: string): Promise<void> => {
-    let nric: string;
+    let id: string;
     try {
       setIsScanningEnabled(false);
       switch (features?.id.validation) {
         case "NRIC":
-          nric = validateAndCleanNric(input);
+          id = validateAndCleanNric(input);
           break;
         case "REGEX":
           const idRegex = features?.id.validationRegex;
-          nric = validateAndCleanId(input, idRegex);
+          id = validateAndCleanId(input, idRegex);
           break;
         default:
           // Remove validation
-          nric = input;
+          id = input;
       }
       Vibration.vibrate(50);
-      if (nrics.indexOf(nric) > -1) {
+      if (ids.indexOf(id) > -1) {
         throw new Error(
-          "You've added this NRIC before, please scan a different NRIC."
+          "You've added this ID before, please scan a different ID."
         );
       }
-      addNric(nric);
+      addId(id);
       setIsVisible(false);
-      setNricInput("");
+      setIdInput("");
     } catch (e) {
       setIsScanningEnabled(false);
       Alert.alert(
@@ -176,17 +176,17 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
             <Card style={styles.card}>
               <View style={styles.cardHeader}>
                 <AppText style={{ flex: 1 }}>
-                  Add another NRIC to combine customer quotas
+                  Add another ID to combine customer quotas
                 </AppText>
                 <View style={{ marginLeft: size(1) }}>
                   <CloseButton onPress={() => setIsVisible(false)} />
                 </View>
               </View>
-              <InputNricSection
+              <InputIdSection
                 openCamera={() => setShouldShowCamera(true)}
-                nricInput={nricInput}
-                setNricInput={setNricInput}
-                submitNric={() => onCheck(nricInput)}
+                idInput={idInput}
+                setIdInput={setIdInput}
+                submitId={() => onCheck(idInput)}
               />
             </Card>
           </View>

--- a/src/components/CustomerQuota/AddUserModal.tsx
+++ b/src/components/CustomerQuota/AddUserModal.tsx
@@ -93,7 +93,7 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
     let nric: string;
     try {
       setIsScanningEnabled(false);
-      if (features?.SCANNER.VALIDATION === "NRIC") {
+      if (features?.id.validation === "NRIC") {
         nric = validateAndCleanNric(input);
       } else {
         // Remove validation
@@ -152,7 +152,7 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
             onCancel={() => setShouldShowCamera(false)}
             cancelButtonText="Enter ID manually"
             barCodeTypes={
-              features?.SCANNER.TYPE === "CODE39"
+              features?.id.scannerType === "CODE_39"
                 ? [BarCodeScanner.Constants.BarCodeType.code39]
                 : [BarCodeScanner.Constants.BarCodeType.qr]
             }

--- a/src/components/CustomerQuota/AddUserModal.tsx
+++ b/src/components/CustomerQuota/AddUserModal.tsx
@@ -178,6 +178,7 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
                 idInput={idInput}
                 setIdInput={setIdInput}
                 submitId={() => onCheck(idInput)}
+                idType={features?.id.type}
               />
             </Card>
           </View>

--- a/src/components/CustomerQuota/AddUserModal.tsx
+++ b/src/components/CustomerQuota/AddUserModal.tsx
@@ -11,12 +11,16 @@ import {
 import { InputNricSection } from "../CustomerDetails/InputNricSection";
 import { IdScanner } from "../IdScanner/IdScanner";
 import { validateAndCleanNric } from "../../utils/validateNric";
-import { BarCodeScannedCallback } from "expo-barcode-scanner";
+import { BarCodeScanner, BarCodeScannedCallback } from "expo-barcode-scanner";
 import { color, size } from "../../common/styles";
 import { Card } from "../Layout/Card";
 import { AppText } from "../Layout/AppText";
 import { Feather } from "@expo/vector-icons";
+<<<<<<< HEAD
 import { KeyboardAvoidingScrollView } from "../Layout/KeyboardAvoidingScrollView";
+=======
+import { useProductContext } from "../../context/products";
+>>>>>>> c622c14... feat: add condition to toggle scanner typebetween code39 and qr
 
 const styles = StyleSheet.create({
   background: {
@@ -80,6 +84,7 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
   const [shouldShowCamera, setShouldShowCamera] = useState(false);
   const [isScanningEnabled, setIsScanningEnabled] = useState(true);
   const [nricInput, setNricInput] = useState("");
+  const { features } = useProductContext();
 
   useEffect(() => {
     if (isVisible) {
@@ -143,6 +148,11 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
             onBarCodeScanned={onBarCodeScanned}
             onCancel={() => setShouldShowCamera(false)}
             cancelButtonText="Enter ID manually"
+            barCodeTypes={
+              features?.SCANNER.TYPE === "CODE39"
+                ? [BarCodeScanner.Constants.BarCodeType.code39]
+                : [BarCodeScanner.Constants.BarCodeType.qr]
+            }
           />
         </View>
       ) : (

--- a/src/components/CustomerQuota/AddUserModal.tsx
+++ b/src/components/CustomerQuota/AddUserModal.tsx
@@ -11,6 +11,7 @@ import {
 import { InputNricSection } from "../CustomerDetails/InputNricSection";
 import { IdScanner } from "../IdScanner/IdScanner";
 import { validateAndCleanNric } from "../../utils/validateNric";
+import { validateAndCleanId } from "../../utils/validateInputWithRegex";
 import { BarCodeScanner, BarCodeScannedCallback } from "expo-barcode-scanner";
 import { color, size } from "../../common/styles";
 import { Card } from "../Layout/Card";
@@ -93,11 +94,17 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
     let nric: string;
     try {
       setIsScanningEnabled(false);
-      if (features?.id.validation === "NRIC") {
-        nric = validateAndCleanNric(input);
-      } else {
-        // Remove validation
-        nric = input;
+      switch (features?.id.validation) {
+        case "NRIC":
+          nric = validateAndCleanNric(input);
+          break;
+        case "REGEX":
+          const idRegex = features?.id.validationRegex;
+          nric = validateAndCleanId(input, idRegex);
+          break;
+        default:
+          // Remove validation
+          nric = input;
       }
       Vibration.vibrate(50);
       if (nrics.indexOf(nric) > -1) {

--- a/src/components/CustomerQuota/AddUserModal.tsx
+++ b/src/components/CustomerQuota/AddUserModal.tsx
@@ -150,9 +150,9 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
             onCancel={() => setShouldShowCamera(false)}
             cancelButtonText="Enter ID manually"
             barCodeTypes={
-              features?.id.scannerType === "CODE_39"
-                ? [BarCodeScanner.Constants.BarCodeType.code39]
-                : [BarCodeScanner.Constants.BarCodeType.qr]
+              features?.id.scannerType === "QR"
+                ? [BarCodeScanner.Constants.BarCodeType.qr]
+                : [BarCodeScanner.Constants.BarCodeType.code39]
             }
           />
         </View>

--- a/src/components/CustomerQuota/AddUserModal.tsx
+++ b/src/components/CustomerQuota/AddUserModal.tsx
@@ -90,9 +90,15 @@ export const AddUserModal: FunctionComponent<AddUserModal> = ({
   }, [isVisible]);
 
   const onCheck = async (input: string): Promise<void> => {
+    let nric: string;
     try {
       setIsScanningEnabled(false);
-      const nric = validateAndCleanNric(input);
+      if (features?.SCANNER.VALIDATION === "NRIC") {
+        nric = validateAndCleanNric(input);
+      } else {
+        // Remove validation
+        nric = input;
+      }
       Vibration.vibrate(50);
       if (nrics.indexOf(nric) > -1) {
         throw new Error(

--- a/src/components/CustomerQuota/AddUserModal.tsx
+++ b/src/components/CustomerQuota/AddUserModal.tsx
@@ -16,11 +16,8 @@ import { color, size } from "../../common/styles";
 import { Card } from "../Layout/Card";
 import { AppText } from "../Layout/AppText";
 import { Feather } from "@expo/vector-icons";
-<<<<<<< HEAD
 import { KeyboardAvoidingScrollView } from "../Layout/KeyboardAvoidingScrollView";
-=======
 import { useProductContext } from "../../context/products";
->>>>>>> c622c14... feat: add condition to toggle scanner typebetween code39 and qr
 
 const styles = StyleSheet.create({
   background: {

--- a/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
+++ b/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
@@ -19,20 +19,17 @@ const styles = StyleSheet.create({
 });
 
 interface CheckoutSuccessCard {
-  nrics: string[];
+  ids: string[];
   onCancel: () => void;
   checkoutResult: CartHook["checkoutResult"];
 }
 
 export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
-  nrics,
+  ids,
   onCancel,
   checkoutResult
 }) => {
-  const checkoutQuantities = getPurchasedQuantitiesByItem(
-    nrics,
-    checkoutResult!
-  );
+  const checkoutQuantities = getPurchasedQuantitiesByItem(ids, checkoutResult!);
   const { getProduct } = useProductContext();
   const productType = getProduct(checkoutQuantities[0].category)?.type;
   const { title, description, ctaButtonText } = getCheckoutMessages(
@@ -41,7 +38,7 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
 
   return (
     <View>
-      <CustomerCard nrics={nrics}>
+      <CustomerCard ids={ids}>
         <View
           style={[
             sharedStyles.resultWrapper,

--- a/src/components/CustomerQuota/CustomerCard.tsx
+++ b/src/components/CustomerQuota/CustomerCard.tsx
@@ -25,12 +25,12 @@ const styles = StyleSheet.create({
     marginLeft: size(1.5),
     flex: 1
   },
-  nricLabel: {
+  idLabel: {
     color: color("grey", 0),
     fontSize: fontSize(-2),
     marginBottom: 2
   },
-  nricText: {
+  idText: {
     color: color("grey", 0),
     fontSize: fontSize(1),
     lineHeight: 1.2 * fontSize(1),
@@ -78,10 +78,10 @@ export const AddButton: FunctionComponent<AddButton> = ({ text, onPress }) => {
 };
 
 export const CustomerCard: FunctionComponent<{
-  nrics: string[];
-  onAddNric?: () => void;
+  ids: string[];
+  onAddId?: () => void;
   headerBackgroundColor?: ViewStyle["backgroundColor"];
-}> = ({ nrics, onAddNric, headerBackgroundColor, children }) => (
+}> = ({ ids, onAddId, headerBackgroundColor, children }) => (
   <Card
     style={{
       paddingTop: 0,
@@ -97,16 +97,16 @@ export const CustomerCard: FunctionComponent<{
     >
       <Feather name="user" size={size(3)} color={color("grey", 0)} />
       <View style={styles.headerText}>
-        <AppText style={styles.nricLabel}>
-          Identification number{nrics.length > 1 ? "s" : ""}
+        <AppText style={styles.idLabel}>
+          Identification number{ids.length > 1 ? "s" : ""}
         </AppText>
-        {nrics.map(nric => (
-          <AppText key={nric} style={styles.nricText}>
-            {nric}
+        {ids.map(id => (
+          <AppText key={id} style={styles.idText}>
+            {id}
           </AppText>
         ))}
       </View>
-      {onAddNric && <AddButton onPress={onAddNric} text="+ Add"></AddButton>}
+      {onAddId && <AddButton onPress={onAddId} text="+ Add"></AddButton>}
     </View>
     <View style={styles.childrenWrapper}>{children}</View>
   </Card>

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -79,7 +79,7 @@ export const CustomerQuotaScreen: FunctionComponent<NavigationProps> = ({
   const { config } = useConfigContext();
   const { token, endpoint } = useAuthenticationContext();
   const showHelpModal = useContext(HelpModalContext);
-  const [nrics, setNrics] = useState([navigation.getParam("nric")]);
+  const [ids, setIds] = useState([navigation.getParam("id")]);
 
   const {
     cartState,
@@ -89,7 +89,7 @@ export const CustomerQuotaScreen: FunctionComponent<NavigationProps> = ({
     checkoutResult,
     error,
     clearError
-  } = useCart(nrics, token, endpoint);
+  } = useCart(ids, token, endpoint);
 
   useEffect(() => {
     Sentry.addBreadcrumb({
@@ -102,8 +102,8 @@ export const CustomerQuotaScreen: FunctionComponent<NavigationProps> = ({
     navigation.goBack();
   }, [navigation]);
 
-  const addNric = useCallback((nric: string): void => {
-    setNrics(nrics => [...nrics, nric]);
+  const addId = useCallback((id: string): void => {
+    setIds(ids => [...ids, id]);
   }, []);
 
   useEffect(() => {
@@ -144,18 +144,18 @@ export const CustomerQuotaScreen: FunctionComponent<NavigationProps> = ({
 
         {cartState === "PURCHASED" ? (
           <CheckoutSuccessCard
-            nrics={nrics}
+            ids={ids}
             onCancel={onCancel}
             checkoutResult={checkoutResult}
           />
         ) : cartState === "NO_QUOTA" ? (
-          <NoQuotaCard nrics={nrics} cart={cart} onCancel={onCancel} />
+          <NoQuotaCard ids={ids} cart={cart} onCancel={onCancel} />
         ) : cartState === "NOT_ELIGIBLE" ? (
-          <NotEligibleCard nrics={nrics} onCancel={onCancel} />
+          <NotEligibleCard ids={ids} onCancel={onCancel} />
         ) : (
           <ItemsSelectionCard
-            nrics={nrics}
-            addNric={addNric}
+            ids={ids}
+            addId={addId}
             isLoading={cartState === "CHECKING_OUT"}
             checkoutCart={checkoutCart}
             onCancel={onCancel}

--- a/src/components/CustomerQuota/ItemsSelection/ItemsSelectionCard.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemsSelectionCard.tsx
@@ -12,8 +12,8 @@ import { Item } from "./Item";
 import { useProductContext } from "../../../context/products";
 
 interface ItemsSelectionCard {
-  nrics: string[];
-  addNric: (nric: string) => void;
+  ids: string[];
+  addId: (id: string) => void;
   isLoading: boolean;
   checkoutCart: () => void;
   onCancel: () => void;
@@ -22,8 +22,8 @@ interface ItemsSelectionCard {
 }
 
 export const ItemsSelectionCard: FunctionComponent<ItemsSelectionCard> = ({
-  nrics,
-  addNric,
+  ids,
+  addId,
   isLoading,
   checkoutCart,
   onCancel,
@@ -36,8 +36,8 @@ export const ItemsSelectionCard: FunctionComponent<ItemsSelectionCard> = ({
   return (
     <View>
       <CustomerCard
-        nrics={nrics}
-        onAddNric={
+        ids={ids}
+        onAddId={
           getFeatures()?.TRANSACTION_GROUPING
             ? () => setIsAddUserModalVisible(true)
             : undefined
@@ -96,8 +96,8 @@ export const ItemsSelectionCard: FunctionComponent<ItemsSelectionCard> = ({
       <AddUserModal
         isVisible={isAddUserModalVisible}
         setIsVisible={setIsAddUserModalVisible}
-        nrics={nrics}
-        addNric={addNric}
+        ids={ids}
+        addId={addId}
       />
     </View>
   );

--- a/src/components/CustomerQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuotaCard.tsx
@@ -85,7 +85,7 @@ const NoPreviousTransactionTitle: FunctionComponent = () => (
 );
 
 interface NoQuotaCard {
-  nrics: string[];
+  ids: string[];
   cart: Cart;
   onCancel: () => void;
 }
@@ -96,7 +96,7 @@ interface NoQuotaCard {
  * Precondition: Only rendered when all items in cart have max quantity of 0
  */
 export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
-  nrics,
+  ids,
   cart,
   onCancel
 }) => {
@@ -131,7 +131,7 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
 
   return (
     <View>
-      <CustomerCard nrics={nrics} headerBackgroundColor={color("red", 60)}>
+      <CustomerCard ids={ids} headerBackgroundColor={color("red", 60)}>
         <View
           style={[
             sharedStyles.resultWrapper,

--- a/src/components/CustomerQuota/NotEligibleCard.tsx
+++ b/src/components/CustomerQuota/NotEligibleCard.tsx
@@ -17,7 +17,7 @@ const NotEligibleTransactionDescription: FunctionComponent = () => (
 );
 
 interface NotEligibleCard {
-  nrics: string[];
+  ids: string[];
   onCancel: () => void;
 }
 
@@ -25,12 +25,12 @@ interface NotEligibleCard {
  * Shows when the user cannot is not eligible for redemption/purchase
  */
 export const NotEligibleCard: FunctionComponent<NotEligibleCard> = ({
-  nrics,
+  ids,
   onCancel
 }) => {
   return (
     <View>
-      <CustomerCard nrics={nrics} headerBackgroundColor={color("red", 60)}>
+      <CustomerCard ids={ids} headerBackgroundColor={color("red", 60)}>
         <View
           style={[
             sharedStyles.resultWrapper,

--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -91,9 +91,10 @@ const defaultProducts: EnvVersion = {
     REQUIRE_OTP: true,
     TRANSACTION_GROUPING: true,
     FLOW_TYPE: "DEFAULT",
-    SCANNER: {
-      TYPE: "CODE39",
-      VALIDATION: "NRIC"
+    id: {
+      type: "STRING",
+      scannerType: "CODE_39",
+      validation: "NRIC"
     }
   }
 };

--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -90,7 +90,11 @@ const defaultProducts: EnvVersion = {
   features: {
     REQUIRE_OTP: true,
     TRANSACTION_GROUPING: true,
-    FLOW_TYPE: "DEFAULT"
+    FLOW_TYPE: "DEFAULT",
+    SCANNER: {
+      TYPE: "CODE39",
+      VALIDATION: "NRIC"
+    }
   }
 };
 

--- a/src/services/envVersion/envVersion.test.tsx
+++ b/src/services/envVersion/envVersion.test.tsx
@@ -44,9 +44,10 @@ const mockGetEnvVersionValidResponse = {
     REQUIRE_OTP: true,
     TRANSACTION_GROUPING: true,
     FLOW_TYPE: "DEFAULT",
-    SCANNER: {
-      TYPE: "CODE39",
-      VALIDATION: "NRIC"
+    id: {
+      type: "STRING",
+      scannerType: "CODE_39",
+      validation: "NRIC"
     }
   }
 };
@@ -85,9 +86,10 @@ const mockGetEnvVersionInvalidResponse = {
     REQUIRE_OTP: true,
     TRANSACTION_GROUPING: true,
     FLOW_TYPE: "DEFAULT",
-    SCANNER: {
-      TYPE: "CODE39",
-      VALIDATION: "NRIC"
+    id: {
+      type: "STRING",
+      scannerType: "CODE_39",
+      validation: "NRIC"
     }
   }
 };

--- a/src/services/envVersion/envVersion.test.tsx
+++ b/src/services/envVersion/envVersion.test.tsx
@@ -43,7 +43,11 @@ const mockGetEnvVersionValidResponse = {
   features: {
     REQUIRE_OTP: true,
     TRANSACTION_GROUPING: true,
-    FLOW_TYPE: "DEFAULT"
+    FLOW_TYPE: "DEFAULT",
+    SCANNER: {
+      TYPE: "CODE39",
+      VALIDATION: "NRIC"
+    }
   }
 };
 

--- a/src/services/envVersion/envVersion.test.tsx
+++ b/src/services/envVersion/envVersion.test.tsx
@@ -80,7 +80,11 @@ const mockGetEnvVersionInvalidResponse = {
   features: {
     REQUIRE_OTP: true,
     TRANSACTION_GROUPING: true,
-    FLOW_TYPE: "DEFAULT"
+    FLOW_TYPE: "DEFAULT",
+    SCANNER: {
+      TYPE: "CODE39",
+      VALIDATION: "NRIC"
+    }
   }
 };
 

--- a/src/services/envVersion/index.ts
+++ b/src/services/envVersion/index.ts
@@ -136,7 +136,11 @@ const mockGetEnvVersion = async (
     features: {
       REQUIRE_OTP: true,
       TRANSACTION_GROUPING: true,
-      FLOW_TYPE: "DEFAULT"
+      FLOW_TYPE: "DEFAULT",
+      SCANNER: {
+        TYPE: "CODE39",
+        VALIDATION: "NRIC"
+      }
     }
   };
 };

--- a/src/services/envVersion/index.ts
+++ b/src/services/envVersion/index.ts
@@ -137,9 +137,10 @@ const mockGetEnvVersion = async (
       REQUIRE_OTP: true,
       TRANSACTION_GROUPING: true,
       FLOW_TYPE: "DEFAULT",
-      SCANNER: {
-        TYPE: "CODE39",
-        VALIDATION: "NRIC"
+      id: {
+        type: "STRING",
+        scannerType: "CODE_39",
+        validation: "NRIC"
       }
     }
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,10 +93,21 @@ const Policy = t.intersection([
   })
 ]);
 
+const ScannerFeatureFlag = t.intersection([
+  t.type({
+    TYPE: t.string
+  }),
+  t.partial({
+    VALIDATION: t.string,
+    VALIDATION_REGEX: t.string
+  })
+]);
+
 const Features = t.type({
   REQUIRE_OTP: t.boolean,
   TRANSACTION_GROUPING: t.boolean,
-  FLOW_TYPE: t.string
+  FLOW_TYPE: t.string,
+  SCANNER: ScannerFeatureFlag
 });
 
 export const EnvVersion = t.type({

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,9 +95,9 @@ const Policy = t.intersection([
 
 const IdentificationFlag = t.intersection([
   t.type({
-    type: t.string,
-    scannerType: t.string,
-    validation: t.string
+    type: t.union([t.literal("STRING"), t.literal("NUMBER")]),
+    scannerType: t.union([t.literal("CODE_39"), t.literal("QR")]),
+    validation: t.union([t.literal("NRIC"), t.literal("REGEX")])
   }),
   t.partial({
     validationRegex: t.string

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,13 +93,14 @@ const Policy = t.intersection([
   })
 ]);
 
-const ScannerFeatureFlag = t.intersection([
+const IdentificationFlag = t.intersection([
   t.type({
-    TYPE: t.string
+    type: t.string,
+    scannerType: t.string,
+    validation: t.string
   }),
   t.partial({
-    VALIDATION: t.string,
-    VALIDATION_REGEX: t.string
+    validationRegex: t.string
   })
 ]);
 
@@ -107,7 +108,7 @@ const Features = t.type({
   REQUIRE_OTP: t.boolean,
   TRANSACTION_GROUPING: t.boolean,
   FLOW_TYPE: t.string,
-  SCANNER: ScannerFeatureFlag
+  id: IdentificationFlag
 });
 
 export const EnvVersion = t.type({

--- a/src/utils/validateIdentification.test.ts
+++ b/src/utils/validateIdentification.test.ts
@@ -1,6 +1,23 @@
 import { validateAndCleanId } from "./validateIdentification";
 import { EnvVersionError } from "../services/envVersion";
 
+describe("validate and clean IDs", () => {
+  it("should return cleaned NRIC if variables are valid", () => {
+    expect.assertions(1);
+    const idNRICValidation = "NRIC";
+    expect(validateAndCleanId("s0000001i", idNRICValidation)).toBe("S0000001I");
+  });
+
+  it("should return cleaned alphanumeric ID if variables are valid", () => {
+    expect.assertions(1);
+    const idRegexValidation = "REGEX";
+    const alphanumericRegex = "^[a-zA-Z0-9-_ ]+$";
+    expect(
+      validateAndCleanId("abcd_1234", idRegexValidation, alphanumericRegex)
+    ).toBe("ABCD_1234");
+  });
+});
+
 describe("throw EnvVersionError", () => {
   it("should throw EnvVersionError if validation is REGEX but validationRegex is missing", () => {
     expect.assertions(1);

--- a/src/utils/validateIdentification.test.ts
+++ b/src/utils/validateIdentification.test.ts
@@ -16,14 +16,21 @@ describe("validate and clean IDs", () => {
       validateAndCleanId("abcd_1234", idRegexValidation, alphanumericRegex)
     ).toBe("ABCD_1234");
   });
-
-  it("should return existing input as ID if validation is missing", () => {
-    expect.assertions(1);
-    expect(validateAndCleanId("abcd_1234")).toBe("abcd_1234");
-  });
 });
 
 describe("throw EnvVersionError", () => {
+  it("should throw EnvVersionError if idValidation is missing or undefined", () => {
+    expect.assertions(1);
+    const undefinedIdValidation = undefined;
+    expect(() =>
+      validateAndCleanId("100000001", undefinedIdValidation)
+    ).toThrow(
+      new EnvVersionError(
+        "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+      )
+    );
+  });
+
   it("should throw EnvVersionError if validation is REGEX but validationRegex is missing", () => {
     expect.assertions(1);
     const idRegexValidation = "REGEX";

--- a/src/utils/validateIdentification.test.ts
+++ b/src/utils/validateIdentification.test.ts
@@ -3,9 +3,9 @@ import { EnvVersionError } from "../services/envVersion";
 
 describe("throw EnvVersionError", () => {
   it("should throw EnvVersionError if validation is REGEX but validationRegex is missing", () => {
+    expect.assertions(1);
     const idRegexValidation = "REGEX";
     const undefinedRegex = undefined;
-    expect.assertions(1);
     expect(() =>
       validateAndCleanId("100000001", idRegexValidation, undefinedRegex)
     ).toThrow(
@@ -16,9 +16,9 @@ describe("throw EnvVersionError", () => {
   });
 
   it("should throw EnvVersionError if validation is NRIC, but validationRegex exists", () => {
+    expect.assertions(1);
     const idNRICValidation = "NRIC";
     const validRegex = "^[a-zA-Z0-9-_ ]+$";
-    expect.assertions(1);
     expect(() =>
       validateAndCleanId("100000001", idNRICValidation, validRegex)
     ).toThrow(

--- a/src/utils/validateIdentification.test.ts
+++ b/src/utils/validateIdentification.test.ts
@@ -16,6 +16,11 @@ describe("validate and clean IDs", () => {
       validateAndCleanId("abcd_1234", idRegexValidation, alphanumericRegex)
     ).toBe("ABCD_1234");
   });
+
+  it("should return existing input as ID if validation is missing", () => {
+    expect.assertions(1);
+    expect(validateAndCleanId("abcd_1234")).toBe("abcd_1234");
+  });
 });
 
 describe("throw EnvVersionError", () => {

--- a/src/utils/validateIdentification.test.ts
+++ b/src/utils/validateIdentification.test.ts
@@ -1,0 +1,30 @@
+import { validateAndCleanId } from "./validateIdentification";
+import { EnvVersionError } from "../services/envVersion";
+
+describe("throw EnvVersionError", () => {
+  it("should throw EnvVersionError if validation is REGEX but validationRegex is missing", () => {
+    const idRegexValidation = "REGEX";
+    const undefinedRegex = undefined;
+    expect.assertions(1);
+    expect(() =>
+      validateAndCleanId("100000001", idRegexValidation, undefinedRegex)
+    ).toThrow(
+      new EnvVersionError(
+        "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+      )
+    );
+  });
+
+  it("should throw EnvVersionError if validation is NRIC, but validationRegex exists", () => {
+    const idNRICValidation = "NRIC";
+    const validRegex = "^[a-zA-Z0-9-_ ]+$";
+    expect.assertions(1);
+    expect(() =>
+      validateAndCleanId("100000001", idNRICValidation, validRegex)
+    ).toThrow(
+      new EnvVersionError(
+        "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+      )
+    );
+  });
+});

--- a/src/utils/validateIdentification.ts
+++ b/src/utils/validateIdentification.ts
@@ -5,7 +5,7 @@ import { EnvVersionError } from "../services/envVersion";
 export const validateAndCleanId = (
   inputId: string,
   idValidation: string | undefined,
-  idRegex: string | undefined
+  idRegex?: string | undefined
 ): string => {
   let id: string;
   switch (idValidation) {

--- a/src/utils/validateIdentification.ts
+++ b/src/utils/validateIdentification.ts
@@ -4,10 +4,14 @@ import { EnvVersionError } from "../services/envVersion";
 
 export const validateAndCleanId = (
   inputId: string,
-  idValidation?: string | undefined,
+  idValidation: string | undefined,
   idRegex?: string | undefined
 ): string => {
   let id: string;
+  if (!idValidation)
+    throw new EnvVersionError(
+      "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+    );
   switch (idValidation) {
     case "NRIC":
       if (idRegex)

--- a/src/utils/validateIdentification.ts
+++ b/src/utils/validateIdentification.ts
@@ -4,7 +4,7 @@ import { EnvVersionError } from "../services/envVersion";
 
 export const validateAndCleanId = (
   inputId: string,
-  idValidation: string | undefined,
+  idValidation?: string | undefined,
   idRegex?: string | undefined
 ): string => {
   let id: string;

--- a/src/utils/validateIdentification.ts
+++ b/src/utils/validateIdentification.ts
@@ -1,0 +1,27 @@
+import { validateAndCleanNric } from "./validateNric";
+import { validateAndCleanRegexInput } from "./validateInputWithRegex";
+import { EnvVersionError } from "../services/envVersion";
+
+export const validateAndCleanId = (
+  inputId: string,
+  idValidation: string | undefined,
+  idRegex: string | undefined
+): string => {
+  let id: string;
+  switch (idValidation) {
+    case "NRIC":
+      if (idRegex)
+        throw new EnvVersionError(
+          "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+        );
+      id = validateAndCleanNric(inputId);
+      break;
+    case "REGEX":
+      id = validateAndCleanRegexInput(inputId, idRegex);
+      break;
+    default:
+      // Remove validation
+      id = inputId;
+  }
+  return id;
+};

--- a/src/utils/validateInputWithRegex.test.tsx
+++ b/src/utils/validateInputWithRegex.test.tsx
@@ -1,4 +1,4 @@
-import { validate, validateAndCleanId } from "./validateInputWithRegex";
+import { validate, validateAndCleanRegexInput } from "./validateInputWithRegex";
 import { EnvVersionError } from "../services/envVersion";
 
 describe("validate", () => {
@@ -21,7 +21,9 @@ describe("throw EnvVersionError", () => {
   const undefinedRegex = undefined;
   it("should throw EnvVersionError if validationRegex is missing", () => {
     expect.assertions(1);
-    expect(() => validateAndCleanId("100000001", undefinedRegex)).toThrow(
+    expect(() =>
+      validateAndCleanRegexInput("100000001", undefinedRegex)
+    ).toThrow(
       new EnvVersionError(
         "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
       )

--- a/src/utils/validateInputWithRegex.test.tsx
+++ b/src/utils/validateInputWithRegex.test.tsx
@@ -1,10 +1,5 @@
 import { validate, validateAndCleanId } from "./validateInputWithRegex";
 import { EnvVersionError } from "../services/envVersion";
-import * as Sentry from "sentry-expo";
-
-jest.mock("sentry-expo");
-const mockCaptureException = jest.fn();
-(Sentry.captureException as jest.Mock).mockImplementation(mockCaptureException);
 
 describe("validate", () => {
   const alphanumericRegex = "^[a-zA-Z0-9-_ ]+$";

--- a/src/utils/validateInputWithRegex.test.tsx
+++ b/src/utils/validateInputWithRegex.test.tsx
@@ -1,0 +1,35 @@
+import { validate, validateAndCleanId } from "./validateInputWithRegex";
+import { EnvVersionError } from "../services/envVersion";
+import * as Sentry from "sentry-expo";
+
+jest.mock("sentry-expo");
+const mockCaptureException = jest.fn();
+(Sentry.captureException as jest.Mock).mockImplementation(mockCaptureException);
+
+describe("validate", () => {
+  const alphanumericRegex = "^[a-zA-Z0-9-_ ]+$";
+  it("should return true for alphanumeric regex", () => {
+    expect.assertions(2);
+    expect(validate("100000001", alphanumericRegex)).toBe(true);
+    expect(validate("202006171", alphanumericRegex)).toBe(true);
+  });
+
+  it("should return false for invalid alphanumeric regex", () => {
+    expect.assertions(3);
+    expect(validate("", alphanumericRegex)).toBe(false);
+    expect(validate("123123/", alphanumericRegex)).toBe(false);
+    expect(validate("abc/", alphanumericRegex)).toBe(false);
+  });
+});
+
+describe("throw EnvVersionError", () => {
+  const undefinedRegex = undefined;
+  it("should throw EnvVersionError if validationRegex is missing", () => {
+    expect.assertions(1);
+    expect(() => validateAndCleanId("100000001", undefinedRegex)).toThrow(
+      new EnvVersionError(
+        "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+      )
+    );
+  });
+});

--- a/src/utils/validateInputWithRegex.test.tsx
+++ b/src/utils/validateInputWithRegex.test.tsx
@@ -4,16 +4,18 @@ import { EnvVersionError } from "../services/envVersion";
 describe("validate", () => {
   const alphanumericRegex = "^[a-zA-Z0-9-_ ]+$";
   it("should return true for alphanumeric regex", () => {
-    expect.assertions(2);
+    expect.assertions(4);
     expect(validate("100000001", alphanumericRegex)).toBe(true);
-    expect(validate("202006171", alphanumericRegex)).toBe(true);
+    expect(validate("1234-ABCD", alphanumericRegex)).toBe(true);
+    expect(validate("ABCD_1234", alphanumericRegex)).toBe(true);
+    expect(validate("ABCD 1234", alphanumericRegex)).toBe(true);
   });
 
   it("should return false for invalid alphanumeric regex", () => {
     expect.assertions(3);
     expect(validate("", alphanumericRegex)).toBe(false);
-    expect(validate("123123/", alphanumericRegex)).toBe(false);
-    expect(validate("abc/", alphanumericRegex)).toBe(false);
+    expect(validate("123abc/", alphanumericRegex)).toBe(false);
+    expect(validate("123abc!", alphanumericRegex)).toBe(false);
   });
 });
 

--- a/src/utils/validateInputWithRegex.ts
+++ b/src/utils/validateInputWithRegex.ts
@@ -14,13 +14,9 @@ export const validateAndCleanRegexInput = (
     );
   const isValid = validate(inputId, idRegex);
   if (!isValid)
-    throw new Error(
-      "Please check that the identification is in the correct format"
-    );
+    throw new Error("Please check that the ID is in the correct format");
   const cleanedId = inputId.match(idRegex)?.[0].toUpperCase();
   if (!cleanedId)
-    throw new Error(
-      "Please check that the identification is in the correct format"
-    );
+    throw new Error("Please check that the ID is in the correct format");
   return cleanedId;
 };

--- a/src/utils/validateInputWithRegex.ts
+++ b/src/utils/validateInputWithRegex.ts
@@ -8,7 +8,6 @@ export const validateAndCleanId = (
   inputId: string,
   idRegex: string | undefined
 ): string => {
-  console.log("regex:", idRegex);
   if (!idRegex)
     throw new EnvVersionError(
       "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"

--- a/src/utils/validateInputWithRegex.ts
+++ b/src/utils/validateInputWithRegex.ts
@@ -1,0 +1,27 @@
+import { EnvVersionError } from "../services/envVersion";
+
+export const validate = (id: string, idRegex: string): boolean => {
+  return id.match(idRegex) !== null;
+};
+
+export const validateAndCleanId = (
+  inputId: string,
+  idRegex: string | undefined
+): string => {
+  console.log("regex:", idRegex);
+  if (!idRegex)
+    throw new EnvVersionError(
+      "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+    );
+  const isValid = validate(inputId, idRegex);
+  if (!isValid)
+    throw new Error(
+      "Please check that the identification is in the correct format"
+    );
+  const cleanedId = inputId.match(idRegex)?.[0].toUpperCase();
+  if (!cleanedId)
+    throw new Error(
+      "Please check that the identification is in the correct format"
+    );
+  return cleanedId;
+};

--- a/src/utils/validateInputWithRegex.ts
+++ b/src/utils/validateInputWithRegex.ts
@@ -4,7 +4,7 @@ export const validate = (id: string, idRegex: string): boolean => {
   return id.match(idRegex) !== null;
 };
 
-export const validateAndCleanId = (
+export const validateAndCleanRegexInput = (
   inputId: string,
   idRegex: string | undefined
 ): string => {

--- a/storybook/stories/CustomerQuota/CheckoutSuccessCard.tsx
+++ b/storybook/stories/CustomerQuota/CheckoutSuccessCard.tsx
@@ -90,7 +90,7 @@ storiesOf("CustomerQuota", module).add("PurchaseSuccessCard", () => (
   >
     <View style={{ margin: size(3) }}>
       <CheckoutSuccessCard
-        nrics={["S0000001I", "S0000002G"]}
+        ids={["S0000001I", "S0000002G"]}
         onCancel={() => null}
         checkoutResult={checkoutResult}
       />


### PR DESCRIPTION
[notion](https://www.notion.so/Feature-Identification-scanning-Using-feature-flag-to-toggle-id-scanning-type-448e2acc9bb644dd9dbbaf38923d8960)

Proposed Solution:
Adding a new feature flag for scanner, toggling the type and validation
```
id: {
  type: "STRING" || "NUMBER"
  scannerType: "CODE_39" || "QR"
  validation: "NRIC" || "REGEX"
  validationRegex?: <regex for voucher and QR>
}
```

- [x] add new scanner feature flag
- [x] use new flag for validation 
- [x] add regex validation option
- [x] refactor components and variables that use the term `NRIC` and replace with `id` to cater for future distributions using different identification