### PR TITLE
feat: check version hook

### DIFF
--- a/src/config/index.tsx
+++ b/src/config/index.tsx
@@ -4,6 +4,6 @@ export const IS_STORYBOOK_VIEW =
   Constants.manifest?.extra?.storybook ||
   (Constants.manifest?.releaseChannel || "").indexOf("storybook") > -1;
 export const IS_MOCK = Constants.manifest?.extra?.mock;
-export const APP_BINARY_VERSION = Constants.manifest.version;
+export const APP_BINARY_VERSION = Constants.manifest?.version;
 export const APP_BUILD_VERSION: number =
-  Constants.manifest.extra.appBuildVersion;
+  Constants.manifest?.extra?.appBuildVersion;

--- a/src/config/index.tsx
+++ b/src/config/index.tsx
@@ -4,3 +4,6 @@ export const IS_STORYBOOK_VIEW =
   Constants.manifest?.extra?.storybook ||
   (Constants.manifest?.releaseChannel || "").indexOf("storybook") > -1;
 export const IS_MOCK = Constants.manifest?.extra?.mock;
+export const APP_BINARY_VERSION = Constants.manifest.version;
+export const APP_BUILD_VERSION: number =
+  Constants.manifest.extra.appBuildVersion;

--- a/src/hooks/useCheckVersion/useCheckVersion.test.tsx
+++ b/src/hooks/useCheckVersion/useCheckVersion.test.tsx
@@ -21,9 +21,7 @@ const wrapper = (
     value={{
       features: {
         minAppBinaryVersion: minAppBinaryVersion,
-        minAppBuildVersion: minAppBuildVersion,
-        flowType: "DEFAULT",
-        transactionGrouping: true
+        minAppBuildVersion: minAppBuildVersion
       },
       setCampaignConfig: () => null,
       clearCampaignConfig: () => null,

--- a/src/hooks/useCheckVersion/useCheckVersion.test.tsx
+++ b/src/hooks/useCheckVersion/useCheckVersion.test.tsx
@@ -1,0 +1,180 @@
+import React, { FunctionComponent } from "react";
+import { renderHook } from "@testing-library/react-hooks";
+import { CampaignConfigContext } from "../../context/campaignConfig";
+import { useCheckVersion } from "./useCheckVersion";
+import * as config from "../../config";
+
+jest.mock("../../config", () => ({
+  get APP_BINARY_VERSION() {
+    return "1.0.0";
+  },
+  get APP_BUILD_VERSION() {
+    return 0;
+  }
+}));
+
+const wrapper = (
+  minAppBinaryVersion: string,
+  minAppBuildVersion: number
+): FunctionComponent => ({ children }) => (
+  <CampaignConfigContext.Provider
+    value={{
+      features: {
+        minAppBinaryVersion: minAppBinaryVersion,
+        minAppBuildVersion: minAppBuildVersion,
+        flowType: "DEFAULT",
+        transactionGrouping: true
+      },
+      setCampaignConfig: () => null,
+      clearCampaignConfig: () => null,
+      configHashes: {}
+    }}
+  >
+    {children}
+  </CampaignConfigContext.Provider>
+);
+
+describe("useCheckVersion", () => {
+  let appBinaryVersionSpy: jest.SpyInstance;
+  let appBuildVersionSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    appBinaryVersionSpy = jest.spyOn(config, "APP_BINARY_VERSION", "get");
+    appBuildVersionSpy = jest.spyOn(config, "APP_BUILD_VERSION", "get");
+  });
+
+  describe("when binary versions are different", () => {
+    it.each([
+      ["3.0.0", "2.0.0"],
+      ["2.0.10", "2.0.3"],
+      ["4.3.0", "4.0.2"]
+    ])(
+      "should return OK when binary version (%s) is greater than the minimum binary version (%s)",
+      (current, minimum) => {
+        expect.assertions(1);
+
+        appBinaryVersionSpy.mockReturnValueOnce(current);
+        const { result } = renderHook(() => useCheckVersion(), {
+          wrapper: wrapper(minimum, 0)
+        });
+        expect(result.current()).toBe("OK");
+      }
+    );
+
+    it.each([
+      ["2.0.0", "3.0.0"],
+      ["1.0.10", "1.0.12"],
+      ["4.0.3", "4.12.0"]
+    ])(
+      "should return OUTDATED_BINARY when binary version (%s) is less than the minimum binary version (%s)",
+      (current, minimum) => {
+        expect.assertions(1);
+
+        appBinaryVersionSpy.mockReturnValueOnce(current);
+        const { result } = renderHook(() => useCheckVersion(), {
+          wrapper: wrapper(minimum, 0)
+        });
+        expect(result.current()).toBe("OUTDATED_BINARY");
+      }
+    );
+  });
+
+  describe("when binary versions are the same", () => {
+    let fixedBinaryVersion: string;
+
+    beforeAll(() => {
+      fixedBinaryVersion = "2.0.0";
+    });
+
+    beforeEach(() => {
+      appBinaryVersionSpy.mockReturnValueOnce(fixedBinaryVersion);
+    });
+
+    it("should return OK when binary and build version are the same as the minimum binary and build version", () => {
+      expect.assertions(1);
+
+      appBuildVersionSpy.mockReturnValueOnce(2);
+      const { result } = renderHook(() => useCheckVersion(), {
+        wrapper: wrapper(fixedBinaryVersion, 2)
+      });
+      expect(result.current()).toBe("OK");
+    });
+
+    it.each([
+      [3, 2],
+      [10, 9],
+      [333, 300]
+    ])(
+      "should return OK when build version (%s) is greater than the minimum build version (%s)",
+      (current, minimum) => {
+        expect.assertions(1);
+
+        appBuildVersionSpy.mockReturnValueOnce(current);
+        const { result } = renderHook(() => useCheckVersion(), {
+          wrapper: wrapper(fixedBinaryVersion, minimum)
+        });
+        expect(result.current()).toBe("OK");
+      }
+    );
+
+    it.each([
+      [0, 3],
+      [8, 20],
+      [200, 290]
+    ])(
+      "should return OUTDATED_BUILD when build version (%s) is less than the minimum build version (%s)",
+      (current, minimum) => {
+        expect.assertions(1);
+
+        appBuildVersionSpy.mockReturnValueOnce(current);
+        const { result } = renderHook(() => useCheckVersion(), {
+          wrapper: wrapper(fixedBinaryVersion, minimum)
+        });
+        expect(result.current()).toBe("OUTDATED_BUILD");
+      }
+    );
+  });
+  describe("when the versions are undefined", () => {
+    it("should throw an error when app binary version is undefined", () => {
+      expect.assertions(1);
+
+      appBinaryVersionSpy.mockReturnValueOnce(undefined);
+      const { result } = renderHook(() => useCheckVersion(), {
+        wrapper: wrapper("1.0.0", 0)
+      });
+      expect(() => result.current()).toThrow(
+        "Current app version is not configured properly"
+      );
+    });
+
+    it("should throw an error when app build version is undefined", () => {
+      expect.assertions(1);
+
+      appBuildVersionSpy.mockReturnValueOnce(undefined);
+      const { result } = renderHook(() => useCheckVersion(), {
+        wrapper: wrapper("1.0.0", 0)
+      });
+      expect(() => result.current()).toThrow(
+        "Current build version is not configured properly"
+      );
+    });
+
+    it("should throw an error when min binary version is undefined", () => {
+      expect.assertions(1);
+
+      const { result } = renderHook(() => useCheckVersion(), {
+        wrapper: wrapper(undefined as any, 0)
+      });
+      expect(() => result.current()).toThrow("Campaign config not loaded");
+    });
+
+    it("should throw an error when min build version is undefined", () => {
+      expect.assertions(1);
+
+      const { result } = renderHook(() => useCheckVersion(), {
+        wrapper: wrapper("1.0.0", undefined as any)
+      });
+      expect(() => result.current()).toThrow("Campaign config not loaded");
+    });
+  });
+});

--- a/src/hooks/useCheckVersion/useCheckVersion.ts
+++ b/src/hooks/useCheckVersion/useCheckVersion.ts
@@ -1,0 +1,60 @@
+import { useContext } from "react";
+import { CampaignConfigContext } from "../../context/campaignConfig";
+import * as config from "../../config";
+
+type CheckVersionResult = "OK" | "OUTDATED_BINARY" | "OUTDATED_BUILD";
+
+export const useCheckVersion = (): (() => CheckVersionResult) => {
+  const { features } = useContext(CampaignConfigContext);
+
+  const isBinaryVersionOK = (): boolean => {
+    const currentBinaryVersion = config.APP_BINARY_VERSION;
+    if (!currentBinaryVersion) {
+      throw new Error("Current app version is not configured properly");
+    }
+
+    const minBinaryVersion = features?.minAppBinaryVersion;
+    if (!minBinaryVersion) {
+      throw new Error("Campaign config not loaded");
+    }
+
+    const currentBinaryVersionSplit = currentBinaryVersion
+      .split(".")
+      .map(Number);
+    const minBinaryVersionSplit = minBinaryVersion.split(".").map(Number);
+    for (let i = 0; i < minBinaryVersionSplit.length; i++) {
+      if (currentBinaryVersionSplit[i] < minBinaryVersionSplit[i]) {
+        return false;
+      } else if (currentBinaryVersionSplit[i] > minBinaryVersionSplit[i]) {
+        return true;
+      }
+    }
+    return true;
+  };
+
+  const isBuildVersionOK = (): boolean => {
+    const currentBuildVersion = config.APP_BUILD_VERSION;
+    if (isNaN(currentBuildVersion)) {
+      throw new Error("Current build version is not configured properly");
+    }
+
+    const minBuildVersion = features?.minAppBuildVersion;
+    if (minBuildVersion === undefined) {
+      throw new Error("Campaign config not loaded");
+    }
+
+    return currentBuildVersion >= minBuildVersion;
+  };
+
+  const check = (): CheckVersionResult => {
+    if (!isBinaryVersionOK()) {
+      return "OUTDATED_BINARY";
+    }
+    if (!isBuildVersionOK()) {
+      return "OUTDATED_BUILD";
+    }
+    return "OK";
+  };
+
+  return check;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "noImplicitAny": true,
-    "types": ["node", "jest"]
+    "types": ["node", "jest"],
+    "target": "esnext"
   },
   "includes": ["src"]
 }


### PR DESCRIPTION
This hook gets the version from `config` and compares it with the minimum version from the campaign config

Checks:
1. `config.APP_BINARY_VERSION` vs `features.minAppBinaryVersion`
2. `config.APP_BUILD_VERSION` vs `features.minAppBuildVersion`

**NOTE**
Location of the current app version is subject to change, depends on the navigation sidebar PR that configure the app version variables