### PR TITLE
feat: update error boundary styles

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,53 +1,7 @@
 import React, { Component, ReactNode } from "react";
 import { Sentry } from "../../utils/errorTracking";
-import * as Updates from "expo-updates";
-import { AppText } from "../Layout/AppText";
-import { StyleSheet, View, Linking } from "react-native";
-import { size, fontSize, color } from "../../common/styles";
-import { DarkButton } from "../Layout/Buttons/DarkButton";
-import { Feather } from "@expo/vector-icons";
 import { format } from "date-fns";
-
-const styles = StyleSheet.create({
-  wrapper: {
-    ...StyleSheet.absoluteFillObject,
-    justifyContent: "center",
-    alignItems: "center",
-    paddingHorizontal: size(5)
-  },
-  content: {
-    width: 512,
-    maxWidth: "100%",
-    marginTop: -size(4)
-  },
-  emoji: {
-    fontSize: fontSize(5)
-  },
-  heading: {
-    fontFamily: "brand-bold",
-    fontSize: fontSize(5)
-  },
-  feedback: {
-    marginTop: size(1),
-    fontSize: fontSize(2)
-  },
-  errorDescription: {
-    marginTop: size(2),
-    fontFamily: "brand-italic",
-    fontSize: fontSize(-1),
-    color: color("grey", 40)
-  },
-  emailLink: {
-    fontFamily: "brand-italic",
-    fontSize: fontSize(-1),
-    textDecorationLine: "underline",
-    color: color("blue", 40)
-  },
-  restartButton: {
-    alignSelf: "flex-start",
-    marginTop: size(5)
-  }
-});
+import { ErrorBoundaryContent } from "./ErrorBoundaryContent";
 
 type State = { hasError: boolean; errorMessage?: string };
 
