### PR TITLE
fix: input env var in deploy preview

### DIFF
--- a/.github/workflows/deploy_branch_preview.yml
+++ b/.github/workflows/deploy_branch_preview.yml
@@ -89,6 +89,14 @@ jobs:
           DOMAIN_FORMAT: ${{ secrets.TEST_DOMAIN_FORMAT }}
         run: expo publish --non-interactive --release-channel pr${{ github.event.number }}
       - name: Expo Publish Storybook Channel
+        env:
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          APP_BUILD_VERSION: ${{ github.run_number }}
+          APP_BINARY_VERSION: ${{ steps.latestBinaryVersion.outputs.version }}
+          DOMAIN_FORMAT: ${{ secrets.TEST_DOMAIN_FORMAT }} 
         run: expo publish --non-interactive --release-channel storybook-pr${{ github.event.number }}
       - name: Add Comment To PR
         uses: mshick/add-pr-comment@v1

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -78,4 +78,12 @@ jobs:
           DOMAIN_FORMAT: ${{ secrets.TEST_DOMAIN_FORMAT }}
         run: expo publish --non-interactive --release-channel staging
       - name: Expo Publish Storybook Channel
+        env:
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          APP_BUILD_VERSION: ${{ github.run_number }}
+          APP_BINARY_VERSION: ${{ steps.latestBinaryVersion.outputs.version }}
+          DOMAIN_FORMAT: ${{ secrets.TEST_DOMAIN_FORMAT }}
         run: expo publish --non-interactive --release-channel storybook-staging


### PR DESCRIPTION
This PR contains a fix for the failing deploy branch preview for storybook possibly due to an update in expo-cli requiring the env variables to be restated in the workflow job.