### PR TITLE
fix: Changed navigate path for onCancel callback

### DIFF
--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -108,7 +108,7 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
   }, [cartState]);
 
   const onCancel = useCallback((): void => {
-    navigation.goBack();
+    navigateHome(navigation);
   }, [navigation]);
 
   const addId = useCallback((id: string): void => {


### PR DESCRIPTION
[Notion Reference](https://www.notion.so/Cancel-button-to-go-back-to-Scan-ID-main-page-instead-of-camera-scanning-feature-30e737b54d1147ef82a6cef2c32f2e79)

Applied a minor fix to alter the navigation behavior after clicking on "Cancel" in the Customer Quota Screen. 
- **Then**: User is brought back to the previous page, which is the scanner.
- **Now**: User is brought back to main page.