### PR TITLE
fix: bug fix for nric validation

### DIFF
--- a/src/utils/validateNric.test.tsx
+++ b/src/utils/validateNric.test.tsx
@@ -11,8 +11,10 @@ describe("validate", () => {
   });
 
   it("should return false for invalid NRIC", () => {
-    expect.assertions(5);
+    expect.assertions(7);
     expect(validate("S0000001A")).toBe(false);
+    expect(validate("123AS0000001A")).toBe(false);
+    expect(validate("S0000001A123A")).toBe(false);
     expect(validate("S0000002B")).toBe(false);
     expect(validate("S0000003C")).toBe(false);
     expect(validate("S0000004D")).toBe(false);

--- a/src/utils/validateNric.tsx
+++ b/src/utils/validateNric.tsx
@@ -1,6 +1,6 @@
 // Thanks to https://gist.github.com/kyrene-chew/6f275325335ab27895beb7a9a7b4c1cb
 
-export const nricRegex = /(\D)(\d{7})(\D)/;
+export const nricRegex = /(\D)(\d{7})(\D)$/;
 
 export const validate = (nricInput: string): boolean => {
   // validation rules

--- a/src/utils/validateNric.tsx
+++ b/src/utils/validateNric.tsx
@@ -1,6 +1,6 @@
 // Thanks to https://gist.github.com/kyrene-chew/6f275325335ab27895beb7a9a7b4c1cb
 
-export const nricRegex = /(\D)(\d{7})(\D)$/;
+export const nricRegex = /^(\D)(\d{7})(\D)$/;
 
 export const validate = (nricInput: string): boolean => {
   // validation rules


### PR DESCRIPTION
This PR contains a frontend fix for the NRIC regex. Previously was accepting NRIC with more than 9 digits.
<img width="1157" alt="Screenshot 2020-07-23 at 11 49 08 AM" src="https://user-images.githubusercontent.com/38589870/88250805-407c1800-ccdb-11ea-8bcd-674db48cf2d5.png">
<img width="1157" alt="Screenshot 2020-07-23 at 11 49 03 AM" src="https://user-images.githubusercontent.com/38589870/88250809-43770880-ccdb-11ea-9fc1-64498736cfd7.png">

