### PR TITLE
feat: show all past transactions on limit reached screen

### DIFF
--- a/.github/workflows/deploy_branch_preview.yml
+++ b/.github/workflows/deploy_branch_preview.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check Lint
         run: npm run lint
       - name: Set Timezone to +8 (Ubuntu)
-        run: sudo timedatectl set-timezone Asia/Shanghai
+        run: sudo timedatectl set-timezone Asia/Singapore
       - name: Test
         run: npm run test -- --coverage
   deploy_branch_preview:

--- a/.github/workflows/deploy_branch_preview.yml
+++ b/.github/workflows/deploy_branch_preview.yml
@@ -29,6 +29,8 @@ jobs:
         run: npx --no-install tsc --noEmit
       - name: Check Lint
         run: npm run lint
+      - name: Set Timezone to +8 (Ubuntu)
+        run: sudo timedatectl set-timezone Asia/Shanghai
       - name: Test
         run: npm run test -- --coverage
   deploy_branch_preview:

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check Lint
         run: npm run lint
       - name: Set Timezone to +8 (Ubuntu)
-        run: sudo timedatectl set-timezone Asia/Shanghai
+        run: sudo timedatectl set-timezone Asia/Singapore
       - name: Test
         run: npm run test -- --coverage
   deploy_prod:

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -19,6 +19,8 @@ jobs:
         run: npx --no-install tsc --noEmit
       - name: Check Lint
         run: npm run lint
+      - name: Set Timezone to +8 (Ubuntu)
+        run: sudo timedatectl set-timezone Asia/Shanghai
       - name: Test
         run: npm run test -- --coverage
   deploy_prod:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -32,6 +32,8 @@ jobs:
         run: npx --no-install tsc --noEmit
       - name: Check Lint
         run: npm run lint
+      - name: Set Timezone to +8 (Ubuntu)
+        run: sudo timedatectl set-timezone Asia/Shanghai
       - name: Test
         run: npm run test -- --coverage
   deploy_staging:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check Lint
         run: npm run lint
       - name: Set Timezone to +8 (Ubuntu)
-        run: sudo timedatectl set-timezone Asia/Shanghai
+        run: sudo timedatectl set-timezone Asia/Singapore
       - name: Test
         run: npm run test -- --coverage
   deploy_staging:

