### PR TITLE
fix: change behavior of cancel in customer quota screen

### DIFF
--- a/src/components/CustomerAppeal/CustomerAppealScreen.tsx
+++ b/src/components/CustomerAppeal/CustomerAppealScreen.tsx
@@ -24,7 +24,7 @@ import {
   ReasonSelectionCard,
   Reason
 } from "./ReasonSelection/ReasonSelectionCard";
-import { pushRoute } from "../../common/navigation";
+import { pushRoute, navigateHome } from "../../common/navigation";
 import { useAuthenticationContext } from "../../context/auth";
 import { useCart } from "../../hooks/useCart/useCart";
 import { Sentry } from "../../utils/errorTracking";
@@ -75,7 +75,7 @@ export const CustomerAppealScreen: FunctionComponent<NavigationProps> = ({
   }, [validateTokenExpiry]);
 
   const onCancel = useCallback((): void => {
-    navigation.goBack();
+    navigateHome(navigation);
   }, [navigation]);
 
   const messageContent = useContext(ImportantMessageContentContext);

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -108,7 +108,7 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
   }, [cartState]);
 
   const onCancel = useCallback((): void => {
-    navigation.goBack();
+    navigateHome(navigation);
   }, [navigation]);
 
   const addId = useCallback((id: string): void => {

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -90,6 +90,7 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
   const { showAlert } = useContext(AlertModalContext);
   const [ids, setIds] = useState<string[]>(navIds);
   const { features: campaignFeatures } = useContext(CampaignConfigContext);
+  const { products } = useProductContext();
 
   const {
     cartState,
@@ -100,8 +101,6 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
     error,
     clearError
   } = useCart(ids, token, endpoint);
-
-  const { products } = useProductContext();
 
   useEffect(() => {
     Sentry.addBreadcrumb({
@@ -115,7 +114,7 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
       product => product.categoryType === "APPEAL"
     );
     isAppeal ? navigation.goBack() : navigateHome(navigation);
-  }, [navigation]);
+  }, [navigation, products]);
 
   const addId = useCallback((id: string): void => {
     setIds(ids => [...ids, id]);

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -36,6 +36,7 @@ import {
 } from "../../context/alert";
 import { navigateHome, replaceRoute } from "../../common/navigation";
 import { NavigationProps } from "../../types";
+import { useProductContext } from "../../context/products";
 
 type CustomerQuotaProps = NavigationProps & { navIds: string[] };
 
@@ -108,7 +109,11 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
   }, [cartState]);
 
   const onCancel = useCallback((): void => {
-    navigateHome(navigation);
+    const { products } = useProductContext();
+    const isAppeal = products.some(
+      product => product.categoryType === "APPEAL"
+    );
+    isAppeal ? navigation.goBack() : navigateHome(navigation);
   }, [navigation]);
 
   const addId = useCallback((id: string): void => {

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -101,6 +101,8 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
     clearError
   } = useCart(ids, token, endpoint);
 
+  const { products } = useProductContext();
+
   useEffect(() => {
     Sentry.addBreadcrumb({
       category: "cartState",
@@ -109,7 +111,6 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
   }, [cartState]);
 
   const onCancel = useCallback((): void => {
-    const { products } = useProductContext();
     const isAppeal = products.some(
       product => product.categoryType === "APPEAL"
     );


### PR DESCRIPTION
[Notion Reference](https://www.notion.so/Cancel-button-to-go-back-to-Scan-ID-main-page-instead-of-camera-scanning-feature-30e737b54d1147ef82a6cef2c32f2e79)

[Related PR](https://github.com/rationally-app/mobile-application/pull/147)

This is a fix for bugs found in the related PR:

- [x]  After a user has selected an appeal reason and clicks back, the user will be redirected to the main page, instead of the Appeal page.
- [x]  Clicking Cancel at the Appeal page goes back to the previous page and not the main screen.
