### PR TITLE
chore: add dependabot.yml for npm deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Set up dependabot to get weekly automatic version updates!
* [GitHub's blogpost](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)
* [Setup instructions](https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates#enabling-github-dependabot-version-updates)