### PR TITLE
feat: campaign config service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7528,6 +7528,11 @@
         "uuid": "^3.3.2"
       }
     },
+    "expo-crypto": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-7.0.0.tgz",
+      "integrity": "sha512-VBpzez6HCVqLtyPkaXRlZpGbWU+V1LPnv2XmPSJ25SQ5G+KGddIWmCGKscDOst+R8zUAXq7DBo+CLC0ZYmBdAw=="
+    },
     "expo-device": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-2.2.1.tgz",
@@ -15416,9 +15421,9 @@
       "dev": true
     },
     "react-native-webview": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-9.4.0.tgz",
-      "integrity": "sha512-BBOFUuza0p04+7fNi7TJmB0arpDJzGxHYwTCgI4vj5n/fl7u4jbm7ETp88mf7lo9lP6C6HGLo38KnEy1aXCQkg==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-10.3.2.tgz",
+      "integrity": "sha512-4A8FKL/puonkqQ1FOKd+iPulqRXCG4inmIK4pQ60zv9Ua+YkBKLxxofQiCvRwIXSSgAXYT+AE3rOHr3bx4A/cw==",
       "requires": {
         "escape-string-regexp": "2.0.0",
         "invariant": "2.2.4"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-navigation": "^4.1.0",
     "react-navigation-drawer": "^2.5.0",
     "react-navigation-stack": "^1.10.3",
-    "sentry-expo": "^2.0.3"
+    "sentry-expo": "^2.0.3",
+    "expo-crypto": "~7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/src/context/campaignConfig.tsx
+++ b/src/context/campaignConfig.tsx
@@ -1,0 +1,67 @@
+import React, {
+  createContext,
+  FunctionComponent,
+  useState,
+  useEffect,
+  useCallback
+} from "react";
+import { AsyncStorage } from "react-native";
+import { CampaignFeatures, CampaignConfig } from "../types";
+
+export const FEATURES_KEY = "FEATURES";
+
+interface CampaignConfigContext {
+  features: CampaignFeatures | null;
+  setCampaignConfig: (config: CampaignConfig) => void;
+  clearCampaignConfig: () => void;
+}
+export const CampaignConfigContext = createContext<CampaignConfigContext>({
+  features: null,
+  setCampaignConfig: () => null,
+  clearCampaignConfig: () => null
+});
+
+export const CampaignConfigContextProvider: FunctionComponent = ({
+  children
+}) => {
+  const [features, setFeatures] = useState<CampaignConfigContext["features"]>(
+    null
+  );
+
+  const setCampaignConfig: CampaignConfigContext["setCampaignConfig"] = useCallback(
+    async ({ features }): Promise<void> => {
+      setFeatures(features);
+      await AsyncStorage.multiSet([[FEATURES_KEY, JSON.stringify(features)]]);
+    },
+    []
+  );
+
+  const clearCampaignConfig: CampaignConfigContext["clearCampaignConfig"] = useCallback(async (): Promise<
+    void
+  > => {
+    setFeatures(null);
+    await AsyncStorage.multiRemove([FEATURES_KEY]);
+  }, []);
+
+  const loadCampaignConfigFromStore = async (): Promise<void> => {
+    const values = await AsyncStorage.multiGet([FEATURES_KEY]);
+    const [features] = values.map(value => value[1]);
+    setFeatures(JSON.parse(features));
+  };
+
+  useEffect(() => {
+    loadCampaignConfigFromStore();
+  }, []);
+
+  return (
+    <CampaignConfigContext.Provider
+      value={{
+        features,
+        setCampaignConfig,
+        clearCampaignConfig
+      }}
+    >
+      {children}
+    </CampaignConfigContext.Provider>
+  );
+};

--- a/src/context/campaignConfig.tsx
+++ b/src/context/campaignConfig.tsx
@@ -38,13 +38,15 @@ export const CampaignConfigContextProvider: FunctionComponent = ({
 
   const setCampaignConfig: CampaignConfigContext["setCampaignConfig"] = useCallback(
     async ({ features }): Promise<void> => {
-      const featuresString = JSON.stringify(features);
-      const configHashes = {
-        features: await hashString(featuresString)
-      };
-      await AsyncStorage.multiSet([[FEATURES_KEY, featuresString]]);
-      setFeatures(features);
-      setConfigHashes(configHashes);
+      if (features) {
+        const featuresString = JSON.stringify(features);
+        const configHashes = {
+          features: await hashString(featuresString)
+        };
+        await AsyncStorage.multiSet([[FEATURES_KEY, featuresString]]);
+        setFeatures(features);
+        setConfigHashes(configHashes);
+      }
     },
     []
   );

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -9,6 +9,7 @@ import { ImportantMessageContextProvider } from "../context/importantMessage";
 import { Content } from "./Content";
 import { Providers } from "../context/composeProviders";
 import { DrawerContextProvider } from "../context/drawer";
+import { CampaignConfigContextProvider } from "../context/campaignConfig";
 
 const App = (): ReactElement => {
   return (
@@ -17,6 +18,7 @@ const App = (): ReactElement => {
         <Providers
           providers={[
             ConfigContextProvider,
+            CampaignConfigContextProvider,
             ProductContextProvider,
             AuthenticationContextProvider,
             HelpModalContextProvider,

--- a/src/services/campaignConfig/campaignConfig.test.ts
+++ b/src/services/campaignConfig/campaignConfig.test.ts
@@ -11,8 +11,8 @@ jest.spyOn(global, "fetch").mockImplementation(mockFetch);
 
 const mockValidResponse = {
   features: {
+    minAppBinaryVersion: "3.0.0",
     minAppBuildVersion: 0,
-    minAppBundleVersion: "3.0.0",
     flowType: "DEFAULT",
     transactionGrouping: true
   }
@@ -20,12 +20,16 @@ const mockValidResponse = {
 
 const mockValidResponseNewFeature = {
   features: {
+    minAppBinaryVersion: "3.0.0",
     minAppBuildVersion: 10,
-    minAppBundleVersion: "3.0.0",
     flowType: "DEFAULT",
     transactionGrouping: true,
     newFeature: true
   }
+};
+
+const mockValidResponseNoUpdates = {
+  features: null
 };
 
 const mockInvalidResponseIncorrectType = {
@@ -69,18 +73,15 @@ describe("campaignConfig", () => {
 
     it("should return null campaign configs when the current ones are the latest", async () => {
       expect.assertions(1);
-      const returnValue = {
-        features: null
-      };
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(returnValue)
+        json: () => Promise.resolve(mockValidResponseNoUpdates)
       });
 
       const config = await getCampaignConfig(key, endpoint, {
         features: "latest-hash"
       });
-      expect(config).toStrictEqual(returnValue);
+      expect(config).toStrictEqual(mockValidResponseNoUpdates);
     });
 
     it.each([mockInvalidResponseIncorrectType, mockInvalidResponseNewConfig])(

--- a/src/services/campaignConfig/campaignConfig.test.ts
+++ b/src/services/campaignConfig/campaignConfig.test.ts
@@ -1,0 +1,139 @@
+import { getCampaignConfig, CampaignConfigError } from "./campaignConfig";
+import * as Sentry from "sentry-expo";
+import { boolean } from "io-ts";
+
+jest.mock("sentry-expo");
+const mockCaptureException = jest.fn();
+(Sentry.captureException as jest.Mock).mockImplementation(mockCaptureException);
+
+const mockFetch = jest.fn();
+jest.spyOn(global, "fetch").mockImplementation(mockFetch);
+
+const mockValidResponse = {
+  features: {
+    minAppBuildVersion: 0,
+    minAppBundleVersion: "3.0.0",
+    flowType: "DEFAULT",
+    transactionGrouping: true
+  }
+};
+
+const mockValidResponseNewFeature = {
+  features: {
+    minAppBuildVersion: 10,
+    minAppBundleVersion: "3.0.0",
+    flowType: "DEFAULT",
+    transactionGrouping: true,
+    newFeature: true
+  }
+};
+
+const mockInvalidResponseIncorrectType = {
+  features: {
+    minAppBuildVersion: "10"
+  }
+};
+
+const mockInvalidResponseNewConfig = {
+  features: {
+    minAppBuildVersion: "10"
+  },
+  newConfig: {
+    newProperty: boolean
+  }
+};
+
+const key = "KEY";
+const endpoint = "https://myendpoint.com";
+
+describe("campaignConfig", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockCaptureException.mockReset();
+  });
+
+  describe("getCampaignConfig", () => {
+    it.each([mockValidResponse, mockValidResponseNewFeature])(
+      "should return the campaign config when it's valid",
+      async (response: any) => {
+        expect.assertions(1);
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(response)
+        });
+
+        const config = await getCampaignConfig(key, endpoint, {});
+        expect(config).toStrictEqual(response);
+      }
+    );
+
+    it("should return null campaign configs when the current ones are the latest", async () => {
+      expect.assertions(1);
+      const returnValue = {
+        features: null
+      };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(returnValue)
+      });
+
+      const config = await getCampaignConfig(key, endpoint, {
+        features: "latest-hash"
+      });
+      expect(config).toStrictEqual(returnValue);
+    });
+
+    it.each([mockInvalidResponseIncorrectType, mockInvalidResponseNewConfig])(
+      "should throw error if campaign config is malformed",
+      async (response: any) => {
+        expect.assertions(1);
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(response)
+        });
+
+        await expect(getCampaignConfig(key, endpoint, {})).rejects.toThrow(
+          CampaignConfigError
+        );
+      }
+    );
+
+    it.each([mockInvalidResponseIncorrectType, mockInvalidResponseNewConfig])(
+      "should capture exception through sentry if campaign config is malformed",
+      async (response: any) => {
+        expect.assertions(2);
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(response)
+        });
+
+        await expect(getCampaignConfig(key, endpoint, {})).rejects.toThrow(
+          CampaignConfigError
+        );
+        expect(mockCaptureException).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    it("should throw error if campaign config could not be retrieved", async () => {
+      expect.assertions(1);
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        json: () =>
+          Promise.resolve({ message: "Invalid authentication token provided" })
+      });
+
+      await expect(getCampaignConfig(key, endpoint, {})).rejects.toThrow(
+        CampaignConfigError
+      );
+    });
+
+    it("should throw error if there were issues fetching", async () => {
+      expect.assertions(1);
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+      await expect(getCampaignConfig(key, endpoint, {})).rejects.toThrow(
+        "Network error"
+      );
+    });
+  });
+});

--- a/src/services/campaignConfig/campaignConfig.ts
+++ b/src/services/campaignConfig/campaignConfig.ts
@@ -1,5 +1,5 @@
 import { IS_MOCK } from "../../config";
-import { CampaignConfig } from "../../types";
+import { CampaignConfig, ConfigHashes } from "../../types";
 import { fetchWithValidator, ValidationError } from "../helpers";
 import * as Sentry from "sentry-expo";
 
@@ -9,10 +9,6 @@ export class CampaignConfigError extends Error {
     this.name = "CampaignConfigError";
   }
 }
