### PR TITLE
fix: error dialog edge cases

### DIFF
--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -203,6 +203,7 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
           break;
 
         case ERROR_MESSAGE.INVALID_PHONE_NUMBER:
+        case ERROR_MESSAGE.INVALID_PHONE_AND_COUNTRY_CODE:
           showAlert({
             ...wrongFormatAlertProps,
             description: error.message,

--- a/src/components/CustomerQuota/ItemsSelection/ItemsSelectionCard.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemsSelectionCard.tsx
@@ -86,6 +86,9 @@ export const ItemsSelectionCard: FunctionComponent<ItemsSelectionCard> = ({
   // We may need to refactor this card once the difference in behaviour between main products and appeal products is vastly different.
   // To be further discuss
   const isAppeal = products.some(product => product.categoryType === "APPEAL");
+  const isChargable = cart.some(
+    cartItem => cartItem.descriptionAlert === "*chargeable"
+  );
   return (
     <View>
       <CustomerCard
@@ -143,7 +146,24 @@ export const ItemsSelectionCard: FunctionComponent<ItemsSelectionCard> = ({
                 color={color("grey", 0)}
               />
             }
-            onPress={checkoutCart}
+            onPress={
+              !isChargable
+                ? checkoutCart
+                : () => {
+                    showAlert({
+                      ...defaultWarningProps,
+                      title: "Payment collected?",
+                      description:
+                        "This action cannot be undone. Proceed only when payment has been collected",
+                      buttonTexts: {
+                        primaryActionText: "Collected",
+                        secondaryActionText: "No"
+                      },
+                      visible: true,
+                      onOk: checkoutCart
+                    });
+                  }
+            }
             isLoading={isLoading}
             fullWidth={true}
           />

--- a/src/components/CustomerQuota/ItemsSelection/ItemsSelectionCard.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemsSelectionCard.tsx
@@ -17,6 +17,7 @@ import {
   wrongFormatAlertProps,
   systemAlertProps,
   ERROR_MESSAGE,
+  WARNING_MESSAGE,
   duplicateAlertProps
 } from "../../../context/alert";
 import { validateAndCleanId } from "../../../utils/validateIdentification";
@@ -87,7 +88,7 @@ export const ItemsSelectionCard: FunctionComponent<ItemsSelectionCard> = ({
   // We may need to refactor this card once the difference in behaviour between main products and appeal products is vastly different.
   // To be further discuss
   const isAppeal = products.some(product => product.categoryType === "APPEAL");
-  const isChargable = cart.some(
+  const isChargeable = cart.some(
     cartItem => cartItem.descriptionAlert === "*chargeable"
   );
   return (
@@ -148,14 +149,13 @@ export const ItemsSelectionCard: FunctionComponent<ItemsSelectionCard> = ({
               />
             }
             onPress={
-              !isChargable
+              !isChargeable
                 ? checkoutCart
                 : () => {
                     showAlert({
                       ...defaultConfirmationProps,
                       title: "Payment collected?",
-                      description:
-                        "This action cannot be undone. Proceed only when payment has been collected",
+                      description: WARNING_MESSAGE.PAYMENT_COLLECTION,
                       buttonTexts: {
                         primaryActionText: "Collected",
                         secondaryActionText: "No"

--- a/src/components/CustomerQuota/ItemsSelection/ItemsSelectionCard.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemsSelectionCard.tsx
@@ -13,6 +13,7 @@ import { useProductContext } from "../../../context/products";
 import {
   AlertModalContext,
   defaultWarningProps,
+  defaultConfirmationProps,
   wrongFormatAlertProps,
   systemAlertProps,
   ERROR_MESSAGE,
@@ -151,7 +152,7 @@ export const ItemsSelectionCard: FunctionComponent<ItemsSelectionCard> = ({
                 ? checkoutCart
                 : () => {
                     showAlert({
-                      ...defaultWarningProps,
+                      ...defaultConfirmationProps,
                       title: "Payment collected?",
                       description:
                         "This action cannot be undone. Proceed only when payment has been collected",

--- a/src/components/Login/utils.test.tsx
+++ b/src/components/Login/utils.test.tsx
@@ -1,11 +1,11 @@
 import { decodeQr } from "./utils";
 
 describe("decodeQr", () => {
-  it("should fail for old QR codes", () => {
+  it("should fail for old, deprecated QR codes", () => {
     expect.assertions(1);
     const code = "1e4457bc-f7d0-4329-a344-f0e3c75d8dd4";
     expect(() => decodeQr(code)).toThrow(
-      "We could not find a validity period. Get a new QR code from your in-charge."
+      "Scan QR code again or get a new QR code from your in-charge."
     );
   });
 
@@ -18,7 +18,7 @@ describe("decodeQr", () => {
   });
 
   it("should throw if the code can be parsed but does not contain the right fields", () => {
-    expect.assertions(2);
+    expect.assertions(3);
     const missingKey = `{"keys": "1e4457bc-f7d0-4329-a344-f0e3c75d8dd4","endpoint": "https://somewhere.com"}`;
     expect(() => decodeQr(missingKey)).toThrow(
       "Scan QR code again or get a new QR code from your in-charge."
@@ -26,6 +26,11 @@ describe("decodeQr", () => {
 
     const missingEndpoint = `{"key": "1e4457bc-f7d0-4329-a344-f0e3c75d8dd4","endpointed": "https://somewhere.com"}`;
     expect(() => decodeQr(missingEndpoint)).toThrow(
+      "Scan QR code again or get a new QR code from your in-charge."
+    );
+
+    const syntaxError = `xxx{"key": "1e4457bc-f7d0-4329-a344-f0e3c75d8dd4","endpoint": "https://somewhere.com"}`;
+    expect(() => decodeQr(syntaxError)).toThrow(
       "Scan QR code again or get a new QR code from your in-charge."
     );
   });

--- a/src/components/Login/utils.ts
+++ b/src/components/Login/utils.ts
@@ -20,7 +20,6 @@ export const decodeQr = (code: string): DecodedQrResponse => {
       throw new Error(ERROR_MESSAGE.AUTH_FAILURE_INVALID_FORMAT);
     return { endpoint: parsedCode.endpoint, key: parsedCode.key };
   } catch (e) {
-    console.log(e);
     if (e.message.includes("token") || e instanceof SyntaxError)
       throw new Error(ERROR_MESSAGE.AUTH_FAILURE_INVALID_FORMAT);
     throw e;

--- a/src/components/Login/utils.ts
+++ b/src/components/Login/utils.ts
@@ -22,6 +22,8 @@ export const decodeQr = (code: string): DecodedQrResponse => {
   } catch (e) {
     if (e.message.includes("Unexpected token"))
       throw new Error(ERROR_MESSAGE.AUTH_FAILURE_EXPIRED_TOKEN);
+    if (e.message.includes("Unrecognized token") || e instanceof SyntaxError)
+      throw new Error(ERROR_MESSAGE.AUTH_FAILURE_INVALID_FORMAT);
     throw e;
   }
 };

--- a/src/components/Login/utils.ts
+++ b/src/components/Login/utils.ts
@@ -20,9 +20,8 @@ export const decodeQr = (code: string): DecodedQrResponse => {
       throw new Error(ERROR_MESSAGE.AUTH_FAILURE_INVALID_FORMAT);
     return { endpoint: parsedCode.endpoint, key: parsedCode.key };
   } catch (e) {
-    if (e.message.includes("Unexpected token"))
-      throw new Error(ERROR_MESSAGE.AUTH_FAILURE_EXPIRED_TOKEN);
-    if (e.message.includes("Unrecognized token") || e instanceof SyntaxError)
+    console.log(e);
+    if (e.message.includes("token") || e instanceof SyntaxError)
       throw new Error(ERROR_MESSAGE.AUTH_FAILURE_INVALID_FORMAT);
     throw e;
   }

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -10,6 +10,10 @@ import {
   AlertModalProps
 } from "../components/AlertModal/AlertModal";
 
+export enum WARNING_MESSAGE {
+  PAYMENT_COLLECTION = "This action cannot be undone. Proceed only when payment has been collected."
+}
+
 export enum ERROR_MESSAGE {
   DUPLICATE_IDENTIFIER_INPUT = "Enter unique code details.",
   DUPLICATE_POD_INPUT = "Scan another item that is not tagged to any ID number.",

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -25,7 +25,7 @@ export enum ERROR_MESSAGE {
   AUTH_FAILURE_INVALID_TOKEN = "Get a new QR code from your in-charge.",
   AUTH_FAILURE_EXPIRED_TOKEN = "We could not find a validity period. Get a new QR code from your in-charge.",
   AUTH_FAILURE_INVALID_FORMAT = "Scan QR code again or get a new QR code from your in-charge.",
-  ENV_VERSION_ERROR = "Encountered an issue obtaining environment information. We've noted this down and are looking into it!",
+  ENV_VERSION_ERROR = "We are currently facing connectivity issues. Try again later or contact your in-charge if the problem persists.",
   INSUFFICIENT_QUOTA = "Insufficient quota.",
   INVALID_QUANTITY = "Invalid quantity.",
   INVALID_CATEGORY = "Category does not exist.",

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -25,7 +25,7 @@ export enum ERROR_MESSAGE {
   MISSING_POD_INPUT = "Scan your device code.",
   INVALID_PHONE_NUMBER = "Enter valid contact number.",
   INVALID_COUNTRY_CODE = "Enter valid country code.",
-  INVALID_PHONE_AND_COUNTRY_CODE = "Enter valid contact number and country code.",
+  INVALID_PHONE_AND_COUNTRY_CODE = "Enter valid country code and contact number.",
   MISSING_SELECTION = "Select at least one item to checkout.",
   AUTH_FAILURE_INVALID_TOKEN = "Get a new QR code from your in-charge.",
   AUTH_FAILURE_EXPIRED_TOKEN = "We could not find a validity period. Get a new QR code from your in-charge.",

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -21,6 +21,7 @@ export enum ERROR_MESSAGE {
   MISSING_POD_INPUT = "Scan your device code.",
   INVALID_PHONE_NUMBER = "Enter valid contact number.",
   INVALID_COUNTRY_CODE = "Enter valid country code.",
+  INVALID_PHONE_AND_COUNTRY_CODE = "Enter valid contact number and country code.",
   MISSING_SELECTION = "Select at least one item to checkout.",
   AUTH_FAILURE_INVALID_TOKEN = "Get a new QR code from your in-charge.",
   AUTH_FAILURE_EXPIRED_TOKEN = "We could not find a validity period. Get a new QR code from your in-charge.",

--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -964,7 +964,7 @@ describe("useCart", () => {
       });
 
       expect(result.current.error?.message).toBe(
-        "Enter valid contact number and country code."
+        "Enter valid country code and contact number."
       );
       expect(result.current.cartState).toBe("DEFAULT");
       expect(result.current.cart).toStrictEqual([

--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -963,7 +963,9 @@ describe("useCart", () => {
         result.current.checkoutCart();
       });
 
-      expect(result.current.error?.message).toBe("Enter valid contact number.");
+      expect(result.current.error?.message).toBe(
+        "Enter valid contact number and country code."
+      );
       expect(result.current.cartState).toBe("DEFAULT");
       expect(result.current.cart).toStrictEqual([
         {

--- a/src/utils/validateIdentification.test.ts
+++ b/src/utils/validateIdentification.test.ts
@@ -26,7 +26,7 @@ describe("throw EnvVersionError", () => {
       validateAndCleanId("100000001", undefinedIdValidation)
     ).toThrow(
       new EnvVersionError(
-        "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+        "We are currently facing connectivity issues. Try again later or contact your in-charge if the problem persists."
       )
     );
   });
@@ -39,7 +39,7 @@ describe("throw EnvVersionError", () => {
       validateAndCleanId("100000001", idRegexValidation, undefinedRegex)
     ).toThrow(
       new EnvVersionError(
-        "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+        "We are currently facing connectivity issues. Try again later or contact your in-charge if the problem persists."
       )
     );
   });
@@ -52,7 +52,7 @@ describe("throw EnvVersionError", () => {
       validateAndCleanId("100000001", idNRICValidation, validRegex)
     ).toThrow(
       new EnvVersionError(
-        "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+        "We are currently facing connectivity issues. Try again later or contact your in-charge if the problem persists."
       )
     );
   });

--- a/src/utils/validateIdentification.ts
+++ b/src/utils/validateIdentification.ts
@@ -10,13 +10,13 @@ export const validateAndCleanId = (
   let id: string;
   if (!idValidation)
     throw new EnvVersionError(
-      "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+      "We are currently facing connectivity issues. Try again later or contact your in-charge if the problem persists."
     );
   switch (idValidation) {
     case "NRIC":
       if (idRegex)
         throw new EnvVersionError(
-          "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+          "We are currently facing connectivity issues. Try again later or contact your in-charge if the problem persists."
         );
       id = validateAndCleanNric(inputId);
       break;

--- a/src/utils/validateIdentifierInputs.test.ts
+++ b/src/utils/validateIdentifierInputs.test.ts
@@ -97,7 +97,7 @@ describe("validateIdentifierInputs", () => {
           textInputType: "PHONE_NUMBER"
         }
       ])
-    ).toThrow("Enter valid contact number");
+    ).toThrow("Enter valid country code and contact number.");
     expect(() =>
       validateIdentifierInputs([
         {
@@ -106,7 +106,7 @@ describe("validateIdentifierInputs", () => {
           textInputType: "PHONE_NUMBER"
         }
       ])
-    ).toThrow("Enter valid contact number");
+    ).toThrow("Enter valid country code and contact number.");
   });
 
   it("should throw error if identifier has empty value", () => {

--- a/src/utils/validateIdentifierInputs.ts
+++ b/src/utils/validateIdentifierInputs.ts
@@ -27,7 +27,7 @@ export const validateIdentifierInputs = (
       throw new Error(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
     }
     if (textInputType === "PHONE_NUMBER" && !fullPhoneNumberValidator(value)) {
-      throw new Error(ERROR_MESSAGE.INVALID_PHONE_NUMBER);
+      throw new Error(ERROR_MESSAGE.INVALID_PHONE_AND_COUNTRY_CODE);
     }
   }
 

--- a/src/utils/validateInputWithRegex.test.tsx
+++ b/src/utils/validateInputWithRegex.test.tsx
@@ -27,7 +27,7 @@ describe("throw EnvVersionError", () => {
       validateAndCleanRegexInput("100000001", undefinedRegex)
     ).toThrow(
       new EnvVersionError(
-        "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+        "We are currently facing connectivity issues. Try again later or contact your in-charge if the problem persists."
       )
     );
   });

--- a/src/utils/validateInputWithRegex.ts
+++ b/src/utils/validateInputWithRegex.ts
@@ -10,7 +10,7 @@ export const validateAndCleanRegexInput = (
 ): string => {
   if (!idRegex)
     throw new EnvVersionError(
-      "Encountered an issue obtaining environment information. We've noted this down and are looking into it!"
+      "We are currently facing connectivity issues. Try again later or contact your in-charge if the problem persists."
     );
   // set ID to all uppercase to remove case sensitivity
   const id = inputId.toUpperCase();


### PR DESCRIPTION
- [x] phone number and country code identifier input to throw generic error `Enter valid contact number and country code.`

- [x] for Login QR codes, ensure wrong formatting (i.e. SyntaxError) is handled with alert `Scan QR code again or get a new QR code from your in-charge.` instead of throwing to `ErrorBoundary`

- [x] add warning alert for appeal flow before checking out chargeable pod