### PR TITLE
feat: update campaign config hook

### DIFF
--- a/src/hooks/useUpdateCampaignConfig/useUpdateCampaignConfig.test.tsx
+++ b/src/hooks/useUpdateCampaignConfig/useUpdateCampaignConfig.test.tsx
@@ -1,0 +1,217 @@
+import React, { FunctionComponent } from "react";
+import { renderHook } from "@testing-library/react-hooks";
+import { CampaignConfigContext } from "../../context/campaignConfig";
+import { ConfigHashes } from "../../types";
+import { useUpdateCampaignConfig } from "./useUpdateCampaignConfig";
+import { getCampaignConfig } from "../../services/campaignConfig";
+import { wait } from "@testing-library/react-native";
+
+jest.mock("../../services/campaignConfig");
+const mockGetCampaignConfig = getCampaignConfig as jest.Mock;
+
+const key = "KEY";
+const endpoint = "https://myendpoint.com";
+
+const setCampaignConfigSpy = jest.fn();
+const wrapper = (configHashes: ConfigHashes): FunctionComponent => ({
+  children
+}) => (
+  <CampaignConfigContext.Provider
+    value={{
+      features: null,
+      setCampaignConfig: setCampaignConfigSpy,
+      clearCampaignConfig: () => null,
+      configHashes
+    }}
+  >
+    {children}
+  </CampaignConfigContext.Provider>
+);
+
+describe("useUpdateCampaignConfig", () => {
+  beforeEach(() => {
+    setCampaignConfigSpy.mockClear();
+  });
+
+  it("should set fetchingState and result when there are updates to the campaign config", async () => {
+    expect.assertions(5);
+    mockGetCampaignConfig.mockResolvedValue({
+      features: {
+        minAppBinaryVersion: "3.0.0",
+        minAppBuildVersion: 0
+      }
+    });
+    const { result } = renderHook(
+      () => useUpdateCampaignConfig(key, endpoint),
+      {
+        wrapper: wrapper({})
+      }
+    );
+    expect(result.current.fetchingState).toBe("DEFAULT");
+
+    await wait(() => {
+      result.current.updateCampaignConfig();
+      expect(result.current.fetchingState).toBe("FETCHING_CONFIG");
+    });
+    expect(setCampaignConfigSpy).toHaveBeenCalledTimes(1);
+    expect(result.current.fetchingState).toBe("RESULT_RETURNED_NEW_UPDATES");
+    expect(result.current.result).toStrictEqual({
+      features: {
+        minAppBinaryVersion: "3.0.0",
+        minAppBuildVersion: 0
+      }
+    });
+  });
+
+  it("should set fetchingState and not set result when there are no updates to the campaign config", async () => {
+    expect.assertions(5);
+    mockGetCampaignConfig.mockResolvedValue({
+      features: null
+    });
+    const { result } = renderHook(
+      () => useUpdateCampaignConfig(key, endpoint),
+      {
+        wrapper: wrapper({})
+      }
+    );
+    expect(result.current.fetchingState).toBe("DEFAULT");
+
+    await wait(() => {
+      result.current.updateCampaignConfig();
+      expect(result.current.fetchingState).toBe("FETCHING_CONFIG");
+    });
+    expect(setCampaignConfigSpy).toHaveBeenCalledTimes(0);
+    expect(result.current.fetchingState).toBe("RESULT_RETURNED_NO_UPDATES");
+    expect(result.current.result).toBeUndefined();
+  });
+
+  it("should set error when there's a problem getting the campaign config", async () => {
+    expect.assertions(6);
+    mockGetCampaignConfig.mockRejectedValue(
+      new Error("Error getting campaign config")
+    );
+    const { result } = renderHook(
+      () => useUpdateCampaignConfig(key, endpoint),
+      {
+        wrapper: wrapper({})
+      }
+    );
+    expect(result.current.fetchingState).toBe("DEFAULT");
+
+    await wait(() => {
+      result.current.updateCampaignConfig();
+      expect(result.current.fetchingState).toBe("FETCHING_CONFIG");
+    });
+    expect(setCampaignConfigSpy).toHaveBeenCalledTimes(0);
+    expect(result.current.fetchingState).toBe("FETCHING_CONFIG");
+    expect(result.current.error?.message).toBe("Error getting campaign config");
+    expect(result.current.result).toBeUndefined();
+  });
+
+  it("should set error when there's a problem saving the campaign config", async () => {
+    expect.assertions(6);
+    mockGetCampaignConfig.mockResolvedValue({
+      features: {
+        minAppBinaryVersion: "3.0.0",
+        minAppBuildVersion: 0
+      }
+    });
+    setCampaignConfigSpy.mockRejectedValue(
+      new Error("Error saving campaign config")
+    );
+    const { result } = renderHook(
+      () => useUpdateCampaignConfig(key, endpoint),
+      {
+        wrapper: wrapper({})
+      }
+    );
+    expect(result.current.fetchingState).toBe("DEFAULT");
+
+    await wait(() => {
+      result.current.updateCampaignConfig();
+      expect(result.current.fetchingState).toBe("FETCHING_CONFIG");
+    });
+    expect(setCampaignConfigSpy).toHaveBeenCalledTimes(1);
+    expect(result.current.fetchingState).toBe("FETCHING_CONFIG");
+    expect(result.current.error?.message).toBe("Error saving campaign config");
+    expect(result.current.result).toBeUndefined();
+  });
+
+  it("should clear error when clearError is called", async () => {
+    expect.assertions(2);
+    mockGetCampaignConfig.mockResolvedValue({
+      features: {
+        minAppBinaryVersion: "3.0.0",
+        minAppBuildVersion: 0
+      }
+    });
+    setCampaignConfigSpy.mockRejectedValue(
+      new Error("Error saving campaign config")
+    );
+    const { result } = renderHook(
+      () => useUpdateCampaignConfig(key, endpoint),
+      {
+        wrapper: wrapper({})
+      }
+    );
+
+    await wait(() => result.current.updateCampaignConfig());
+    expect(result.current.error?.message).toBe("Error saving campaign config");
+
+    await wait(() => result.current.clearError());
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("should clear the previous error when calling updateCampaignConfig again", async () => {
+    expect.assertions(2);
+    mockGetCampaignConfig.mockResolvedValue({
+      features: {
+        minAppBinaryVersion: "3.0.0",
+        minAppBuildVersion: 0
+      }
+    });
+    setCampaignConfigSpy.mockRejectedValue(
+      new Error("Error saving campaign config")
+    );
+    const { result } = renderHook(
+      () => useUpdateCampaignConfig(key, endpoint),
+      {
+        wrapper: wrapper({})
+      }
+    );
+
+    await wait(() => result.current.updateCampaignConfig());
+    expect(result.current.error?.message).toBe("Error saving campaign config");
+
+    await wait(() => {
+      result.current.updateCampaignConfig();
+      expect(result.current.error).toBeUndefined();
+    });
+  });
+
+  it("should clear the previous result when calling updateCampaignConfig again", async () => {
+    expect.assertions(3);
+    mockGetCampaignConfig.mockResolvedValue({
+      features: {
+        minAppBinaryVersion: "3.0.0",
+        minAppBuildVersion: 0
+      }
+    });
+    setCampaignConfigSpy.mockReset();
+    const { result } = renderHook(
+      () => useUpdateCampaignConfig(key, endpoint),
+      {
+        wrapper: wrapper({})
+      }
+    );
+
+    await wait(() => result.current.updateCampaignConfig());
+    expect(result.current.fetchingState).toBe("RESULT_RETURNED_NEW_UPDATES");
+    expect(result.current.result).not.toBeUndefined();
+
+    await wait(() => {
+      result.current.updateCampaignConfig();
+      expect(result.current.result).toBeUndefined();
+    });
+  });
+});

--- a/src/hooks/useUpdateCampaignConfig/useUpdateCampaignConfig.test.tsx
+++ b/src/hooks/useUpdateCampaignConfig/useUpdateCampaignConfig.test.tsx
@@ -54,7 +54,7 @@ describe("useUpdateCampaignConfig", () => {
       expect(result.current.fetchingState).toBe("FETCHING_CONFIG");
     });
     expect(setCampaignConfigSpy).toHaveBeenCalledTimes(1);
-    expect(result.current.fetchingState).toBe("RESULT_RETURNED_NEW_UPDATES");
+    expect(result.current.fetchingState).toBe("RETURNED_NEW_UPDATES");
     expect(result.current.result).toStrictEqual({
       features: {
         minAppBinaryVersion: "3.0.0",
@@ -81,7 +81,7 @@ describe("useUpdateCampaignConfig", () => {
       expect(result.current.fetchingState).toBe("FETCHING_CONFIG");
     });
     expect(setCampaignConfigSpy).toHaveBeenCalledTimes(0);
-    expect(result.current.fetchingState).toBe("RESULT_RETURNED_NO_UPDATES");
+    expect(result.current.fetchingState).toBe("RETURNED_NO_UPDATES");
     expect(result.current.result).toBeUndefined();
   });
 
@@ -206,7 +206,7 @@ describe("useUpdateCampaignConfig", () => {
     );
 
     await wait(() => result.current.updateCampaignConfig());
-    expect(result.current.fetchingState).toBe("RESULT_RETURNED_NEW_UPDATES");
+    expect(result.current.fetchingState).toBe("RETURNED_NEW_UPDATES");
     expect(result.current.result).not.toBeUndefined();
 
     await wait(() => {

--- a/src/hooks/useUpdateCampaignConfig/useUpdateCampaignConfig.tsx
+++ b/src/hooks/useUpdateCampaignConfig/useUpdateCampaignConfig.tsx
@@ -6,8 +6,8 @@ import { getCampaignConfig } from "../../services/campaignConfig";
 type FetchingState =
   | "DEFAULT"
   | "FETCHING_CONFIG"
-  | "RESULT_RETURNED_NEW_UPDATES"
-  | "RESULT_RETURNED_NO_UPDATES";
+  | "RETURNED_NEW_UPDATES"
+  | "RETURNED_NO_UPDATES";
 
 type UpdateCampaignConfigHook = {
   fetchingState: FetchingState;
@@ -41,10 +41,10 @@ export const useUpdateCampaignConfig = (
         const configs = Object.values(campaignConfigResponse);
         if (configs.some(c => !!c)) {
           await setCampaignConfig(campaignConfigResponse);
-          setFetchingState("RESULT_RETURNED_NEW_UPDATES");
           setResult(campaignConfigResponse);
+          setFetchingState("RETURNED_NEW_UPDATES");
         } else {
-          setFetchingState("RESULT_RETURNED_NO_UPDATES");
+          setFetchingState("RETURNED_NO_UPDATES");
         }
       } catch (e) {
         setError(e);

--- a/src/hooks/useUpdateCampaignConfig/useUpdateCampaignConfig.tsx
+++ b/src/hooks/useUpdateCampaignConfig/useUpdateCampaignConfig.tsx
@@ -1,0 +1,68 @@
+import { useState, useCallback, useContext } from "react";
+import { CampaignConfig } from "../../types";
+import { CampaignConfigContext } from "../../context/campaignConfig";
+import { getCampaignConfig } from "../../services/campaignConfig";
+
+type FetchingState =
+  | "DEFAULT"
+  | "FETCHING_CONFIG"
+  | "RESULT_RETURNED_NEW_UPDATES"
+  | "RESULT_RETURNED_NO_UPDATES";
+
+type UpdateCampaignConfigHook = {
+  fetchingState: FetchingState;
+  updateCampaignConfig: () => void;
+  error?: Error;
+  clearError: () => void;
+  result?: CampaignConfig;
+};
+
+export const useUpdateCampaignConfig = (
+  authKey: string,
+  endpoint: string
+): UpdateCampaignConfigHook => {
+  const [fetchingState, setFetchingState] = useState<FetchingState>("DEFAULT");
+  const [result, setResult] = useState<CampaignConfig>();
+  const [error, setError] = useState<Error>();
+
+  const { setCampaignConfig, configHashes } = useContext(CampaignConfigContext);
+
+  const updateCampaignConfig = useCallback(() => {
+    const fetchCampaignConfig = async (): Promise<void> => {
+      setError(undefined);
+      setResult(undefined);
+      setFetchingState("FETCHING_CONFIG");
+      try {
+        const campaignConfigResponse = await getCampaignConfig(
+          authKey,
+          endpoint,
+          configHashes
+        );
+        const configs = Object.values(campaignConfigResponse);
+        if (configs.some(c => !!c)) {
+          await setCampaignConfig(campaignConfigResponse);
+          setFetchingState("RESULT_RETURNED_NEW_UPDATES");
+          setResult(campaignConfigResponse);
+        } else {
+          setFetchingState("RESULT_RETURNED_NO_UPDATES");
+        }
+      } catch (e) {
+        setError(e);
+      }
+    };
+
+    fetchCampaignConfig();
+  }, [authKey, configHashes, endpoint, setCampaignConfig]);
+
+  const clearError = useCallback(() => {
+    setError(undefined);
+  }, []);
+
+  return {
+    fetchingState,
+    updateCampaignConfig,
+    error,
+    clearError,
+    result
+  };
+};


### PR DESCRIPTION
* This hook helps with the actual calling of the endpoint and saving to the context
* It provides stateful return values so that consumers can react to the changes. E.g. consumers can show a loading spinner when `fetchingState` is `FETCHING_CONFIG`