-
-type ConfigHashes = {
-  [config in keyof CampaignConfig]?: string;
-};
 
 const liveGetCampaignConfig = async (
   token: string,

--- a/src/services/campaignConfig/campaignConfig.ts
+++ b/src/services/campaignConfig/campaignConfig.ts
@@ -47,8 +47,8 @@ const mockGetCampaignConfig = async (
 ): Promise<CampaignConfig> => {
   return {
     features: {
+      minAppBinaryVersion: "3.0.0",
       minAppBuildVersion: 0,
-      minAppBundleVersion: "3.0.0",
       flowType: "DEFAULT",
       transactionGrouping: true
     }

--- a/src/services/campaignConfig/campaignConfig.ts
+++ b/src/services/campaignConfig/campaignConfig.ts
@@ -48,9 +48,7 @@ const mockGetCampaignConfig = async (
   return {
     features: {
       minAppBinaryVersion: "3.0.0",
-      minAppBuildVersion: 0,
-      flowType: "DEFAULT",
-      transactionGrouping: true
+      minAppBuildVersion: 0
     }
   };
 };

--- a/src/services/campaignConfig/campaignConfig.ts
+++ b/src/services/campaignConfig/campaignConfig.ts
@@ -1,0 +1,60 @@
+import { IS_MOCK } from "../../config";
+import { CampaignConfig } from "../../types";
+import { fetchWithValidator, ValidationError } from "../helpers";
+import * as Sentry from "sentry-expo";
+
+export class CampaignConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CampaignConfigError";
+  }
+}
+
+type ConfigHashes = {
+  [config in keyof CampaignConfig]?: string;
+};
+
+const liveGetCampaignConfig = async (
+  token: string,
+  endpoint: string,
+  configHashes: ConfigHashes
+): Promise<CampaignConfig> => {
+  try {
+    const response = await fetchWithValidator(
+      CampaignConfig,
+      `${endpoint}/client-config`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: token
+        },
+        body: JSON.stringify(configHashes)
+      }
+    );
+    return response;
+  } catch (e) {
+    if (e instanceof ValidationError) {
+      Sentry.captureException(e);
+    }
+    throw new CampaignConfigError(e.message);
+  }
+};
+
+const mockGetCampaignConfig = async (
+  _token: string,
+  _endpoint: string,
+  configHashes: ConfigHashes
+): Promise<CampaignConfig> => {
+  return {
+    features: {
+      minAppBuildVersion: 0,
+      minAppBundleVersion: "3.0.0",
+      flowType: "DEFAULT",
+      transactionGrouping: true
+    }
+  };
+};
+
+export const getCampaignConfig = IS_MOCK
+  ? mockGetCampaignConfig
+  : liveGetCampaignConfig;

