### PR TITLE
chore: specify permissions

### DIFF
--- a/app.json
+++ b/app.json
@@ -40,7 +40,8 @@
       }
     },
     "android": {
-      "package": "sg.gov.tech.musket"
+      "package": "sg.gov.tech.musket",
+      "permissions": ["CAMERA", "VIBRATE"]
     },
     "packagerOpts": {
       "config": "metro.config.js",


### PR DESCRIPTION
Have added `["CAMERA", "VIBRATE"]` as these are the only two additional permissions found in the following link that we use.

https://docs.expo.io/versions/latest/config/app/#android > under permissions
>  To use ONLY the following minimum necessary permissions and none of the extras supported by Expo in a default managed app, set permissions to []. The minimum necessary permissions do not require a Privacy Policy when uploading to Google Play Store and are:
• receive data from Internet
• view network connections
• full network access
• change your audio settings
• draw over other apps
• prevent device from sleeping 
 To use ALL permissions supported by Expo by default, do not specify the permissions key. 
  To use the minimum necessary permissions ALONG with certain additional permissions, specify those extras in permissions, e.g.
 [ "CAMERA", "ACCESS_FINE_LOCATION" ].

Tested it by building an app through expo, attached are the before and after `AndroidManifest.xml`. Went from 49 `uses-permission` to 26 `uses-permission`.

[AndroidManifest-4.0.0.txt](https://github.com/rationally-app/mobile-application/files/4994004/AndroidManifest-4.0.0.txt)
[AndroidManifest-test-version.txt](https://github.com/rationally-app/mobile-application/files/4994006/AndroidManifest-test-version.txt)
