### PR TITLE
feat: add ability to force check updates

### DIFF
--- a/src/hooks/useCheckUpdates.tsx
+++ b/src/hooks/useCheckUpdates.tsx
@@ -15,7 +15,7 @@ type CheckUpdatesResult =
   | "UPDATE_ERROR";
 
 export const useCheckUpdates = (): ((
-  forceCheck: boolean
+  forceCheck?: boolean
 ) => Promise<CheckUpdatesResult>) => {
   const setMessageContent = useContext(ImportantMessageSetterContext);
 

--- a/src/hooks/useCheckUpdates.tsx
+++ b/src/hooks/useCheckUpdates.tsx
@@ -6,7 +6,7 @@ import { useContext, useCallback } from "react";
 import { ImportantMessageSetterContext } from "../context/importantMessage";
 
 const LAST_UPDATE_KEY = "LAST_UPDATE";
-const CHECK_UPDATE_INTERVAL_MINUTES = 60;
+const CHECK_UPDATE_INTERVAL_MINUTES = 30;
 
 type CheckUpdatesResult =
   | "TOO_RECENT_CHECK"

--- a/src/hooks/useCheckUpdates.tsx
+++ b/src/hooks/useCheckUpdates.tsx
@@ -8,53 +8,72 @@ import { ImportantMessageSetterContext } from "../context/importantMessage";
 const LAST_UPDATE_KEY = "LAST_UPDATE";
 const CHECK_UPDATE_INTERVAL_MINUTES = 60;
 
-export const useCheckUpdates = (): (() => void) => {
+type CheckUpdatesResult =
+  | "TOO_RECENT_CHECK"
+  | "NO_UPDATE"
+  | "UPDATE_READY"
+  | "UPDATE_ERROR";
+
+export const useCheckUpdates = (): ((
+  forceCheck: boolean
+) => Promise<CheckUpdatesResult>) => {
   const setMessageContent = useContext(ImportantMessageSetterContext);
 
-  const checkForUpdates = useCallback(async () => {
-    if (__DEV__) {
-      return;
-    }
-    try {
-      const lastUpdate = await AsyncStorage.getItem(LAST_UPDATE_KEY);
-      if (
-        !lastUpdate ||
-        differenceInMinutes(new Date(), Number(lastUpdate)) >
-          CHECK_UPDATE_INTERVAL_MINUTES
-      ) {
-        const update = await Updates.checkForUpdateAsync();
-        if (update.isAvailable) {
-          await Promise.all([
-            AsyncStorage.setItem(LAST_UPDATE_KEY, `${new Date().getTime()}`),
-            Updates.fetchUpdateAsync()
-          ]);
-
-          // Update message only if there's no other important message
-          // i.e. token expiry is of higher priority
-          setMessageContent(msg =>
-            msg
-              ? msg
-              : {
-                  title: "Update available",
-                  description:
-                    "Simply tap on update to apply the latest updates!",
-                  action: {
-                    label: "Update",
-                    callback: () => Updates.reloadFromCache()
-                  },
-                  featherIconName: "gift"
-                }
-          );
-        }
+  const checkForUpdates = useCallback(
+    async (forceCheck = false) => {
+      if (__DEV__) {
+        await new Promise(res => setTimeout(res, 2000));
+        return "NO_UPDATE";
       }
-    } catch (e) {
-      Sentry.addBreadcrumb({
-        category: "action",
-        message: "Check for updates"
-      });
-      Sentry.captureException(e);
-    }
-  }, [setMessageContent]);
+      try {
+        const lastUpdate = await AsyncStorage.getItem(LAST_UPDATE_KEY);
+        if (
+          forceCheck ||
+          !lastUpdate ||
+          differenceInMinutes(new Date(), Number(lastUpdate)) >
+            CHECK_UPDATE_INTERVAL_MINUTES
+        ) {
+          const update = await Updates.checkForUpdateAsync();
+          if (update.isAvailable) {
+            await Promise.all([
+              AsyncStorage.setItem(LAST_UPDATE_KEY, `${new Date().getTime()}`),
+              Updates.fetchUpdateAsync()
+            ]);
+
+            // Update message only if there's no other important message
+            // i.e. token expiry is of higher priority
+            setMessageContent(msg =>
+              msg
+                ? msg
+                : {
+                    title: "Update available",
+                    description:
+                      "Simply tap on update to apply the latest updates!",
+                    action: {
+                      label: "Update",
+                      callback: () => Updates.reloadFromCache()
+                    },
+                    featherIconName: "gift"
+                  }
+            );
+            return "UPDATE_READY";
+          } else {
+            return "NO_UPDATE";
+          }
+        } else {
+          return "TOO_RECENT_CHECK";
+        }
+      } catch (e) {
+        Sentry.addBreadcrumb({
+          category: "action",
+          message: "Check for updates"
+        });
+        Sentry.captureException(e);
+        return "UPDATE_ERROR";
+      }
+    },
+    [setMessageContent]
+  );
 
   return checkForUpdates;
 };


### PR DESCRIPTION
Right now updates can only be checked every 60 minutes, there are situations where we will want to perform checks that are not constrained by this rule.

This PR also adds a return type so consumers can know the outcome of the check.