--- a/src/services/campaignConfig/index.ts
+++ b/src/services/campaignConfig/index.ts
@@ -1,0 +1,1 @@
+export * from "./campaignConfig";

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,3 +175,7 @@ export const CampaignConfig = t.type({
 
 export type CampaignFeatures = t.TypeOf<typeof NewFeatures>;
 export type CampaignConfig = t.TypeOf<typeof CampaignConfig>;
+
+export type ConfigHashes = {
+  [config in keyof CampaignConfig]?: string;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,3 +163,16 @@ export type Voucher = {
   serial: string;
   denomination: number;
 };
+
+const NewFeatures = t.type({
+  minAppBuildVersion: t.number,
+  minAppBundleVersion: t.string,
+  flowType: t.string,
+  transactionGrouping: t.boolean
+});
+
+export const CampaignConfig = t.type({
+  features: t.union([NewFeatures, t.null])
+});
+
+export type CampaignConfig = t.TypeOf<typeof CampaignConfig>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,4 +173,5 @@ export const CampaignConfig = t.type({
   features: t.union([NewFeatures, t.null])
 });
 
+export type CampaignFeatures = t.TypeOf<typeof NewFeatures>;
 export type CampaignConfig = t.TypeOf<typeof CampaignConfig>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,9 +166,7 @@ export type Voucher = {
 
 const NewFeatures = t.type({
   minAppBinaryVersion: t.string,
-  minAppBuildVersion: t.number,
-  flowType: t.string,
-  transactionGrouping: t.boolean
+  minAppBuildVersion: t.number
 });
 
 export const CampaignConfig = t.type({

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,8 +165,8 @@ export type Voucher = {
 };
 
 const NewFeatures = t.type({
+  minAppBinaryVersion: t.string,
   minAppBuildVersion: t.number,
-  minAppBundleVersion: t.string,
   flowType: t.string,
   transactionGrouping: t.boolean
 });

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,4 @@
+import { digestStringAsync, CryptoDigestAlgorithm } from "expo-crypto";
+
+export const hashString = async (str: string): Promise<string> =>
+  await digestStringAsync(CryptoDigestAlgorithm.SHA256, str);


### PR DESCRIPTION
* Added a `campaignConfig` service that calls `${endpoint}/client-config` to retrieve the config.
* Added a `campaignConfig` context that allows consumers to retrieve the campaign config anywhere in the tree. This context exposes a `configHashes` that is updated every time a new configuration is saved and when it's loaded from async storage. This `configHashes` is used when calling the endpoint so that the endpoint does not need to return the same set of data if the client already has the most updated config