### PR TITLE
fix: add additional validation for phone number identifier input using regex

### DIFF
--- a/src/utils/validateIdentifierInputs.test.ts
+++ b/src/utils/validateIdentifierInputs.test.ts
@@ -41,6 +41,37 @@ describe("validateIdentifierInputs", () => {
     ).toBe(true);
   });
 
+  it("should throw error if input is phone number and fails default regex", () => {
+    expect.assertions(3);
+    expect(() =>
+      validateIdentifierInputs([
+        {
+          label: "input without +",
+          value: "1234567",
+          textInputType: "PHONE_NUMBER"
+        }
+      ])
+    ).toThrow("Enter valid country code and contact number.");
+    expect(() =>
+      validateIdentifierInputs([
+        {
+          label: "input with invalid characters",
+          value: "+1234567~",
+          textInputType: "PHONE_NUMBER"
+        }
+      ])
+    ).toThrow("Enter valid country code and contact number.");
+    expect(() =>
+      validateIdentifierInputs([
+        {
+          label: "input with spaces",
+          value: "+1234567 890",
+          textInputType: "PHONE_NUMBER"
+        }
+      ])
+    ).toThrow("Enter valid country code and contact number.");
+  });
+
   it("should throw error if at least one of the identifiers does not match the given regex pattern", () => {
     expect.assertions(2);
     expect(() =>

--- a/src/utils/validateIdentifierInputs.ts
+++ b/src/utils/validateIdentifierInputs.ts
@@ -2,6 +2,8 @@ import { IdentifierInput } from "../types";
 import { fullPhoneNumberValidator } from "./validatePhoneNumbers";
 import { ERROR_MESSAGE } from "../context/alert";
 
+const defaultPhoneNumberValidationRegex = "^\\+[0-9]*$";
+
 const isMatchRegex = (text: string, regex?: string): boolean => {
   if (!regex) {
     return true;
@@ -25,7 +27,10 @@ export const validateIdentifierInputs = (
     }
     if (
       textInputType === "PHONE_NUMBER" &&
-      !isMatchRegex(value, validationRegex)
+      !isMatchRegex(
+        value,
+        validationRegex ? validationRegex : defaultPhoneNumberValidationRegex
+      )
     ) {
       throw new Error(ERROR_MESSAGE.INVALID_PHONE_AND_COUNTRY_CODE);
     }

--- a/src/utils/validateIdentifierInputs.ts
+++ b/src/utils/validateIdentifierInputs.ts
@@ -23,6 +23,12 @@ export const validateIdentifierInputs = (
     if (textInputType === "NUMBER" && isNaN(Number(value))) {
       throw new Error(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
     }
+    if (
+      textInputType === "PHONE_NUMBER" &&
+      !isMatchRegex(value, validationRegex)
+    ) {
+      throw new Error(ERROR_MESSAGE.INVALID_PHONE_AND_COUNTRY_CODE);
+    }
     if (!isMatchRegex(value, validationRegex)) {
       throw new Error(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
     }


### PR DESCRIPTION
will we need a default regex validation? in the event phone number does not have a regex.