### PR TITLE
fix: double alert modal appears during error in checkout

### DIFF
--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -279,8 +279,8 @@ export const useCart = (
         setCheckoutResult(transactionResponse);
         setCartState("PURCHASED");
       } catch (e) {
-        setError(new Error("Couldn't checkout, please try again later"));
         setCartState("DEFAULT");
+        setError(new Error("Couldn't checkout, please try again later"));
       }
     };
 


### PR DESCRIPTION
Setting cart state before throwing error helps to fix this bug, thanks to @justin0108 ^^