### PR TITLE
feat: Display global limits messages only if there is a single category

### DIFF
--- a/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
+++ b/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
@@ -171,10 +171,10 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
      * since we have not catered for showing global limit messages for multiple
      * categories.
      */
-    quotaResponse.globalQuota.length === 1 &&
+    allProducts?.length === 1 &&
     !!getProduct(sortedTransactions[0].category)?.quantity.usage;
 
-  const globalQuota = showGlobalQuota
+  const firstGlobalQuota = showGlobalQuota
     ? quotaResponse!.globalQuota![0]
     : undefined;
 
@@ -190,12 +190,10 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
             />
             <AppText style={sharedStyles.statusTitleWrapper}>
               <AppText style={sharedStyles.statusTitle}>{title}</AppText>
-              {showGlobalQuota &&
-              globalQuota!.quantity &&
-              globalQuota!.quotaRefreshTime ? (
+              {showGlobalQuota && firstGlobalQuota!.quotaRefreshTime ? (
                 <UsageQuotaTitle
-                  quantity={globalQuota!.quantity}
-                  quotaRefreshTime={globalQuota!.quotaRefreshTime}
+                  quantity={firstGlobalQuota!.quantity}
+                  quotaRefreshTime={firstGlobalQuota!.quotaRefreshTime}
                 />
               ) : undefined}
             </AppText>

--- a/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
+++ b/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
@@ -172,7 +172,7 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
      * categories.
      */
     allProducts?.length === 1 &&
-    !!getProduct(sortedTransactions[0].category)?.quantity.usage;
+    !!allProducts[0].quantity.usage;
 
   const firstGlobalQuota = showGlobalQuota
     ? quotaResponse!.globalQuota![0]

--- a/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
+++ b/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
@@ -166,7 +166,17 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
     !!quotaResponse?.globalQuota &&
     !!sortedTransactions &&
     sortedTransactions.length > 0 &&
+    /**
+     * We only display global limit messages if there is only one global quota,
+     * since we have not catered for showing global limit messages for multiple
+     * categories.
+     */
+    quotaResponse.globalQuota.length === 1 &&
     !!getProduct(sortedTransactions[0].category)?.quantity.usage;
+
+  const globalQuota = showGlobalQuota
+    ? quotaResponse!.globalQuota![0]
+    : undefined;
 
   return (
     <View>
@@ -181,16 +191,13 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
             <AppText style={sharedStyles.statusTitleWrapper}>
               <AppText style={sharedStyles.statusTitle}>{title}</AppText>
               {showGlobalQuota &&
-                quotaResponse!.globalQuota!.map(
-                  ({ quantity, quotaRefreshTime }, index: number) =>
-                    quotaRefreshTime ? (
-                      <UsageQuotaTitle
-                        key={index}
-                        quantity={quantity}
-                        quotaRefreshTime={quotaRefreshTime}
-                      />
-                    ) : undefined
-                )}
+              globalQuota!.quantity &&
+              globalQuota!.quotaRefreshTime ? (
+                <UsageQuotaTitle
+                  quantity={globalQuota!.quantity}
+                  quotaRefreshTime={globalQuota!.quotaRefreshTime}
+                />
+              ) : undefined}
             </AppText>
             <View>
               <AppText>{description}</AppText>

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -222,14 +222,12 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
     !!quotaResponse?.globalQuota &&
     cart.length > 0 &&
     /**
-     * We only display global limit messages if there is only one global limit,
-     * since we have not catered for showing global limit messages for multiple
-     * categories.
+     * We only display global limit messages if there is only one category for now
      */
-    quotaResponse.globalQuota.length === 1 &&
+    allProducts?.length === 1 &&
     !!getProduct(cart[0].category)?.quantity.usage;
 
-  const globalQuota = showGlobalQuota
+  const firstGlobalQuota = showGlobalQuota
     ? quotaResponse!.globalQuota![0]
     : undefined;
 
@@ -262,12 +260,10 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
                   toggleTimeSensitiveTitle={showGlobalQuota}
                 />
               )}
-              {showGlobalQuota &&
-              globalQuota!.quantity &&
-              globalQuota!.quotaRefreshTime ? (
+              {showGlobalQuota && firstGlobalQuota!.quotaRefreshTime ? (
                 <UsageQuotaTitle
-                  quantity={globalQuota!.quantity}
-                  quotaRefreshTime={globalQuota!.quotaRefreshTime}
+                  quantity={firstGlobalQuota!.quantity}
+                  quotaRefreshTime={firstGlobalQuota!.quotaRefreshTime}
                 />
               ) : undefined}
             </AppText>

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -221,7 +221,17 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
   const showGlobalQuota =
     !!quotaResponse?.globalQuota &&
     cart.length > 0 &&
+    /**
+     * We only display global limit messages if there is only one global limit,
+     * since we have not catered for showing global limit messages for multiple
+     * categories.
+     */
+    quotaResponse.globalQuota.length === 1 &&
     !!getProduct(cart[0].category)?.quantity.usage;
+
+  const globalQuota = showGlobalQuota
+    ? quotaResponse!.globalQuota![0]
+    : undefined;
 
   return (
     <View>
@@ -253,16 +263,13 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
                 />
               )}
               {showGlobalQuota &&
-                quotaResponse!.globalQuota!.map(
-                  ({ quantity, quotaRefreshTime }, index: number) =>
-                    quotaRefreshTime ? (
-                      <UsageQuotaTitle
-                        key={index}
-                        quantity={quantity}
-                        quotaRefreshTime={quotaRefreshTime}
-                      />
-                    ) : undefined
-                )}
+              globalQuota!.quantity &&
+              globalQuota!.quotaRefreshTime ? (
+                <UsageQuotaTitle
+                  quantity={globalQuota!.quantity}
+                  quotaRefreshTime={globalQuota!.quotaRefreshTime}
+                />
+              ) : undefined}
             </AppText>
             {loading ? (
               <ActivityIndicator

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -225,7 +225,7 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
      * We only display global limit messages if there is only one category for now
      */
     allProducts?.length === 1 &&
-    !!getProduct(cart[0].category)?.quantity.usage;
+    !!allProducts[0].quantity.usage;
 
   const firstGlobalQuota = showGlobalQuota
     ? quotaResponse!.globalQuota![0]


### PR DESCRIPTION
This is related to #170 and #171 .

Global limits messages should only display if there is a single item category for now, since we have not decided how to show global limits messages for policies with multiple categories.

### Tests

- [x] `ffth-belanja-stg` should show global limits messages
- [x] `ffth-cfp-stg` should **not** show global limits messages
- [x] Every other distribution should **not** show global limits messages