--- a/.github/workflows/test_development_environment.yml
+++ b/.github/workflows/test_development_environment.yml
@@ -35,10 +35,10 @@ jobs:
         run: npm run lint
       - name: Set Timezone to +8 (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
-        run: sudo timedatectl set-timezone Asia/Shanghai
+        run: sudo timedatectl set-timezone Asia/Singapore
       - name: Set Timezone to +8 (MacOS)
         if: startsWith(matrix.os, 'macOS')
-        run: sudo systemsetup -settimezone Asia/Shanghai
+        run: sudo systemsetup -settimezone Asia/Singapore
       - name: Set Timezone to +8 (Windows)
         if: startsWith(matrix.os, 'windows')
         run: tzutil /s "Singapore Standard Time"

--- a/.github/workflows/test_development_environment.yml
+++ b/.github/workflows/test_development_environment.yml
@@ -33,5 +33,14 @@ jobs:
         run: npx --no-install tsc --noEmit
       - name: Check Lint
         run: npm run lint
+      - name: Set Timezone to +8 (Ubuntu)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: sudo timedatectl set-timezone Asia/Shanghai
+      - name: Set Timezone to +8 (MacOS)
+        if: startsWith(matrix.os, 'macOS')
+        run: sudo systemsetup -settimezone Asia/Shanghai
+      - name: Set Timezone to +8 (Windows)
+        if: startsWith(matrix.os, 'windows')
+        run: tzutil /s "Singapore Standard Time"
       - name: Test
         run: npm run test -- --coverage

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -15,7 +15,7 @@ import { TopBackground } from "../Layout/TopBackground";
 import { useConfigContext } from "../../context/config";
 import { Card } from "../Layout/Card";
 import { ItemsSelectionCard } from "./ItemsSelection/ItemsSelectionCard";
-import { NoQuotaCard } from "./NoQuotaCard";
+import { NoQuotaCard } from "./NoQuota/NoQuotaCard";
 import { CheckoutSuccessCard } from "./CheckoutSuccess/CheckoutSuccessCard";
 import { useCart } from "../../hooks/useCart/useCart";
 import { Sentry } from "../../utils/errorTracking";

--- a/src/components/CustomerQuota/ItemsSelection/ItemMaxUnitLabel.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemMaxUnitLabel.tsx
@@ -1,14 +1,10 @@
 import React, { FunctionComponent } from "react";
 import { CampaignPolicy } from "../../../types";
+import { formatQuantityText } from "../utils";
 
 export const ItemMaxUnitLabel: FunctionComponent<{
   unit: CampaignPolicy["quantity"]["unit"];
   maxQuantity: number;
 }> = ({ unit, maxQuantity }) => {
-  const maxUnit = unit
-    ? unit?.type === "PREFIX"
-      ? `${unit.label}${maxQuantity}`
-      : `${maxQuantity}${unit.label}`
-    : maxQuantity;
-  return <>max {maxUnit}</>;
+  return <>max {formatQuantityText(maxQuantity, unit)}</>;
 };

--- a/src/components/CustomerQuota/NoQuota/AppealButton.tsx
+++ b/src/components/CustomerQuota/NoQuota/AppealButton.tsx
@@ -1,0 +1,16 @@
+import React, { FunctionComponent } from "react";
+import { View, TouchableOpacity } from "react-native";
+import { AppText } from "../../Layout/AppText";
+import { styles } from "./styles";
+
+export const AppealButton: FunctionComponent<{
+  onAppeal: () => void;
+}> = ({ onAppeal }) => {
+  return (
+    <TouchableOpacity onPress={onAppeal}>
+      <View style={{ alignItems: "center" }}>
+        <AppText style={styles.appealButtonText}>Raise an appeal</AppText>
+      </View>
+    </TouchableOpacity>
+  );
+};

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.test.ts
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.test.ts
@@ -1,6 +1,6 @@
 import { toDate } from "date-fns";
-import { defaultIdentifier } from "../../../test/helpers/wrapper";
-import { Policy, PastTransactionsResult } from "../../../types";
+import { defaultIdentifier } from "../../../test/helpers/defaults";
+import { PastTransactionsResult, CampaignPolicy } from "../../../types";
 import {
   groupTransactionsByCategory,
   sortTransactions,
@@ -9,7 +9,7 @@ import {
 
 describe("NoQuotaCard utility functions", () => {
   let sortedTransactions: PastTransactionsResult["pastTransactions"];
-  let allProducts: Policy[];
+  let allProducts: CampaignPolicy[];
   let mockTransactionsByCategoryMap: TransactionsByCategoryMap;
 
   const latestTransactionTimeMs = 1596530350000;

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.test.ts
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.test.ts
@@ -1,0 +1,209 @@
+import { toDate } from "date-fns";
+import { defaultIdentifier } from "../../../test/helpers/wrapper";
+import { Policy, PastTransactionsResult } from "../../../types";
+import {
+  groupTransactionsByCategory,
+  sortTransactions,
+  TransactionsByCategoryMap
+} from "./NoQuotaCard";
+
+describe("NoQuotaCard utility functions", () => {
+  let sortedTransactions: PastTransactionsResult["pastTransactions"];
+  let allProducts: Policy[];
+  let mockTransactionsByCategoryMap: TransactionsByCategoryMap;
+
+  const latestTransactionTimeMs = 1596530350000;
+  const latestTransactionTime = toDate(latestTransactionTimeMs);
+
+  beforeAll(() => {
+    sortedTransactions = [
+      {
+        category: "tt-token",
+        quantity: 1,
+        identifierInputs: [
+          {
+            ...defaultIdentifier,
+            label: "Device code",
+            value: "AAA987654321"
+          }
+        ],
+        transactionTime: latestTransactionTime
+      },
+      {
+        category: "meal-credits",
+        quantity: 10,
+        transactionTime: latestTransactionTime
+      },
+      {
+        category: "vouchers",
+        quantity: 1,
+        identifierInputs: [
+          {
+            ...defaultIdentifier,
+            label: "Voucher code",
+            value: "AAA987654322"
+          }
+        ],
+        transactionTime: toDate(latestTransactionTimeMs - 10000)
+      },
+      {
+        category: "meal-credits",
+        quantity: 5,
+        transactionTime: toDate(latestTransactionTimeMs - 20000)
+      }
+    ];
+    allProducts = [
+      {
+        category: "tt-token",
+        name: "TT token",
+        order: 0,
+        quantity: { period: 1, limit: 1 },
+        identifiers: [
+          {
+            label: "Device code",
+            textInput: { disabled: true, visible: true, type: "STRING" },
+            scanButton: { disabled: false, visible: true, type: "QR" }
+          }
+        ]
+      },
+      {
+        category: "vouchers",
+        name: "CDC Vouchers",
+        order: 0,
+        quantity: {
+          period: 1,
+          limit: 1,
+          unit: { type: "POSTFIX", label: " book" }
+        },
+        identifiers: [
+          {
+            label: "Voucher code",
+            textInput: { disabled: false, visible: true, type: "STRING" },
+            scanButton: { disabled: false, visible: true, type: "BARCODE" }
+          }
+        ]
+      },
+      {
+        category: "meal-credits",
+        name: "Meal credits",
+        order: 0,
+        quantity: { period: 1, limit: 20, unit: { type: "PREFIX", label: "$" } }
+      }
+    ];
+
+    mockTransactionsByCategoryMap = {
+      "TT token": {
+        transactions: [
+          {
+            transactionDate: "4 Aug 2020, 4:39PM",
+            details: "AAA987654321",
+            quantity: "1 qty",
+            isAppeal: false
+          }
+        ],
+        hasLatestTransaction: true
+      },
+      "Meal credits": {
+        transactions: [
+          {
+            transactionDate: "4 Aug 2020, 4:39PM",
+            details: "",
+            quantity: "$10",
+            isAppeal: false
+          },
+          {
+            transactionDate: "4 Aug 2020, 4:38PM",
+            details: "",
+            quantity: "$5",
+            isAppeal: false
+          }
+        ],
+        hasLatestTransaction: true
+      },
+      "CDC Vouchers": {
+        transactions: [
+          {
+            transactionDate: "4 Aug 2020, 4:39PM",
+            details: "AAA987654322",
+            quantity: "1 book",
+            isAppeal: false
+          }
+        ],
+        hasLatestTransaction: false
+      }
+    };
+  });
+
+  describe("groupTransactionsByCategory", () => {
+    it("should return categories with latest transactions and other categories", () => {
+      expect.assertions(1);
+
+      expect(
+        groupTransactionsByCategory(
+          sortedTransactions,
+          allProducts,
+          latestTransactionTime
+        )
+      ).toStrictEqual(mockTransactionsByCategoryMap);
+    });
+
+    it("should return empty object if sortedTransactions is null", () => {
+      expect.assertions(1);
+
+      expect(
+        groupTransactionsByCategory(null, allProducts, undefined)
+      ).toStrictEqual({});
+    });
+  });
+
+  describe("sortTransactions", () => {
+    it("should return array of transactions by category, categories with latest transactions should be before the rest", () => {
+      expect.assertions(1);
+      expect(sortTransactions(mockTransactionsByCategoryMap)).toStrictEqual([
+        {
+          category: "Meal credits",
+          transactions: [
+            {
+              transactionDate: "4 Aug 2020, 4:39PM",
+              details: "",
+              quantity: "$10",
+              isAppeal: false,
+              order: 0
+            },
+            {
+              transactionDate: "4 Aug 2020, 4:38PM",
+              details: "",
+              quantity: "$5",
+              isAppeal: false,
+              order: 1
+            }
+          ]
+        },
+        {
+          category: "TT token",
+          transactions: [
+            {
+              transactionDate: "4 Aug 2020, 4:39PM",
+              details: "AAA987654321",
+              quantity: "1 qty",
+              isAppeal: false,
+              order: 2
+            }
+          ]
+        },
+        {
+          category: "CDC Vouchers",
+          transactions: [
+            {
+              transactionDate: "4 Aug 2020, 4:39PM",
+              details: "AAA987654322",
+              quantity: "1 book",
+              isAppeal: false,
+              order: 3
+            }
+          ]
+        }
+      ]);
+    });
+  });
+});

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.test.ts
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.test.ts
@@ -1,4 +1,3 @@
-import { toDate } from "date-fns";
 import { defaultIdentifier } from "../../../test/helpers/defaults";
 import { PastTransactionsResult, CampaignPolicy } from "../../../types";
 import {
@@ -13,7 +12,7 @@ describe("NoQuotaCard utility functions", () => {
   let mockTransactionsByCategoryMap: TransactionsByCategoryMap;
 
   const latestTransactionTimeMs = 1596530350000;
-  const latestTransactionTime = toDate(latestTransactionTimeMs);
+  const latestTransactionTime = new Date(latestTransactionTimeMs);
 
   beforeAll(() => {
     sortedTransactions = [
@@ -44,12 +43,12 @@ describe("NoQuotaCard utility functions", () => {
             value: "AAA987654322"
           }
         ],
-        transactionTime: toDate(latestTransactionTimeMs - 10000)
+        transactionTime: new Date(latestTransactionTimeMs - 10000)
       },
       {
         category: "meal-credits",
         quantity: 5,
-        transactionTime: toDate(latestTransactionTimeMs - 20000)
+        transactionTime: new Date(latestTransactionTimeMs - 20000)
       }
     ];
     allProducts = [

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.test.ts
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.test.ts
@@ -54,9 +54,15 @@ describe("NoQuotaCard utility functions", () => {
     ];
     allProducts = [
       {
+        category: "meal-credits",
+        name: "Meal credits",
+        order: 0,
+        quantity: { period: 1, limit: 20, unit: { type: "PREFIX", label: "$" } }
+      },
+      {
         category: "tt-token",
         name: "TT token",
-        order: 0,
+        order: 1,
         quantity: { period: 1, limit: 1 },
         identifiers: [
           {
@@ -69,7 +75,7 @@ describe("NoQuotaCard utility functions", () => {
       {
         category: "vouchers",
         name: "CDC Vouchers",
-        order: 0,
+        order: 2,
         quantity: {
           period: 1,
           limit: 1,
@@ -82,12 +88,6 @@ describe("NoQuotaCard utility functions", () => {
             scanButton: { disabled: false, visible: true, type: "BARCODE" }
           }
         ]
-      },
-      {
-        category: "meal-credits",
-        name: "Meal credits",
-        order: 0,
-        quantity: { period: 1, limit: 20, unit: { type: "PREFIX", label: "$" } }
       }
     ];
 
@@ -101,7 +101,8 @@ describe("NoQuotaCard utility functions", () => {
             isAppeal: false
           }
         ],
-        hasLatestTransaction: true
+        hasLatestTransaction: true,
+        order: 1
       },
       "Meal credits": {
         transactions: [
@@ -118,7 +119,8 @@ describe("NoQuotaCard utility functions", () => {
             isAppeal: false
           }
         ],
-        hasLatestTransaction: true
+        hasLatestTransaction: true,
+        order: 0
       },
       "CDC Vouchers": {
         transactions: [
@@ -129,7 +131,8 @@ describe("NoQuotaCard utility functions", () => {
             isAppeal: false
           }
         ],
-        hasLatestTransaction: false
+        hasLatestTransaction: false,
+        order: 2
       }
     };
   });
@@ -177,7 +180,8 @@ describe("NoQuotaCard utility functions", () => {
               isAppeal: false,
               order: 1
             }
-          ]
+          ],
+          order: 0
         },
         {
           category: "TT token",
@@ -189,7 +193,8 @@ describe("NoQuotaCard utility functions", () => {
               isAppeal: false,
               order: 2
             }
-          ]
+          ],
+          order: 1
         },
         {
           category: "CDC Vouchers",
@@ -201,7 +206,8 @@ describe("NoQuotaCard utility functions", () => {
               isAppeal: false,
               order: 3
             }
-          ]
+          ],
+          order: 2
         }
       ]);
     });

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -212,70 +212,69 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
   return (
     <View>
       <CustomerCard ids={ids} headerBackgroundColor={color("red", 60)}>
-        <View
-          style={[
-            sharedStyles.resultWrapper,
-            sharedStyles.failureResultWrapper
-          ]}
-        >
-          <FontAwesome
-            name="thumbs-down"
-            color={color("red", 60)}
-            style={sharedStyles.icon}
-          />
-          <AppText style={sharedStyles.statusTitleWrapper}>
-            {secondsFromLatestTransaction > 0 ? (
-              secondsFromLatestTransaction > DURATION_THRESHOLD_SECONDS ? (
-                <DistantTransactionTitle
-                  transactionTime={latestTransactionTime!}
-                  toggleTimeSensitiveTitle={showGlobalQuota}
-                />
-              ) : (
-                <RecentTransactionTitle
-                  now={now}
-                  transactionTime={latestTransactionTime!}
-                  toggleTimeSensitiveTitle={showGlobalQuota}
-                />
-              )
-            ) : (
-              <NoPreviousTransactionTitle
-                toggleTimeSensitiveTitle={showGlobalQuota}
-              />
-            )}
-            {showGlobalQuota &&
-              quotaResponse!.globalQuota!.map(
-                ({ quantity, quotaRefreshTime }, index: number) =>
-                  quotaRefreshTime ? (
-                    <UsageQuotaTitle
-                      key={index}
-                      quantity={quantity}
-                      quotaRefreshTime={quotaRefreshTime}
-                    />
-                  ) : undefined
-              )}
-          </AppText>
-          {transactionsByCategoryList.length > 0 && (
-            <View>
-              <AppText style={styles.wrapper}>
-                Item(s) {policyType === "REDEEM" ? "redeemed" : "purchased"}{" "}
-                previously:
-              </AppText>
-              {transactionsByCategoryList.map(
-                (
-                  transactionsByCategory: TransactionsByCategory,
-                  index: number
-                ) => (
-                  <TransactionsByCategory
-                    key={index}
-                    maxTransactionsToDisplay={
-                      isShowFullList ? BIG_NUMBER : MAX_TRANSACTIONS_TO_DISPLAY
-                    }
-                    {...transactionsByCategory}
+        <View style={sharedStyles.failureResultWrapper}>
+          <View style={sharedStyles.resultWrapper}>
+            <FontAwesome
+              name="thumbs-down"
+              color={color("red", 60)}
+              style={sharedStyles.icon}
+            />
+            <AppText style={sharedStyles.statusTitleWrapper}>
+              {secondsFromLatestTransaction > 0 ? (
+                secondsFromLatestTransaction > DURATION_THRESHOLD_SECONDS ? (
+                  <DistantTransactionTitle
+                    transactionTime={latestTransactionTime!}
+                    toggleTimeSensitiveTitle={showGlobalQuota}
+                  />
+                ) : (
+                  <RecentTransactionTitle
+                    now={now}
+                    transactionTime={latestTransactionTime!}
+                    toggleTimeSensitiveTitle={showGlobalQuota}
                   />
                 )
+              ) : (
+                <NoPreviousTransactionTitle
+                  toggleTimeSensitiveTitle={showGlobalQuota}
+                />
               )}
-            </View>
-          )}
+              {showGlobalQuota &&
+                quotaResponse!.globalQuota!.map(
+                  ({ quantity, quotaRefreshTime }, index: number) =>
+                    quotaRefreshTime ? (
+                      <UsageQuotaTitle
+                        key={index}
+                        quantity={quantity}
+                        quotaRefreshTime={quotaRefreshTime}
+                      />
+                    ) : undefined
+                )}
+            </AppText>
+            {transactionsByCategoryList.length > 0 && (
+              <View>
+                <AppText style={styles.wrapper}>
+                  Item(s) {policyType === "REDEEM" ? "redeemed" : "purchased"}{" "}
+                  previously:
+                </AppText>
+                {transactionsByCategoryList.map(
+                  (
+                    transactionsByCategory: TransactionsByCategory,
+                    index: number
+                  ) => (
+                    <TransactionsByCategory
+                      key={index}
+                      maxTransactionsToDisplay={
+                        isShowFullList
+                          ? BIG_NUMBER
+                          : MAX_TRANSACTIONS_TO_DISPLAY
+                      }
+                      {...transactionsByCategory}
+                    />
+                  )
+                )}
+              </View>
+            )}
+          </View>
           {sortedTransactions &&
             sortedTransactions.length > MAX_TRANSACTIONS_TO_DISPLAY && (
               <ShowFullListToggle

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -77,7 +77,7 @@ export const groupTransactionsByCategory = (
     const categoryName = policy?.name ?? item.category;
     const formattedDate = format(item.transactionTime, "d MMM yyyy, h:mma");
 
-    if (!(categoryName in transactionsByCategoryMap)) {
+    if (!transactionsByCategoryMap.hasOwnProperty(categoryName)) {
       transactionsByCategoryMap[categoryName] = {
         transactions: [],
         hasLatestTransaction: false,

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent, useContext, useState } from "react";
+import React, {
+  FunctionComponent,
+  useState,
+  useContext,
+  useEffect
+} from "react";
 import { differenceInSeconds, format } from "date-fns";
 import { View } from "react-native";
 import { CustomerCard } from "../CustomerCard";
@@ -24,6 +29,7 @@ import { CampaignConfigContext } from "../../../context/campaignConfig";
 import { ProductContext } from "../../../context/products";
 import { AuthContext } from "../../../context/auth";
 import { Quota, PastTransactionsResult } from "../../../types";
+import { AlertModalContext, systemAlertProps } from "../../../context/alert";
 
 const DURATION_THRESHOLD_SECONDS = 60 * 10; // 10 minutes
 const MAX_TRANSACTIONS_TO_DISPLAY = 5;
@@ -155,9 +161,19 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
   const { sessionToken, endpoint } = useContext(AuthContext);
   const policyType = cart.length > 0 && getProduct(cart[0].category)?.type;
 
-  const { pastTransactionsResult } = usePastTransaction(ids, sessionToken, endpoint);
+  const { pastTransactionsResult, error } = usePastTransaction(ids, sessionToken, endpoint);
   // Assumes results are already sorted (valid assumption for results from /transactions/history)
   const sortedTransactions = pastTransactionsResult;
+
+  const { showAlert } = useContext(AlertModalContext);
+  useEffect(() => {
+    if (error) {
+      showAlert({
+        ...systemAlertProps,
+        description: error.message || ""
+      });
+    }
+  }, [error, showAlert]);
 
   const latestTransactionTime: Date | undefined =
     sortedTransactions?.[0].transactionTime ?? undefined;

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -102,9 +102,9 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
       quantity: formatQuantityText(
         item.quantity,
         policy?.quantity.unit || { type: "POSTFIX", label: " qty" }
-      )
+      ),
+      isAppeal: policy?.categoryType === "APPEAL"
     });
-    // TODO: check if seconds is good, or need to change to minutes
     transactionsByCategoryMap[categoryName].hasLatestTransaction =
       transactionsByCategoryMap[categoryName].hasLatestTransaction ||
       differenceInSeconds(latestTransactionTime || 0, item.transactionTime) ===

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -22,7 +22,8 @@ import { ShowFullListToggle } from "./ShowFullListToggle";
 import {
   DistantTransactionTitle,
   RecentTransactionTitle,
-  NoPreviousTransactionTitle
+  NoPreviousTransactionTitle,
+  UsageQuotaTitle
 } from "./TransactionTitle";
 import { AppealButton } from "./AppealButton";
 import { CampaignConfigContext } from "../../../context/campaignConfig";
@@ -156,7 +157,8 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
   ids,
   cart,
   onCancel,
-  onAppeal
+  onAppeal,
+  quotaResponse
 }) => {
   const [isShowFullList, setIsShowFullList] = useState<boolean>(false);
   const { policies: allProducts } = useContext(CampaignConfigContext);

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -29,7 +29,7 @@ import { AppealButton } from "./AppealButton";
 import { CampaignConfigContext } from "../../../context/campaignConfig";
 import { ProductContext } from "../../../context/products";
 import { AuthContext } from "../../../context/auth";
-import { Quota, PastTransactionsResult } from "../../../types";
+import { Quota, PastTransactionsResult, CampaignPolicy } from "../../../types";
 import { AlertModalContext, systemAlertProps } from "../../../context/alert";
 
 const DURATION_THRESHOLD_SECONDS = 60 * 10; // 10 minutes
@@ -66,7 +66,7 @@ const sortTransactionsByOrder = (
  */
 export const groupTransactionsByCategory = (
   sortedTransactions: PastTransactionsResult["pastTransactions"] | null,
-  allProducts: Policy[],
+  allProducts: CampaignPolicy[],
   latestTransactionTime: Date | undefined
 ): TransactionsByCategoryMap => {
   const transactionsByCategoryMap: TransactionsByCategoryMap = {};
@@ -166,7 +166,11 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
   const { sessionToken, endpoint } = useContext(AuthContext);
   const policyType = cart.length > 0 && getProduct(cart[0].category)?.type;
 
-  const { pastTransactionsResult, error } = usePastTransaction(ids, sessionToken, endpoint);
+  const { pastTransactionsResult, error } = usePastTransaction(
+    ids,
+    sessionToken,
+    endpoint
+  );
   // Assumes results are already sorted (valid assumption for results from /transactions/history)
   const sortedTransactions = pastTransactionsResult;
 
@@ -187,9 +191,8 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
     ? differenceInSeconds(now, latestTransactionTime)
     : -1;
 
-  const hasAppealProduct = allProducts?.some(
-    policy => policy.categoryType === "APPEAL"
-  ) ?? false;
+  const hasAppealProduct =
+    allProducts?.some(policy => policy.categoryType === "APPEAL") ?? false;
 
   const transactionsByCategoryMap = groupTransactionsByCategory(
     sortedTransactions,

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -1,7 +1,15 @@
 import React, { FunctionComponent, useContext, useState } from "react";
 import { differenceInSeconds, format } from "date-fns";
 import { View } from "react-native";
-import { FontAwesome, Ionicons } from "@expo/vector-icons";
+import { CustomerCard } from "../CustomerCard";
+import { AppText } from "../../Layout/AppText";
+import { color } from "../../../common/styles";
+import { sharedStyles } from "../sharedStyles";
+import { DarkButton } from "../../Layout/Buttons/DarkButton";
+import { Cart } from "../../../hooks/useCart/useCart";
+import { getAllIdentifierInputDisplay } from "../../../utils/getIdentifierInputDisplay";
+import { usePastTransaction } from "../../../hooks/usePastTransaction/usePastTransaction";
+import { FontAwesome } from "@expo/vector-icons";
 import { formatQuantityText } from "../utils";
 import { styles } from "./styles";
 import { TransactionsByCategory, Transaction } from "./TransactionsByCategory";
@@ -13,18 +21,9 @@ import {
 } from "./TransactionTitle";
 import { AppealButton } from "./AppealButton";
 import { Quota } from "../../../types";
-import { Cart } from "../../../hooks/useCart/useCart";
 import { CampaignConfigContext } from "../../../context/campaignConfig";
 import { ProductContext } from "../../../context/products";
 import { AuthContext } from "../../../context/auth";
-import { usePastTransaction } from "../../../hooks/usePastTransaction/usePastTransaction";
-import { getAllIdentifierInputDisplay } from "../../../utils/getIdentifierInputDisplay";
-import { CustomerCard } from "../CustomerCard";
-import { color } from "react-native-reanimated";
-import { sharedStyles } from "../sharedStyles";
-import { AppText } from "../../Layout/AppText";
-import { size } from "fp-ts/lib/ReadonlyRecord";
-import { DarkButton } from "../../Layout/Buttons/DarkButton";
 
 const DURATION_THRESHOLD_SECONDS = 60 * 10; // 10 minutes
 const MAX_TRANSACTIONS_TO_DISPLAY = 5;
@@ -225,19 +224,8 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
           )}
           {transactionCounter > MAX_TRANSACTIONS_TO_DISPLAY && (
             <ShowFullListToggle
-              onClick={() => setIsShowFullList(!isShowFullList)}
-              displayText={isShowFullList ? "Show less" : "Show more"}
-              icon={
-                <Ionicons
-                  name={
-                    isShowFullList
-                      ? "ios-arrow-dropup-circle"
-                      : "ios-arrow-dropdown-circle"
-                  }
-                  size={size(4)}
-                  color={color("blue", 50)}
-                />
-              }
+              toggleIsShowFullList={() => setIsShowFullList(!isShowFullList)}
+              isShowFullList={isShowFullList}
             />
           )}
         </View>

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -60,7 +60,7 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
     endpoint
   );
   // Assumes results are already sorted (valid assumption for results from /transactions/history)
-  const sortedTransactions = pastTransactionsResult?.pastTransactions;
+  const sortedTransactions = pastTransactionsResult;
 
   const latestTransactionTime: Date | undefined =
     sortedTransactions?.[0].transactionTime ?? undefined;

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -69,11 +69,9 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
     ? differenceInSeconds(now, latestTransactionTime)
     : -1;
 
-  const hasAppealProduct = (): boolean => {
-    return (
-      allProducts?.some(policy => policy.categoryType === "APPEAL") ?? false
-    );
-  };
+  const hasAppealProduct = allProducts?.some(
+    policy => policy.categoryType === "APPEAL"
+  ) ?? false;
 
   // Group transactions by category
   const transactionsByCategoryMap: {
@@ -233,7 +231,7 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
       <View style={sharedStyles.ctaButtonsWrapper}>
         <DarkButton text="Next identity" onPress={onCancel} fullWidth={true} />
       </View>
-      {onAppeal && hasAppealProduct() ? (
+      {onAppeal && hasAppealProduct ? (
         <AppealButton onAppeal={onAppeal} />
       ) : undefined}
     </View>

--- a/src/components/CustomerQuota/NoQuota/ShowFullListToggle.tsx
+++ b/src/components/CustomerQuota/NoQuota/ShowFullListToggle.tsx
@@ -1,14 +1,14 @@
 import React, { FunctionComponent } from "react";
 import { View, TouchableOpacity } from "react-native";
 import { AppText } from "../../Layout/AppText";
-import { size } from "../../../common/styles";
+import { size, color } from "../../../common/styles";
 import { styles } from "./styles";
+import { Ionicons } from "@expo/vector-icons";
 
 export const ShowFullListToggle: FunctionComponent<{
-  onClick: () => void;
-  displayText: string;
-  icon: any;
-}> = ({ onClick, displayText, icon }) => (
+  toggleIsShowFullList: () => void;
+  isShowFullList: boolean;
+}> = ({ toggleIsShowFullList, isShowFullList }) => (
   <View
     style={{
       display: "flex",
@@ -19,13 +19,23 @@ export const ShowFullListToggle: FunctionComponent<{
     }}
   >
     <TouchableOpacity
-      onPress={onClick}
+      onPress={toggleIsShowFullList}
       style={styles.showFullListToggleWrapper}
     >
       <View style={styles.showFullListToggleBorder} />
-      {icon}
+      <Ionicons
+        name={
+          isShowFullList
+            ? "ios-arrow-dropup-circle"
+            : "ios-arrow-dropdown-circle"
+        }
+        size={size(4)}
+        color={color("blue", 50)}
+      />
       <View style={styles.showFullListToggleBorder} />
     </TouchableOpacity>
-    <AppText style={styles.itemHeader}>{displayText}</AppText>
+    <AppText style={styles.itemHeader}>{`Show ${
+      isShowFullList ? "less" : "more"
+    }`}</AppText>
   </View>
 );

--- a/src/components/CustomerQuota/NoQuota/ShowFullListToggle.tsx
+++ b/src/components/CustomerQuota/NoQuota/ShowFullListToggle.tsx
@@ -13,29 +13,30 @@ export const ShowFullListToggle: FunctionComponent<{
     style={{
       display: "flex",
       justifyContent: "center",
-      alignItems: "center",
       marginTop: size(2),
       marginBottom: size(2)
     }}
   >
     <TouchableOpacity
       onPress={toggleIsShowFullList}
-      style={styles.showFullListToggleWrapper}
+      style={{ alignItems: "center" }}
     >
-      <View style={styles.showFullListToggleBorder} />
-      <Ionicons
-        name={
-          isShowFullList
-            ? "ios-arrow-dropup-circle"
-            : "ios-arrow-dropdown-circle"
-        }
-        size={size(4)}
-        color={color("blue", 50)}
-      />
-      <View style={styles.showFullListToggleBorder} />
+      <View style={styles.showFullListToggleWrapper}>
+        <View style={styles.showFullListToggleBorder} />
+        <Ionicons
+          name={
+            isShowFullList
+              ? "ios-arrow-dropup-circle"
+              : "ios-arrow-dropdown-circle"
+          }
+          size={size(4)}
+          color={color("blue", 50)}
+        />
+        <View style={styles.showFullListToggleBorder} />
+      </View>
+      <AppText style={styles.itemHeader}>{`Show ${
+        isShowFullList ? "less" : "more"
+      }`}</AppText>
     </TouchableOpacity>
-    <AppText style={styles.itemHeader}>{`Show ${
-      isShowFullList ? "less" : "more"
-    }`}</AppText>
   </View>
 );

--- a/src/components/CustomerQuota/NoQuota/ShowFullListToggle.tsx
+++ b/src/components/CustomerQuota/NoQuota/ShowFullListToggle.tsx
@@ -1,0 +1,31 @@
+import React, { FunctionComponent } from "react";
+import { View, TouchableOpacity } from "react-native";
+import { AppText } from "../../Layout/AppText";
+import { size } from "../../../common/styles";
+import { styles } from "./styles";
+
+export const ShowFullListToggle: FunctionComponent<{
+  onClick: () => void;
+  displayText: string;
+  icon: any;
+}> = ({ onClick, displayText, icon }) => (
+  <View
+    style={{
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+      marginTop: size(2),
+      marginBottom: size(2)
+    }}
+  >
+    <TouchableOpacity
+      onPress={onClick}
+      style={styles.showFullListToggleWrapper}
+    >
+      <View style={styles.showFullListToggleBorder} />
+      {icon}
+      <View style={styles.showFullListToggleBorder} />
+    </TouchableOpacity>
+    <AppText style={styles.itemHeader}>{displayText}</AppText>
+  </View>
+);

--- a/src/components/CustomerQuota/NoQuota/TransactionTitle.tsx
+++ b/src/components/CustomerQuota/NoQuota/TransactionTitle.tsx
@@ -1,0 +1,32 @@
+import React, { FunctionComponent } from "react";
+import { format, formatDistance } from "date-fns";
+import { AppText } from "../../Layout/AppText";
+import { sharedStyles } from "../sharedStyles";
+
+export const DistantTransactionTitle: FunctionComponent<{
+  transactionTime: Date;
+}> = ({ transactionTime }) => (
+  <>
+    <AppText style={sharedStyles.statusTitle}>Limit reached on </AppText>
+    <AppText style={sharedStyles.statusTitle}>
+      {format(transactionTime, "d MMM yyyy, h:mma")}.
+    </AppText>
+  </>
+);
+
+export const RecentTransactionTitle: FunctionComponent<{
+  now: Date;
+  transactionTime: Date;
+}> = ({ now, transactionTime }) => (
+  <>
+    <AppText style={sharedStyles.statusTitle}>Limit reached </AppText>
+    <AppText style={sharedStyles.statusTitle}>
+      {formatDistance(now, transactionTime)}
+    </AppText>
+    <AppText style={sharedStyles.statusTitle}> ago.</AppText>
+  </>
+);
+
+export const NoPreviousTransactionTitle: FunctionComponent = () => (
+  <AppText style={sharedStyles.statusTitle}>Limit reached.</AppText>
+);

--- a/src/components/CustomerQuota/NoQuota/TransactionTitle.tsx
+++ b/src/components/CustomerQuota/NoQuota/TransactionTitle.tsx
@@ -5,28 +5,61 @@ import { sharedStyles } from "../sharedStyles";
 
 export const DistantTransactionTitle: FunctionComponent<{
   transactionTime: Date;
-}> = ({ transactionTime }) => (
+  toggleTimeSensitiveTitle: boolean;
+}> = ({ transactionTime, toggleTimeSensitiveTitle }) => (
   <>
     <AppText style={sharedStyles.statusTitle}>Limit reached on </AppText>
     <AppText style={sharedStyles.statusTitle}>
-      {format(transactionTime, "d MMM yyyy, h:mma")}.
+      {format(transactionTime, "d MMM yyyy, h:mma")}
     </AppText>
+    {toggleTimeSensitiveTitle ? (
+      <AppText style={sharedStyles.statusTitle}> for today.</AppText>
+    ) : (
+      <AppText style={sharedStyles.statusTitle}>.</AppText>
+    )}
   </>
 );
 
 export const RecentTransactionTitle: FunctionComponent<{
   now: Date;
   transactionTime: Date;
-}> = ({ now, transactionTime }) => (
+  toggleTimeSensitiveTitle: boolean;
+}> = ({ now, transactionTime, toggleTimeSensitiveTitle }) => (
   <>
     <AppText style={sharedStyles.statusTitle}>Limit reached </AppText>
     <AppText style={sharedStyles.statusTitle}>
       {formatDistance(now, transactionTime)}
     </AppText>
-    <AppText style={sharedStyles.statusTitle}> ago.</AppText>
+    <AppText style={sharedStyles.statusTitle}> ago</AppText>
+    {toggleTimeSensitiveTitle ? (
+      <AppText style={sharedStyles.statusTitle}> for today.</AppText>
+    ) : (
+      <AppText style={sharedStyles.statusTitle}>.</AppText>
+    )}
   </>
 );
 
-export const NoPreviousTransactionTitle: FunctionComponent = () => (
-  <AppText style={sharedStyles.statusTitle}>Limit reached.</AppText>
+export const NoPreviousTransactionTitle: FunctionComponent<{
+  toggleTimeSensitiveTitle: boolean;
+}> = ({ toggleTimeSensitiveTitle }) => (
+  <>
+    <AppText style={sharedStyles.statusTitle}>Limit reached</AppText>
+    {toggleTimeSensitiveTitle ? (
+      <AppText style={sharedStyles.statusTitle}> for today.</AppText>
+    ) : (
+      <AppText style={sharedStyles.statusTitle}>.</AppText>
+    )}
+  </>
+);
+
+export const UsageQuotaTitle: FunctionComponent<{
+  quantity: number;
+  quotaRefreshTime: number;
+}> = ({ quantity, quotaRefreshTime }) => (
+  <>
+    <AppText style={sharedStyles.statusTitle}>
+      {"\n"}
+      {quantity} item(s) more till {format(quotaRefreshTime, "d MMM yyyy")}.
+    </AppText>
+  </>
 );

--- a/src/components/CustomerQuota/NoQuota/TransactionsByCategory.tsx
+++ b/src/components/CustomerQuota/NoQuota/TransactionsByCategory.tsx
@@ -14,6 +14,7 @@ export interface Transaction {
 export interface TransactionsByCategory {
   category: string;
   transactions: Transaction[];
+  order: number;
 }
 
 const Transaction: FunctionComponent<Transaction> = ({

--- a/src/components/CustomerQuota/NoQuota/TransactionsByCategory.tsx
+++ b/src/components/CustomerQuota/NoQuota/TransactionsByCategory.tsx
@@ -7,6 +7,7 @@ export interface Transaction {
   transactionDate: string;
   details: string;
   quantity: string;
+  isAppeal: boolean;
   order?: number;
 }
 
@@ -18,7 +19,8 @@ export interface TransactionsByCategory {
 const Transaction: FunctionComponent<Transaction> = ({
   transactionDate,
   details,
-  quantity
+  quantity,
+  isAppeal
 }) => (
   <>
     <View style={styles.itemRow}>
@@ -26,10 +28,22 @@ const Transaction: FunctionComponent<Transaction> = ({
       <AppText style={styles.itemSubheader}>{quantity}</AppText>
     </View>
     {!!details && (
-      <View style={styles.itemDetailWrapper}>
-        <View style={styles.itemDetailBorder} />
-        <AppText style={styles.itemDetail}>{details}</AppText>
+      <View style={styles.itemRow}>
+        <View style={styles.itemDetailWrapper}>
+          <View style={styles.itemDetailBorder} />
+          <AppText style={styles.itemDetail}>{details}</AppText>
+        </View>
+        {isAppeal && (
+          <AppText style={{ ...styles.appealLabel, alignSelf: "flex-start" }}>
+            via appeal
+          </AppText>
+        )}
       </View>
+    )}
+    {!details && isAppeal && (
+      <AppText style={{ ...styles.appealLabel, textAlign: "right" }}>
+        via appeal
+      </AppText>
     )}
   </>
 );

--- a/src/components/CustomerQuota/NoQuota/TransactionsByCategory.tsx
+++ b/src/components/CustomerQuota/NoQuota/TransactionsByCategory.tsx
@@ -1,0 +1,57 @@
+import React, { FunctionComponent } from "react";
+import { View } from "react-native";
+import { AppText } from "../../Layout/AppText";
+import { styles } from "./styles";
+
+export interface Transaction {
+  transactionDate: string;
+  details: string;
+  quantity: string;
+  order?: number;
+}
+
+export interface TransactionsByCategory {
+  category: string;
+  transactions: Transaction[];
+}
+
+const Transaction: FunctionComponent<Transaction> = ({
+  transactionDate,
+  details,
+  quantity
+}) => (
+  <>
+    <View style={styles.itemRow}>
+      <AppText style={styles.itemSubheader}>{transactionDate}</AppText>
+      <AppText style={styles.itemSubheader}>{quantity}</AppText>
+    </View>
+    {!!details && (
+      <View style={styles.itemDetailWrapper}>
+        <View style={styles.itemDetailBorder} />
+        <AppText style={styles.itemDetail}>{details}</AppText>
+      </View>
+    )}
+  </>
+);
+
+export const TransactionsByCategory: FunctionComponent<{
+  category: string;
+  transactions: Transaction[];
+  maxTransactionsToDisplay: number;
+}> = ({ category, transactions, maxTransactionsToDisplay }) => {
+  const shouldShowCategory =
+    (transactions[0].order || 0) < maxTransactionsToDisplay;
+  return shouldShowCategory ? (
+    <View style={styles.wrapper}>
+      <View style={styles.itemRow}>
+        <AppText style={styles.itemHeader}>{category}</AppText>
+      </View>
+      {transactions.map(
+        (transaction, index) =>
+          (transaction.order || 0) < maxTransactionsToDisplay && (
+            <Transaction key={index} {...transaction} />
+          )
+      )}
+    </View>
+  ) : null;
+};

--- a/src/components/CustomerQuota/NoQuota/styles.ts
+++ b/src/components/CustomerQuota/NoQuota/styles.ts
@@ -1,0 +1,50 @@
+import { StyleSheet } from "react-native";
+import { color, size, fontSize } from "../../../common/styles";
+
+export const styles = StyleSheet.create({
+  wrapper: {
+    marginTop: size(2),
+    marginBottom: size(2)
+  },
+  itemRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline"
+  },
+  itemHeader: {
+    lineHeight: 1.5 * fontSize(0),
+    fontFamily: "brand-bold"
+  },
+  itemSubheader: {
+    fontSize: fontSize(-1),
+    fontFamily: "brand-bold"
+  },
+  itemDetailWrapper: {
+    flexDirection: "row"
+  },
+  itemDetailBorder: {
+    borderLeftWidth: 1,
+    borderLeftColor: color("grey", 30),
+    marginLeft: size(1),
+    marginRight: size(1)
+  },
+  itemDetail: {
+    fontSize: fontSize(-1)
+  },
+  appealButtonText: {
+    marginTop: size(1),
+    marginBottom: 0,
+    fontFamily: "brand-bold",
+    fontSize: size(2)
+  },
+  showFullListToggleBorder: {
+    borderBottomWidth: 1,
+    borderBottomColor: color("grey", 30),
+    flex: 1
+  },
+  showFullListToggleWrapper: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center"
+  }
+});

--- a/src/components/CustomerQuota/NoQuota/styles.ts
+++ b/src/components/CustomerQuota/NoQuota/styles.ts
@@ -31,6 +31,11 @@ export const styles = StyleSheet.create({
   itemDetail: {
     fontSize: fontSize(-1)
   },
+  appealLabel: {
+    fontSize: fontSize(-1),
+    color: color("red", 60),
+    fontFamily: "brand-italic"
+  },
   appealButtonText: {
     marginTop: size(1),
     marginBottom: 0,

--- a/src/components/CustomerQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuotaCard.tsx
@@ -180,9 +180,8 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
    * 2. Listing of past transactions with identifiers and transacted time; identifier and single ID transactions
    */
 
-  // This hook is only used in single ID transaction
   const { pastTransactionsResult } = usePastTransaction(
-    ids[0],
+    ids,
     sessionToken,
     endpoint
   );

--- a/src/components/CustomerQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuotaCard.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useContext } from "react";
+import React, { FunctionComponent, useContext, useState } from "react";
 import { compareDesc } from "date-fns";
 import { differenceInSeconds, format, formatDistance } from "date-fns";
 import { View, StyleSheet, TouchableOpacity } from "react-native";
@@ -9,15 +9,16 @@ import { sharedStyles } from "./sharedStyles";
 import { DarkButton } from "../Layout/Buttons/DarkButton";
 import { Cart } from "../../hooks/useCart/useCart";
 import { usePastTransaction } from "../../hooks/usePastTransaction/usePastTransaction";
-import { FontAwesome } from "@expo/vector-icons";
 import { Quota } from "../../types";
 import { CampaignConfigContext } from "../../context/campaignConfig";
 import { ProductContext } from "../../context/products";
 import { getAllIdentifierInputDisplay } from "../../utils/getIdentifierInputDisplay";
 import { AuthContext } from "../../context/auth";
+import { FontAwesome, Ionicons } from "@expo/vector-icons";
 import { formatQuantityText } from "./utils";
 
 const DURATION_THRESHOLD_SECONDS = 60 * 10; // 10 minutes
+const MAX_TRANSACTIONS_TO_DISPLAY = 5;
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -54,6 +55,16 @@ const styles = StyleSheet.create({
     marginBottom: 0,
     fontFamily: "brand-bold",
     fontSize: size(2)
+  },
+  showFullListToggleBorder: {
+    borderBottomWidth: 1,
+    borderBottomColor: color("grey", 30),
+    flex: 1
+  },
+  showFullListToggleWrapper: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center"
   }
 });
 
@@ -105,23 +116,46 @@ const UsageQuotaTitle: FunctionComponent<{
   </>
 );
 
-interface ItemTransaction {
-  name: string;
+interface TransactionsByCategory {
+  category: string;
+  transactions: Transaction[];
+}
+
+interface Transaction {
   transactionDate: string;
   details: string;
   quantity: string;
+  order?: number;
 }
 
-const ItemTransaction: FunctionComponent<ItemTransaction> = ({
-  name,
+const TransactionsByCategory: FunctionComponent<{
+  category: string;
+  transactions: Transaction[];
+  maxTransactionsToDisplay: number;
+}> = ({ category, transactions, maxTransactionsToDisplay }) => {
+  const shouldShowCategory =
+    (transactions[0].order || 0) < maxTransactionsToDisplay;
+  return shouldShowCategory ? (
+    <View style={styles.wrapper}>
+      <View style={styles.itemRow}>
+        <AppText style={styles.itemHeader}>{category}</AppText>
+      </View>
+      {transactions.map(
+        (transaction, index) =>
+          (transaction.order || 0) < maxTransactionsToDisplay && (
+            <Transaction key={index} {...transaction} />
+          )
+      )}
+    </View>
+  ) : null;
+};
+
+const Transaction: FunctionComponent<Transaction> = ({
   transactionDate,
   details,
   quantity
 }) => (
-  <View style={styles.wrapper}>
-    <View style={styles.itemRow}>
-      <AppText style={styles.itemHeader}>{name}</AppText>
-    </View>
+  <>
     <View style={styles.itemRow}>
       <AppText style={styles.itemSubheader}>{transactionDate}</AppText>
       <AppText style={styles.itemSubheader}>{quantity}</AppText>
@@ -132,7 +166,7 @@ const ItemTransaction: FunctionComponent<ItemTransaction> = ({
         <AppText style={styles.itemDetail}>{details}</AppText>
       </View>
     )}
-  </View>
+  </>
 );
 
 const NoPreviousTransactionTitle: FunctionComponent<{
@@ -170,6 +204,32 @@ interface NoQuotaCard {
   quotaResponse: Quota | null;
 }
 
+const ShowFullListToggle: FunctionComponent<{
+  onClick: () => void;
+  displayText: string;
+  icon: any;
+}> = ({ onClick, displayText, icon }) => (
+  <View
+    style={{
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+      marginTop: size(2),
+      marginBottom: size(2)
+    }}
+  >
+    <TouchableOpacity
+      onPress={onClick}
+      style={styles.showFullListToggleWrapper}
+    >
+      <View style={styles.showFullListToggleBorder} />
+      {icon}
+      <View style={styles.showFullListToggleBorder} />
+    </TouchableOpacity>
+    <AppText style={styles.itemHeader}>{displayText}</AppText>
+  </View>
+);
+
 /**
  * Shows when the user cannot purchase anything
  *
@@ -182,34 +242,44 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
   onAppeal,
   quotaResponse
 }) => {
+  const [isShowFullList, setIsShowFullList] = useState<boolean>(false);
   const { policies: allProducts } = useContext(CampaignConfigContext);
   const { getProduct } = useContext(ProductContext);
   const { sessionToken, endpoint } = useContext(AuthContext);
 
   const policyType = cart.length > 0 && getProduct(cart[0].category)?.type;
 
-  const itemTransactions: ItemTransaction[] = [];
-  let latestTransactionTime: Date | undefined = new Date();
+  const { pastTransactionsResult } = usePastTransaction(ids, sessionToken, endpoint);
+  // Assumes results are already sorted (valid assumption for results from /transactions/history)
+  const sortedTransactions = pastTransactionsResult?.pastTransactions;
 
-  const { pastTransactionsResult } = usePastTransaction(
-    ids,
-    sessionToken,
-    endpoint
-  );
+  const latestTransactionTime: Date | undefined =
+    sortedTransactions?.[0].transactionTime ?? undefined;
+  const now = new Date();
+  const secondsFromLatestTransaction = latestTransactionTime
+    ? differenceInSeconds(now, latestTransactionTime)
+    : -1;
 
-  const sortedTransactions = pastTransactionsResult?.pastTransactions.sort(
-    (item1, item2) =>
-      compareDesc(item1.transactionTime ?? 0, item2.transactionTime ?? 0)
-  );
-
+  const transactionsByCategoryMap: {
+    [category: string]: {
+      transactions: Transaction[];
+      hasLatestTransaction?: boolean;
+    };
+  } = {};
   sortedTransactions?.forEach(item => {
     const policy = allProducts.find(
       policy => policy.category === item.category
     );
     const categoryName = policy?.name ?? item.category;
     const formattedDate = format(item.transactionTime, "d MMM yyyy, h:mma");
-    itemTransactions.push({
-      name: categoryName,
+
+    if (!(categoryName in transactionsByCategoryMap)) {
+      transactionsByCategoryMap[categoryName] = {
+        transactions: [],
+        hasLatestTransaction: false
+      };
+    }
+    transactionsByCategoryMap[categoryName].transactions.push({
       transactionDate: formattedDate,
       details: getAllIdentifierInputDisplay(item.identifierInputs ?? []),
       quantity: formatQuantityText(
@@ -217,14 +287,48 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
         policy?.quantity.unit || { type: "POSTFIX", label: " qty" }
       )
     });
+    // TODO: check if seconds is good, or need to change to minutes
+    transactionsByCategoryMap[categoryName].hasLatestTransaction =
+      transactionsByCategoryMap[categoryName].hasLatestTransaction ||
+      differenceInSeconds(latestTransactionTime || 0, item.transactionTime) ===
+        0;
   });
 
-  latestTransactionTime = sortedTransactions?.[0].transactionTime ?? undefined;
+  const latestTransactionsByCategory: TransactionsByCategory[] = [];
+  const otherTransactionsByCategory: TransactionsByCategory[] = [];
+  Object.entries(transactionsByCategoryMap).forEach(([key, value]) => {
+    const { transactions, hasLatestTransaction } = value;
+    if (hasLatestTransaction) {
+      latestTransactionsByCategory.push({
+        category: key,
+        transactions: transactions
+      });
+    } else {
+      otherTransactionsByCategory.push({ category: key, transactions });
+    }
+  });
 
-  const now = new Date();
-  const secondsFromLatestTransaction = latestTransactionTime
-    ? differenceInSeconds(now, latestTransactionTime)
-    : -1;
+  const sortTransactionsByCategory = (
+    a: TransactionsByCategory,
+    b: TransactionsByCategory
+  ): 1 | -1 | 0 =>
+    a.category > b.category ? 1 : b.category > a.category ? -1 : 0;
+  latestTransactionsByCategory.sort(sortTransactionsByCategory);
+  otherTransactionsByCategory.sort(sortTransactionsByCategory);
+
+  let transactionCounter = 0;
+  const transactionsByCategoryList = latestTransactionsByCategory
+    .concat(otherTransactionsByCategory)
+    .map(transactionsByCategory => {
+      const orderedTransactions = transactionsByCategory.transactions.map(
+        transaction => {
+          const result = { ...transaction, order: transactionCounter };
+          transactionCounter += 1;
+          return result;
+        }
+      );
+      return { ...transactionsByCategory, transactions: orderedTransactions };
+    });
 
   const hasAppealProduct = (): boolean => {
     return (
@@ -282,16 +386,44 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
                   ) : undefined
               )}
           </AppText>
-          {itemTransactions.length > 0 && (
+          {transactionsByCategoryList.length > 0 && (
             <View>
               <AppText style={styles.wrapper}>
                 Item(s) {policyType === "REDEEM" ? "redeemed" : "purchased"}{" "}
                 previously:
               </AppText>
-              {itemTransactions.map((transaction, index: number) => (
-                <ItemTransaction key={index} {...transaction} />
-              ))}
+              {transactionsByCategoryList.map(
+                (
+                  transactionsByCategory: TransactionsByCategory,
+                  index: number
+                ) => (
+                  <TransactionsByCategory
+                    key={index}
+                    maxTransactionsToDisplay={
+                      isShowFullList ? 99999 : MAX_TRANSACTIONS_TO_DISPLAY
+                    }
+                    {...transactionsByCategory}
+                  />
+                )
+              )}
             </View>
+          )}
+          {transactionCounter > MAX_TRANSACTIONS_TO_DISPLAY && (
+            <ShowFullListToggle
+              onClick={() => setIsShowFullList(!isShowFullList)}
+              displayText={isShowFullList ? "Show less" : "Show more"}
+              icon={
+                <Ionicons
+                  name={
+                    isShowFullList
+                      ? "ios-arrow-dropup-circle"
+                      : "ios-arrow-dropdown-circle"
+                  }
+                  size={size(4)}
+                  color={color("blue", 50)}
+                />
+              }
+            />
           )}
         </View>
       </CustomerCard>

--- a/src/components/CustomerQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuotaCard.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent, useContext, useState } from "react";
-import { compareDesc } from "date-fns";
 import { differenceInSeconds, format, formatDistance } from "date-fns";
 import { View, StyleSheet, TouchableOpacity } from "react-native";
 import { CustomerCard } from "./CustomerCard";
@@ -249,7 +248,11 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
 
   const policyType = cart.length > 0 && getProduct(cart[0].category)?.type;
 
-  const { pastTransactionsResult } = usePastTransaction(ids, sessionToken, endpoint);
+  const { pastTransactionsResult } = usePastTransaction(
+    ids,
+    sessionToken,
+    endpoint
+  );
   // Assumes results are already sorted (valid assumption for results from /transactions/history)
   const sortedTransactions = pastTransactionsResult?.pastTransactions;
 
@@ -260,6 +263,13 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
     ? differenceInSeconds(now, latestTransactionTime)
     : -1;
 
+  const hasAppealProduct = (): boolean => {
+    return (
+      allProducts?.some(policy => policy.categoryType === "APPEAL") ?? false
+    );
+  };
+
+  // Group transactions by category
   const transactionsByCategoryMap: {
     [category: string]: {
       transactions: Transaction[];
@@ -294,6 +304,7 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
         0;
   });
 
+  // Split categories into those with the latest transactions and those without
   const latestTransactionsByCategory: TransactionsByCategory[] = [];
   const otherTransactionsByCategory: TransactionsByCategory[] = [];
   Object.entries(transactionsByCategoryMap).forEach(([key, value]) => {
@@ -308,6 +319,7 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
     }
   });
 
+  // Order each category list by alphabetical order
   const sortTransactionsByCategory = (
     a: TransactionsByCategory,
     b: TransactionsByCategory
@@ -316,6 +328,8 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
   latestTransactionsByCategory.sort(sortTransactionsByCategory);
   otherTransactionsByCategory.sort(sortTransactionsByCategory);
 
+  // Concat category lists into a single list
+  // Add order to each transaction for "Show more" feature
   let transactionCounter = 0;
   const transactionsByCategoryList = latestTransactionsByCategory
     .concat(otherTransactionsByCategory)
@@ -329,12 +343,6 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
       );
       return { ...transactionsByCategory, transactions: orderedTransactions };
     });
-
-  const hasAppealProduct = (): boolean => {
-    return (
-      allProducts?.some(policy => policy.categoryType === "APPEAL") ?? false
-    );
-  };
 
   const showGlobalQuota =
     !!quotaResponse?.globalQuota &&

--- a/src/components/CustomerQuota/sharedStyles.tsx
+++ b/src/components/CustomerQuota/sharedStyles.tsx
@@ -3,16 +3,17 @@ import { size, color, fontSize } from "../../common/styles";
 
 export const sharedStyles = StyleSheet.create({
   resultWrapper: {
-    padding: size(2),
-    paddingTop: size(0.5)
+    paddingLeft: size(2),
+    paddingRight: size(2),
+    paddingBottom: size(2)
   },
   successfulResultWrapper: {
-    paddingTop: size(2),
+    paddingTop: size(3),
     backgroundColor: color("green", 10),
     borderColor: color("green", 30)
   },
   failureResultWrapper: {
-    paddingTop: size(2),
+    paddingTop: size(3),
     paddingBottom: size(4),
     backgroundColor: color("red", 10),
     borderColor: color("red", 30)

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -41,7 +41,8 @@ export enum ERROR_MESSAGE {
   LAST_OTP_ERROR = "Enter OTP again. After 1 more invalid OTP entry, you will have to wait 3 minutes before trying again.",
   AUTH_FAILURE_TAKEN_TOKEN = "Get a new QR code that is not tagged to any contact number from your in-charge.",
   OTP_EXPIRED = "Get a new OTP and try again.",
-  LOGIN_ERROR = "We are currently facing login issues. Get a new QR code from your in-charge."
+  LOGIN_ERROR = "We are currently facing login issues. Get a new QR code from your in-charge.",
+  PAST_TRANSACTIONS_ERROR = "We are currently facing server issues. Try again later or contact your in-charge if the problem persists."
 }
 
 const defaultAlertProps: AlertModalProps = {

--- a/src/hooks/usePastTransaction/usePastTransaction.test.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.test.tsx
@@ -7,7 +7,6 @@ import {
 } from "../../services/quota";
 import { PastTransactionsResult, CampaignPolicy } from "../../types";
 import { defaultIdentifier } from "../../test/helpers/defaults";
-import { toDate } from "date-fns";
 import { ProductContextProvider } from "../../context/products";
 import { ERROR_MESSAGE } from "../../context/alert";
 
@@ -77,7 +76,7 @@ const mockPastTransactions: PastTransactionsResult = {
           value: "AAA987654321"
         }
       ],
-      transactionTime: toDate(1596530356430)
+      transactionTime: new Date(1596530356430)
     },
     {
       category: "tt-token-lost",
@@ -89,7 +88,7 @@ const mockPastTransactions: PastTransactionsResult = {
           value: "AAA987654322"
         }
       ],
-      transactionTime: toDate(1596530356431)
+      transactionTime: new Date(1596530356431)
     },
     {
       category: "tt-token-lost",
@@ -101,7 +100,7 @@ const mockPastTransactions: PastTransactionsResult = {
           value: "AAA987654323"
         }
       ],
-      transactionTime: toDate(1596530356432)
+      transactionTime: new Date(1596530356432)
     }
   ]
 };
@@ -144,7 +143,7 @@ describe("usePastTransaction", () => {
               value: "AAA987654321"
             }
           ],
-          transactionTime: toDate(1596530356430)
+          transactionTime: new Date(1596530356430)
         },
         {
           category: "tt-token-lost",
@@ -156,7 +155,7 @@ describe("usePastTransaction", () => {
               value: "AAA987654322"
             }
           ],
-          transactionTime: toDate(1596530356431)
+          transactionTime: new Date(1596530356431)
         },
         {
           category: "tt-token-lost",
@@ -168,7 +167,7 @@ describe("usePastTransaction", () => {
               value: "AAA987654323"
             }
           ],
-          transactionTime: toDate(1596530356432)
+          transactionTime: new Date(1596530356432)
         }
       ]);
     });

--- a/src/hooks/usePastTransaction/usePastTransaction.test.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.test.tsx
@@ -13,7 +13,7 @@ import { ERROR_MESSAGE } from "../../context/alert";
 jest.mock("../../services/quota");
 const mockGetPastTransactions = getPastTransactions as jest.Mock;
 
-const id = "ID1";
+const ids = ["ID1"];
 const key = "KEY";
 const endpoint = "https://myendpoint.com";
 
@@ -126,7 +126,7 @@ describe("usePastTransaction", () => {
       mockGetPastTransactions.mockReturnValue(mockPastTransactions);
 
       const { result, waitForNextUpdate } = renderHook(
-        () => usePastTransaction([id], key, endpoint),
+        () => usePastTransaction(ids, key, endpoint),
         { wrapper }
       );
 
@@ -177,7 +177,7 @@ describe("usePastTransaction", () => {
       mockGetPastTransactions.mockReturnValue(mockEmptyPastTransactions);
 
       const { result, waitForNextUpdate } = renderHook(
-        () => usePastTransaction([id], key, endpoint),
+        () => usePastTransaction(ids, key, endpoint),
         { wrapper }
       );
 
@@ -193,7 +193,7 @@ describe("usePastTransaction", () => {
       );
 
       const { result, waitForNextUpdate } = renderHook(
-        () => usePastTransaction([id], key, endpoint),
+        () => usePastTransaction(ids, key, endpoint),
         { wrapper }
       );
 

--- a/src/hooks/usePastTransaction/usePastTransaction.test.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.test.tsx
@@ -137,46 +137,44 @@ describe("usePastTransaction", () => {
 
       await waitForNextUpdate();
 
-      expect(result.current.pastTransactionsResult).toStrictEqual({
-        pastTransactions: [
-          {
-            category: "tt-token",
-            quantity: 1,
-            identifierInputs: [
-              {
-                ...defaultIdentifier,
-                label: "first",
-                value: "AAA987654321"
-              }
-            ],
-            transactionTime: toDate(1596530356430)
-          },
-          {
-            category: "tt-token-lost",
-            quantity: 1,
-            identifierInputs: [
-              {
-                ...defaultIdentifier,
-                label: "first",
-                value: "AAA987654322"
-              }
-            ],
-            transactionTime: toDate(1596530356431)
-          },
-          {
-            category: "tt-token-lost",
-            quantity: 1,
-            identifierInputs: [
-              {
-                ...defaultIdentifier,
-                label: "first",
-                value: "AAA987654323"
-              }
-            ],
-            transactionTime: toDate(1596530356432)
-          }
-        ]
-      });
+      expect(result.current.pastTransactionsResult).toStrictEqual([
+        {
+          category: "tt-token",
+          quantity: 1,
+          identifierInputs: [
+            {
+              ...defaultIdentifier,
+              label: "first",
+              value: "AAA987654321"
+            }
+          ],
+          transactionTime: toDate(1596530356430)
+        },
+        {
+          category: "tt-token-lost",
+          quantity: 1,
+          identifierInputs: [
+            {
+              ...defaultIdentifier,
+              label: "first",
+              value: "AAA987654322"
+            }
+          ],
+          transactionTime: toDate(1596530356431)
+        },
+        {
+          category: "tt-token-lost",
+          quantity: 1,
+          identifierInputs: [
+            {
+              ...defaultIdentifier,
+              label: "first",
+              value: "AAA987654323"
+            }
+          ],
+          transactionTime: toDate(1596530356432)
+        }
+      ]);
     });
 
     it("should populate the past transactions with empty values", async () => {
@@ -190,9 +188,7 @@ describe("usePastTransaction", () => {
 
       await waitForNextUpdate();
 
-      expect(result.current.pastTransactionsResult).toStrictEqual({
-        pastTransactions: []
-      });
+      expect(result.current.pastTransactionsResult).toStrictEqual([]);
     });
 
     it("should catch error when thrown", async () => {

--- a/src/hooks/usePastTransaction/usePastTransaction.test.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.test.tsx
@@ -128,10 +128,10 @@ describe("usePastTransaction", () => {
   describe("fetch past transactions on initialisation", () => {
     it("should populate the past transactions with values", async () => {
       expect.assertions(1);
-      mockGetPastTransactions.mockReturnValueOnce(mockPastTransactions);
+      mockGetPastTransactions.mockReturnValue(mockPastTransactions);
 
       const { result, waitForNextUpdate } = renderHook(
-        () => usePastTransaction(id, key, endpoint),
+        () => usePastTransaction([id], key, endpoint),
         { wrapper }
       );
 
@@ -181,10 +181,10 @@ describe("usePastTransaction", () => {
 
     it("should populate the past transactions with empty values", async () => {
       expect.assertions(1);
-      mockGetPastTransactions.mockReturnValueOnce(mockEmptyPastTransactions);
+      mockGetPastTransactions.mockReturnValue(mockEmptyPastTransactions);
 
       const { result, waitForNextUpdate } = renderHook(
-        () => usePastTransaction(id, key, endpoint),
+        () => usePastTransaction([id], key, endpoint),
         { wrapper }
       );
 
@@ -200,7 +200,7 @@ describe("usePastTransaction", () => {
       mockGetPastTransactions.mockImplementation(mockSomeUnknownError);
 
       const { result } = renderHook(
-        () => usePastTransaction(id, key, endpoint),
+        () => usePastTransaction([id], key, endpoint),
         { wrapper }
       );
 

--- a/src/hooks/usePastTransaction/usePastTransaction.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.tsx
@@ -10,6 +10,23 @@ export type PastTransactionHook = {
   error: { message: string } | null;
 };
 
+const areSameIds = (
+  prevIds: string[] | undefined,
+  ids: string[] | undefined
+): boolean => {
+  if (typeof prevIds !== typeof ids) {
+    return false;
+  }
+
+  if (!!prevIds && !!ids) {
+    return (
+      prevIds.length === ids.length && prevIds.every(id => ids.includes(id))
+    );
+  }
+
+  return true;
+};
+
 export const usePastTransaction = (
   ids: string[],
   authKey: string,
@@ -36,10 +53,8 @@ export const usePastTransaction = (
       }
     };
 
-    if (
-      typeof prevIds !== typeof ids ||
-      (prevIds && ids && !prevIds.every(id => ids.includes(id)))
-    ) {
+    if (!areSameIds(prevIds, ids)) {
+      setError(null);
       fetchPastTransactions();
     }
   }, [authKey, endpoint, ids, prevIds]);

--- a/src/hooks/usePastTransaction/usePastTransaction.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.tsx
@@ -10,23 +10,6 @@ export type PastTransactionHook = {
   error: { message: string } | null;
 };
 
-const areSameIds = (
-  prevIds: string[] | undefined,
-  ids: string[] | undefined
-): boolean => {
-  if (typeof prevIds !== typeof ids) {
-    return false;
-  }
-
-  if (!!prevIds && !!ids) {
-    return (
-      prevIds.length === ids.length && prevIds.every(id => ids.includes(id))
-    );
-  }
-
-  return true;
-};
-
 export const usePastTransaction = (
   ids: string[],
   authKey: string,
@@ -53,7 +36,7 @@ export const usePastTransaction = (
       }
     };
 
-    if (!areSameIds(prevIds, ids)) {
+    if (prevIds !== ids) {
       setError(null);
       fetchPastTransactions();
     }

--- a/src/hooks/usePastTransaction/usePastTransaction.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.tsx
@@ -9,7 +9,7 @@ export type PastTransactionHook = {
 };
 
 export const usePastTransaction = (
-  id: string,
+  ids: string[],
   authKey: string,
   endpoint: string
 ): PastTransactionHook => {
@@ -17,12 +17,12 @@ export const usePastTransaction = (
     pastTransactionsResult,
     setPastTransactionsResult
   ] = useState<PastTransactionsResult | null>(null);
-  const prevId = usePrevious(id);
+  const prevIds = usePrevious(ids);
 
   useEffect(() => {
     const fetchPastTransactions = async (): Promise<void> => {
       const pastTransactionsResponse = await getPastTransactions(
-        id,
+        ids,
         authKey,
         endpoint
       );
@@ -30,11 +30,11 @@ export const usePastTransaction = (
       setPastTransactionsResult(pastTransactionsResponse);
     };
 
-    if (prevId != id)
+    if (prevIds !== ids)
       fetchPastTransactions().catch(() => {
-        Sentry.captureException(`Unable to fetch past transactions: ${id}`);
+        Sentry.captureException(`Unable to fetch past transactions: ${ids}`);
       });
-  }, [authKey, endpoint, id, prevId]);
+  }, [authKey, endpoint, ids, prevIds]);
 
   return {
     pastTransactionsResult

--- a/src/hooks/usePastTransaction/usePastTransaction.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.tsx
@@ -5,7 +5,7 @@ import { getPastTransactions } from "../../services/quota";
 import { Sentry } from "../../utils/errorTracking";
 
 export type PastTransactionHook = {
-  pastTransactionsResult: PastTransactionsResult | null;
+  pastTransactionsResult: PastTransactionsResult["pastTransactions"] | null;
 };
 
 export const usePastTransaction = (
@@ -13,10 +13,9 @@ export const usePastTransaction = (
   authKey: string,
   endpoint: string
 ): PastTransactionHook => {
-  const [
-    pastTransactionsResult,
-    setPastTransactionsResult
-  ] = useState<PastTransactionsResult | null>(null);
+  const [pastTransactionsResult, setPastTransactionsResult] = useState<
+    PastTransactionsResult["pastTransactions"] | null
+  >(null);
   const prevIds = usePrevious(ids);
 
   useEffect(() => {
@@ -27,7 +26,7 @@ export const usePastTransaction = (
         endpoint
       );
 
-      setPastTransactionsResult(pastTransactionsResponse);
+      setPastTransactionsResult(pastTransactionsResponse?.pastTransactions);
     };
 
     if (prevIds !== ids)

--- a/src/hooks/usePastTransaction/usePastTransaction.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.tsx
@@ -3,9 +3,11 @@ import { PastTransactionsResult } from "../../types";
 import { usePrevious } from "../usePrevious";
 import { getPastTransactions } from "../../services/quota";
 import { Sentry } from "../../utils/errorTracking";
+import { ERROR_MESSAGE } from "../../context/alert";
 
 export type PastTransactionHook = {
   pastTransactionsResult: PastTransactionsResult["pastTransactions"] | null;
+  error: { message: string } | null;
 };
 
 export const usePastTransaction = (
@@ -16,26 +18,34 @@ export const usePastTransaction = (
   const [pastTransactionsResult, setPastTransactionsResult] = useState<
     PastTransactionsResult["pastTransactions"] | null
   >(null);
+  const [error, setError] = useState<{ message: string } | null>(null);
   const prevIds = usePrevious(ids);
 
   useEffect(() => {
     const fetchPastTransactions = async (): Promise<void> => {
-      const pastTransactionsResponse = await getPastTransactions(
-        ids,
-        authKey,
-        endpoint
-      );
-
-      setPastTransactionsResult(pastTransactionsResponse?.pastTransactions);
+      try {
+        const pastTransactionsResponse = await getPastTransactions(
+          ids,
+          authKey,
+          endpoint
+        );
+        setPastTransactionsResult(pastTransactionsResponse?.pastTransactions);
+      } catch (error) {
+        Sentry.captureException(`Unable to fetch past transactions: ${ids}`);
+        setError(new Error(ERROR_MESSAGE.PAST_TRANSACTIONS_ERROR));
+      }
     };
 
-    if (prevIds !== ids)
-      fetchPastTransactions().catch(() => {
-        Sentry.captureException(`Unable to fetch past transactions: ${ids}`);
-      });
+    if (
+      typeof prevIds !== typeof ids ||
+      (prevIds && ids && !prevIds.every(id => ids.includes(id)))
+    ) {
+      fetchPastTransactions();
+    }
   }, [authKey, endpoint, ids, prevIds]);
 
   return {
-    pastTransactionsResult
+    pastTransactionsResult,
+    error
   };
 };

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -264,17 +264,20 @@ export const livePastTransactions = async (
 ): Promise<PastTransactionsResult> => {
   let response;
   if (_.isEmpty(id)) {
-    throw new PastTransactionError("No ID was provided");
+    throw new PastTransactionError("No IDs were provided");
   }
   try {
     response = await fetchWithValidator(
       PastTransactionsResult,
-      `${endpoint}/transactions/${id}`,
+      `${endpoint}/transactions/history`,
       {
-        method: "GET",
+        method: "POST",
         headers: {
           Authorization: key
-        }
+        },
+        body: JSON.stringify({
+          ids: [id]
+        })
       }
     );
     return response;

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -5,7 +5,6 @@ import {
   PostTransactionResult,
   PastTransactionsResult
 } from "../../types";
-import _ from "lodash";
 import { fetchWithValidator, ValidationError, SessionError } from "../helpers";
 import { Sentry } from "../../utils/errorTracking";
 import { systemAlertProps, ERROR_MESSAGE } from "../../context/alert";

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -225,11 +225,14 @@ export const livePostTransaction = async ({
 };
 
 export const mockPastTransactions = async (
-  id: string,
+  ids: string[],
   _key: string,
   _endpoint: string
 ): Promise<PastTransactionsResult> => {
-  if (id === "S0000000J") throw new Error("Something broke");
+  if (ids[0] === "S0000000J") throw new Error("Something broke");
+  if (ids.length === 0) {
+    throw new PastTransactionError("No ID was provided");
+  }
   const transactionTime = new Date(2020, 3, 5);
   return {
     pastTransactions: [
@@ -258,13 +261,13 @@ export const mockPastTransactions = async (
 };
 
 export const livePastTransactions = async (
-  id: string,
+  ids: string[],
   key: string,
   endpoint: string
 ): Promise<PastTransactionsResult> => {
   let response;
-  if (_.isEmpty(id)) {
-    throw new PastTransactionError("No IDs were provided");
+  if (ids.length === 0) {
+    throw new PastTransactionError("No ID was provided");
   }
   try {
     response = await fetchWithValidator(
@@ -276,7 +279,7 @@ export const livePastTransactions = async (
           Authorization: key
         },
         body: JSON.stringify({
-          ids: [id]
+          ids
         })
       }
     );

--- a/src/services/quota/quota.test.tsx
+++ b/src/services/quota/quota.test.tsx
@@ -306,7 +306,7 @@ describe("quota", () => {
         json: () => Promise.resolve(mockPastTransactionsResponse)
       });
       const pastTransactionsResult = await getPastTransactions(
-        "S0000000J",
+        ["S0000000J"],
         key,
         endpoint
       );
@@ -320,7 +320,7 @@ describe("quota", () => {
         json: () => Promise.resolve({ message: "No ID was provided" })
       });
 
-      await expect(getPastTransactions("", key, endpoint)).rejects.toThrow(
+      await expect(getPastTransactions([""], key, endpoint)).rejects.toThrow(
         PastTransactionError
       );
     });
@@ -336,7 +336,7 @@ describe("quota", () => {
       });
 
       await expect(
-        getPastTransactions("S0000000J", key, endpoint)
+        getPastTransactions(["S0000000J"], key, endpoint)
       ).rejects.toThrow(PastTransactionError);
     });
   });

--- a/src/utils/getIdentifierInputDisplay.ts
+++ b/src/utils/getIdentifierInputDisplay.ts
@@ -12,6 +12,7 @@ const processIdentifierInputValue = (
     : identifierInput.value;
 };
 
+// TODO: @deprecated in favour of getAllIdentifierInputDisplay below
 export const getIdentifierInputDisplay = (
   identifierInputs: IdentifierInput[]
 ): string => {
@@ -33,7 +34,6 @@ export const getIdentifierInputDisplay = (
   return identifierInputDisplay;
 };
 
-// TODO: this is just an interim solution for the 24th deadline.
 export const getAllIdentifierInputDisplay = (
   identifierInputs: IdentifierInput[]
 ): string => {


### PR DESCRIPTION
This PR adds 
- [x] Change `usePastTransactions` hook to call `/transactions/history` endpoint so it works for multiple IDs (prep for showing all past transactions on checkout success screen
- [x] Restyling of each transaction in limit reached screen
- [x] Display quantity with units for each transaction in limit reached screen
- [x] Group past transactions in limit reached screen by category
- [x] Order past transactions by latest transacted category, followed by the rest in order of category in policy
- [x] Show only first 5 transactions by default, hide the rest with "Show more"
- [x] Display appeal label for appeal transactions
- [x] Refactor `NoQuotaCard` into smaller files
- [x] Add/Update unit tests