### PR TITLE
feat: run e2e after staging is deployed

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -3,11 +3,15 @@ name: E2E Tests
 on:
   # Runs E2E every day at 9am and 5pm (0100, 0900 UTC)
   schedule:
-    - cron: '0 1,9 * * *'
-  # Runs on every push to master
-  push:
+    - cron: "0 1,9 * * *"
+  # Runs after staging is redeployed
+  workflow_run:
+    workflows:
+      - "Deploy Staging"
     branches:
       - master
+    types:
+      - completed
 
 jobs:
   e2e_test:


### PR DESCRIPTION
Since the E2E tests run on push to master, it may run concurrently with the staging deployment. This could result in our E2E tests not using the newly deployed staging Expo application, which is unintended