### PR TITLE
fix: sync build number

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -12,8 +12,7 @@ const buildNumber: string = getValue(
   "Please provide a Build Version with APP_BUILD_VERSION env variable"
 );
 // The APP_BUILD_VERSION number is 38 behind the actual deploy, adding 38 synchronises the build number
-const androidVersionCode = parseInt(buildNumber) + 38;
-const appBuildVersion = androidVersionCode.toString();
+const appBuildVersion = parseInt(buildNumber) + 38;
 
 export default ({ config }: any): any => {
   return {
@@ -24,11 +23,11 @@ export default ({ config }: any): any => {
     ),
     android: {
       ...config.android,
-      versionCode: androidVersionCode
+      versionCode: appBuildVersion
     },
     ios: {
       ...config.ios,
-      buildNumber: appBuildVersion
+      buildNumber: appBuildVersion.toString()
     },
     extra: {
       mock: process.env.MOCK === "true",

--- a/app.config.ts
+++ b/app.config.ts
@@ -13,7 +13,7 @@ const buildNumber: string = getValue(
 );
 // The APP_BUILD_VERSION number is 38 behind the actual deploy, adding 38 synchronises the build number
 const androidVersionCode = parseInt(buildNumber) + 38;
-const iosVersionCode = androidVersionCode.toString();
+const appBuildVersion = androidVersionCode.toString();
 
 export default ({ config }: any): any => {
   return {
@@ -28,11 +28,12 @@ export default ({ config }: any): any => {
     },
     ios: {
       ...config.ios,
-      buildNumber: iosVersionCode
+      buildNumber: appBuildVersion
     },
     extra: {
       mock: process.env.MOCK === "true",
-      storybook: process.env.START_STORYBOOK === "true"
+      storybook: process.env.START_STORYBOOK === "true",
+      appBuildVersion
     }
   };
 };

--- a/app.config.ts
+++ b/app.config.ts
@@ -11,7 +11,9 @@ const buildNumber: string = getValue(
   process.env.APP_BUILD_VERSION,
   "Please provide a Build Version with APP_BUILD_VERSION env variable"
 );
-const androidVersionCode: number = parseInt(buildNumber);
+// The APP_BUILD_VERSION number is 38 behind the actual deploy, adding synchronize the version
+const androidVersionCode = parseInt(buildNumber) + 38;
+const iosVersionCode = androidVersionCode.toString();
 
 export default ({ config }: any): any => {
   return {
@@ -26,7 +28,7 @@ export default ({ config }: any): any => {
     },
     ios: {
       ...config.ios,
-      buildNumber
+      buildNumber: iosVersionCode
     },
     extra: {
       mock: process.env.MOCK === "true",

--- a/app.config.ts
+++ b/app.config.ts
@@ -11,7 +11,7 @@ const buildNumber: string = getValue(
   process.env.APP_BUILD_VERSION,
   "Please provide a Build Version with APP_BUILD_VERSION env variable"
 );
-// The APP_BUILD_VERSION number is 38 behind the actual deploy, adding synchronize the version
+// The APP_BUILD_VERSION number is 38 behind the actual deploy, adding 38 synchronises the build number
 const androidVersionCode = parseInt(buildNumber) + 38;
 const iosVersionCode = androidVersionCode.toString();
 

--- a/src/components/Layout/DrawerNavigation.tsx
+++ b/src/components/Layout/DrawerNavigation.tsx
@@ -125,10 +125,8 @@ export const DrawerNavigationComponent: FunctionComponent<DrawerContentComponent
   let version = "";
   if (releaseChannel) {
     version += `ver ${Constants.manifest.version}`;
-    if (Constants.platform?.ios) {
-      version += ` / ${Constants.manifest.ios.buildNumber}`;
-    } else if (Constants.platform?.android) {
-      version += ` / ${Constants.manifest.android.versionCode}`;
+    if (Constants.manifest.extra.appBuildVersion) {
+      version += ` / ${Constants.manifest.extra.appBuildVersion}`;
     }
     if (releaseChannel === "staging" || releaseChannel.match(/pr\d+/g)) {
       version += ` / ${releaseChannel}`;

--- a/src/components/Layout/DrawerNavigation.tsx
+++ b/src/components/Layout/DrawerNavigation.tsx
@@ -125,8 +125,10 @@ export const DrawerNavigationComponent: FunctionComponent<DrawerContentComponent
   let version = "";
   if (releaseChannel) {
     version += `ver ${Constants.manifest.version}`;
-    if (Constants.nativeBuildVersion) {
-      version += ` / ${Constants.nativeBuildVersion}`;
+    if (Constants.platform?.ios) {
+      version += ` / ${Constants.manifest.ios.buildNumber}`;
+    } else if (Constants.platform?.android) {
+      version += ` / ${Constants.manifest.android.versionCode}`;
     }
     if (releaseChannel === "staging" || releaseChannel.match(/pr\d+/g)) {
       version += ` / ${releaseChannel}`;


### PR DESCRIPTION
We need to synchronize the buildNumber and `GITHUB_RUN_NUMBER` before building and releasing it to the app stores.
Also, added `appBuildVersion` into extra for easy consumption