@@ -69,48 +23,13 @@ export class ErrorBoundary extends Component<unknown, State> {
   render(): ReactNode {
     const error = `(${this.state.errorMessage} ${format(
       Date.now(),
-      "hh:mm a, do MMMM"
+      "hh:mma, do MMMM"
     )})`;
-    const supportLink = `mailto:supplyallyhelp@hive.gov.sg?subject=[SupplyAlly Error]&body=${error}`;
 
     return this.state.hasError ? (
-      <View style={styles.wrapper}>
-        <View style={styles.content}>
-          <AppText style={styles.emoji}>😓</AppText>
-          <AppText style={styles.heading}>Paiseh...</AppText>
-          <AppText style={styles.feedback}>
-            SupplyAlly has encountered an issue. We&apos;ve noted this down and
-            are looking into it!
-          </AppText>
-          {this.state.errorMessage && (
-            <>
-              <AppText style={styles.errorDescription}>
-                If this persists, drop us an email at{" "}
-                <AppText
-                  style={styles.emailLink}
-                  onPress={() => Linking.openURL(supportLink)}
-                >
-                  supplyallyhelp@hive.gov.sg
-                </AppText>
-              </AppText>
-              <AppText style={styles.errorDescription}>{error}</AppText>
-            </>
-          )}
-          <View style={styles.restartButton}>
-            <DarkButton
-              text="Restart app"
-              onPress={() => Updates.reloadAsync()}
-              icon={
-                <Feather
-                  name="refresh-cw"
-                  size={size(2)}
-                  color={color("grey", 0)}
-                />
-              }
-            />
-          </View>
-        </View>
-      </View>
+      <ErrorBoundaryContent
+        error={this.state.errorMessage ? error : undefined}
+      />
     ) : (
       this.props.children
     );

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -23,7 +23,7 @@ export class ErrorBoundary extends Component<unknown, State> {
   render(): ReactNode {
     const error = `(${this.state.errorMessage} ${format(
       Date.now(),
-      "hh:mma, do MMMM"
+      "h:mma, d MMM yyyy"
     )})`;
 
     return this.state.hasError ? (

--- a/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
@@ -1,0 +1,71 @@
+import React, { FunctionComponent } from "react";
+import { View, StyleSheet } from "react-native";
+import { size, fontSize } from "../../common/styles";
+import { AppText } from "../Layout/AppText";
+import * as Updates from "expo-updates";
+import { DarkButton } from "../Layout/Buttons/DarkButton";
+import AlertIcon from "../../../assets/icons/alert.svg";
+
+const styles = StyleSheet.create({
+  wrapper: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: size(4),
+    paddingTop: "20%"
+  },
+  content: {
+    width: 512,
+    maxWidth: "100%",
+    alignItems: "center",
+    flex: 1
+  },
+  icon: {
+    marginBottom: size(3)
+  },
+  heading: {
+    fontFamily: "brand-bold",
+    fontSize: fontSize(3),
+    textAlign: "center"
+  },
+  body: {
+    marginTop: size(1.5),
+    textAlign: "center"
+  },
+  errorDescription: {
+    textAlign: "center",
+    marginTop: size(4),
+    fontSize: fontSize(-3)
+  },
+  restartButton: {
+    position: "absolute",
+    bottom: size(4),
+    marginHorizontal: size(4),
+    marginTop: size(5),
+    maxWidth: 512,
+    width: "100%"
+  }
+});
+
+export const ErrorBoundaryContent: FunctionComponent<{
+  error?: string;
+}> = ({ error }) => (
+  <View style={styles.wrapper}>
+    <View style={styles.content}>
+      <AlertIcon style={styles.icon} width={size(5)} height={size(5)} />
+      <AppText style={styles.heading}>System issue</AppText>
+      <AppText style={styles.body}>
+        We are currently facing connectivity issues and are looking into it. Try
+        restarting the app or contact GovTech if the problem persists.
+      </AppText>
+      {error && <AppText style={styles.errorDescription}>{error}</AppText>}
+    </View>
+    <View style={styles.restartButton}>
+      <DarkButton
+        text="Restart app"
+        onPress={() => Updates.reloadAsync()}
+        fullWidth={true}
+      />
+    </View>
+  </View>
+);

--- a/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
@@ -55,8 +55,8 @@ export const ErrorBoundaryContent: FunctionComponent<{
       <AlertIcon style={styles.icon} width={size(5)} height={size(5)} />
       <AppText style={styles.heading}>System issue</AppText>
       <AppText style={styles.body}>
-        We are currently facing connectivity issues and are looking into it. Try
-        restarting the app or contact GovTech if the problem persists.
+        We are currently facing connectivity issues. Try restarting the app or
+        contact GovTech if the problem persists.
       </AppText>
       {error && <AppText style={styles.errorDescription}>{error}</AppText>}
     </View>

--- a/storybook/stories/ErrorBoundary/ErrorBoundary.tsx
+++ b/storybook/stories/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { storiesOf } from "@storybook/react-native";
+import { format } from "date-fns";
+import { ErrorBoundaryContent } from "../../../src/components/ErrorBoundary/ErrorBoundaryContent";
+
+storiesOf("ErrorBoundary", module).add("ErrorBoundary", () => (
+  <ErrorBoundaryContent
+    error={`(LoginError ${format(Date.now(), "hh:mma, d MMMM")})`}
+  />
+));

--- a/storybook/stories/index.tsx
+++ b/storybook/stories/index.tsx
@@ -1,3 +1,4 @@
 import "./CustomerQuota/CheckoutSuccessCard";
+import "./ErrorBoundary/ErrorBoundary";
 import "./Layout";
 import "./Modals";


### PR DESCRIPTION
* Refactored error boundary content into a new component so it's easier to showcase in Storybook
* Use new styling for the error boundary to match the alert dialogs

![image](https://user-images.githubusercontent.com/577802/90091121-3f795c00-dd58-11ea-8554-614d55036ee0.png)
