### PR TITLE
chore: release 4.0.0

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,7 +8,7 @@
       "android",
       "web"
     ],
-    "version": "3.6.1",
+    "version": "4.0.0",
     "orientation": "portrait",
     "scheme": "supplyally",
     "icon": "./assets/icon.png",
@@ -24,7 +24,7 @@
       "**/*"
     ],
     "ios": {
-      "buildNumber": "1",
+      "buildNumber": "40",
       "supportsTablet": true,
       "bundleIdentifier": "sg.gov.tech.musket",
       "splash": {
@@ -48,7 +48,7 @@
       }
     },
     "android": {
-      "versionCode": 38,
+      "versionCode": 40,
       "package": "sg.gov.tech.musket"
     },
     "packagerOpts": {


### PR DESCRIPTION
Right now the app.json version codes are not dynamic. Once https://github.com/rationally-app/mobile-application/pull/105 is done, it will be fully dynamic and will increment automatically.

In the meantime, this PR just bumps the version to 4.0.0, a breaking change because of the new sdk 38.

Also, from here on out, we'll sync up the `ios.buildNumber` and `android.versionCode`, and will start from 40.