### PR TITLE
feat: redemption stats ui changes

### DIFF
--- a/src/components/DailyStatistics/DailyStatisticsScreen.tsx
+++ b/src/components/DailyStatistics/DailyStatisticsScreen.tsx
@@ -21,7 +21,7 @@ import { ImportantMessageContentContext } from "../../context/importantMessage";
 import { KeyboardAvoidingScrollView } from "../Layout/KeyboardAvoidingScrollView";
 import { TransactionHistoryCard } from "./TransactionHistoryCard";
 import { StatisticsHeader } from "./StatisticsHeader";
-import { addDays, subDays, getTime } from "date-fns";
+import { addDays, subDays, getTime, isSameDay } from "date-fns";
 import { AlertModalContext, ERROR_MESSAGE } from "../../context/alert";
 import { navigateHome } from "../../common/navigation";
 import { NavigationProps } from "../../types";
@@ -84,8 +84,10 @@ const DailyStatisticsScreen: FunctionComponent<NavigationProps> = ({
   };
 
   const onPressNextDay = (): void => {
-    const nextDay = getTime(addDays(currentTimestamp, 1));
-    setCurrentTimestamp(nextDay);
+    if (!isSameDay(currentTimestamp, Date.now())) {
+      const nextDay = getTime(addDays(currentTimestamp, 1));
+      setCurrentTimestamp(nextDay);
+    }
   };
 
   useEffect(() => {

--- a/src/components/DailyStatistics/DailyStatisticsScreen.tsx
+++ b/src/components/DailyStatistics/DailyStatisticsScreen.tsx
@@ -104,7 +104,7 @@ const DailyStatisticsScreen: FunctionComponent<NavigationProps> = ({
         scrollViewContentContainerStyle={{
           flexGrow: 1,
           alignItems: "center",
-          paddingBottom: size(2)
+          paddingBottom: size(1)
         }}
       >
         <TopBackground

--- a/src/components/DailyStatistics/TitleStatistic.tsx
+++ b/src/components/DailyStatistics/TitleStatistic.tsx
@@ -3,7 +3,7 @@ import { size, fontSize } from "../../common/styles";
 import { View, StyleSheet, TouchableOpacity } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { AppText } from "../Layout/AppText";
-import { format } from "date-fns";
+import { format, isSameDay } from "date-fns";
 
 interface TitleStatisticComponent {
   totalCount: number | null;
@@ -90,7 +90,9 @@ export const TitleStatisticComponent: FunctionComponent<TitleStatisticComponent>
             <MaterialCommunityIcons
               name="chevron-right"
               size={size(4)}
-              color="white"
+              color={
+                isSameDay(currentTimestamp, Date.now()) ? "#597585" : "white"
+              }
               style={styles.chevron}
             />
           </View>

--- a/src/components/DailyStatistics/TransactionHistoryCard.tsx
+++ b/src/components/DailyStatistics/TransactionHistoryCard.tsx
@@ -9,6 +9,7 @@ interface TransactionHistoryCardComponent {
     name: string;
     category: string;
     quantityText: string;
+    descriptionAlert?: string;
   }[];
   loading: boolean;
 }
@@ -40,6 +41,16 @@ const styles = StyleSheet.create({
     marginBottom: size(3),
     flexDirection: "row",
     textAlign: "center"
+  },
+  reasonAlert: {
+    marginLeft: size(1.5),
+    marginTop: -size(3),
+    marginBottom: size(3),
+    fontFamily: "brand-italic",
+    color: color("red", 50)
+  },
+  descriptionAlertText: {
+    alignItems: "flex-end"
   }
 });
 
@@ -52,11 +63,18 @@ export const TransactionHistoryCardComponent: FunctionComponent<TransactionHisto
       {!loading ? (
         transactionHistory.length !== 0 ? (
           transactionHistory.map(item => (
-            <View style={styles.transactionText} key={item.category}>
-              <AppText style={styles.categoryName}>{item.name}</AppText>
+            <View key={item.category}>
               <View style={styles.transactionText}>
-                <AppText style={styles.quantityText}>
-                  {item.quantityText}
+                <AppText style={styles.categoryName}>{item.name}</AppText>
+                <View style={styles.transactionText}>
+                  <AppText style={styles.quantityText}>
+                    {item.quantityText}
+                  </AppText>
+                </View>
+              </View>
+              <View style={styles.descriptionAlertText}>
+                <AppText style={styles.reasonAlert}>
+                  {item.descriptionAlert ?? ""}
                 </AppText>
               </View>
             </View>

--- a/src/hooks/useDailyStatistics/useDailyStatistics.test.tsx
+++ b/src/hooks/useDailyStatistics/useDailyStatistics.test.tsx
@@ -126,7 +126,8 @@ describe("useDailyStatistics", () => {
         category: "vouchers",
         name: "vouchers",
         quantityText: "9,999,999 qty",
-        descriptionAlert: undefined
+        descriptionAlert: undefined,
+        order: -1
       }
     ]);
   });
@@ -178,7 +179,8 @@ describe("useDailyStatistics", () => {
         category: "vouchers",
         name: "vouchers",
         quantityText: "9,999,999 qty",
-        descriptionAlert: undefined
+        descriptionAlert: undefined,
+        order: -1
       }
     ]);
 
@@ -215,7 +217,8 @@ describe("useDailyStatistics", () => {
           category: "vouchers",
           name: "vouchers",
           quantityText: "9,999,999 qty",
-          descriptionAlert: undefined
+          descriptionAlert: undefined,
+          order: -1
         }
       ]);
     });
@@ -243,7 +246,8 @@ describe("useDailyStatistics", () => {
           category: "vouchers",
           name: "vouchers",
           quantityText: "20 qty",
-          descriptionAlert: undefined
+          descriptionAlert: undefined,
+          order: -1
         }
       ]);
     });

--- a/src/hooks/useDailyStatistics/useDailyStatistics.test.tsx
+++ b/src/hooks/useDailyStatistics/useDailyStatistics.test.tsx
@@ -125,7 +125,8 @@ describe("useDailyStatistics", () => {
       {
         category: "vouchers",
         name: "vouchers",
-        quantityText: "9,999,999 qty"
+        quantityText: "9,999,999 qty",
+        descriptionAlert: undefined
       }
     ]);
   });
@@ -176,7 +177,8 @@ describe("useDailyStatistics", () => {
       {
         category: "vouchers",
         name: "vouchers",
-        quantityText: "9,999,999 qty"
+        quantityText: "9,999,999 qty",
+        descriptionAlert: undefined
       }
     ]);
 
@@ -212,7 +214,8 @@ describe("useDailyStatistics", () => {
         {
           category: "vouchers",
           name: "vouchers",
-          quantityText: "9,999,999 qty"
+          quantityText: "9,999,999 qty",
+          descriptionAlert: undefined
         }
       ]);
     });
@@ -239,7 +242,8 @@ describe("useDailyStatistics", () => {
         {
           category: "vouchers",
           name: "vouchers",
-          quantityText: "20 qty"
+          quantityText: "20 qty",
+          descriptionAlert: undefined
         }
       ]);
     });

--- a/src/hooks/useDailyStatistics/useDailyStatistics.tsx
+++ b/src/hooks/useDailyStatistics/useDailyStatistics.tsx
@@ -3,6 +3,7 @@ import { usePrevious } from "../usePrevious";
 import { CampaignConfigContext } from "../../context/campaignConfig";
 import { getDailyStatistics } from "../../services/statistics";
 import { countTotalTransactionsAndByCategory } from "./utils";
+import { sortTransactionsByOrder } from "../../components/CustomerQuota/utils";
 
 export type StatisticsHook = {
   totalCount: number | null;
@@ -55,7 +56,9 @@ export const useDailyStatistics = (
           response.pastTransactions,
           policies
         );
-        setTransactionHistory(summarisedTransactionHistory);
+        setTransactionHistory(
+          summarisedTransactionHistory.sort(sortTransactionsByOrder)
+        );
         setTotalCount(summarisedTotalCount);
 
         if (summarisedTransactionHistory.length !== 0) {

--- a/src/hooks/useDailyStatistics/useDailyStatistics.tsx
+++ b/src/hooks/useDailyStatistics/useDailyStatistics.tsx
@@ -11,6 +11,7 @@ export type StatisticsHook = {
     name: string;
     category: string;
     quantityText: string;
+    descriptionAlert?: string;
   }[];
   error?: Error;
   loading: boolean;

--- a/src/hooks/useDailyStatistics/utils.test.ts
+++ b/src/hooks/useDailyStatistics/utils.test.ts
@@ -148,13 +148,20 @@ describe("countTotalTransactionsAndByCategory", () => {
         {
           category: "instant-noodles",
           name: "🍜 Instant Noodles",
-          quantityText: "999 pack(s)"
+          quantityText: "999 pack(s)",
+          descriptionAlert: undefined
         },
-        { category: "chocolate", name: "🍫 Chocolate", quantityText: "$3,000" },
+        {
+          category: "chocolate",
+          name: "🍫 Chocolate",
+          quantityText: "$3,000",
+          descriptionAlert: undefined
+        },
         {
           category: "vouchers",
           name: "Funfair Vouchers",
-          quantityText: "20 qty"
+          quantityText: "20 qty",
+          descriptionAlert: undefined
         }
       ]
     });
@@ -173,7 +180,8 @@ describe("countTotalTransactionsAndByCategory", () => {
         {
           category: "instant-noodles",
           name: "🍜 Instant Noodles",
-          quantityText: "999 pack(s)"
+          quantityText: "999 pack(s)",
+          descriptionAlert: undefined
         }
       ]
     });
@@ -192,7 +200,8 @@ describe("countTotalTransactionsAndByCategory", () => {
         {
           category: "funny-category",
           name: "funny-category",
-          quantityText: "999 qty"
+          quantityText: "999 qty",
+          descriptionAlert: undefined
         }
       ]
     });

--- a/src/hooks/useDailyStatistics/utils.test.ts
+++ b/src/hooks/useDailyStatistics/utils.test.ts
@@ -6,6 +6,7 @@ describe("countTotalTransactionsAndByCategory", () => {
   let campaignPolicy: CampaignPolicy[] = [];
   let pastInstantNoodleTransactions: DailyStatistics[];
   let invalidPastTransactions: DailyStatistics[];
+  let pastTransactionsWithAppeal: DailyStatistics[];
 
   beforeAll(() => {
     pastTransactions = [
@@ -38,6 +39,14 @@ describe("countTotalTransactionsAndByCategory", () => {
       {
         category: "funny-category",
         quantity: 999,
+        transactionTime: new Date(12000000000)
+      }
+    ];
+
+    pastTransactionsWithAppeal = [
+      {
+        category: "appeal-product",
+        quantity: 200,
         transactionTime: new Date(12000000000)
       }
     ];
@@ -134,11 +143,19 @@ describe("countTotalTransactionsAndByCategory", () => {
             }
           }
         ]
+      },
+      {
+        category: "appeal-product",
+        name: "This Product is for Appeal",
+        order: 6,
+        type: "REDEEM",
+        categoryType: "APPEAL",
+        quantity: { period: 1, limit: 1, default: 1 }
       }
     ];
   });
 
-  it("should return multiple summarised transactions categories with total count and count per category and the name to be displayed on the stats page", () => {
+  it("should return multiple summarised transactions categories with total count and count per category and the name to be displayed on the stats page, as well as ordered by ascending order number", () => {
     expect.assertions(1);
     expect(
       countTotalTransactionsAndByCategory(pastTransactions, campaignPolicy)
@@ -149,19 +166,22 @@ describe("countTotalTransactionsAndByCategory", () => {
           category: "instant-noodles",
           name: "🍜 Instant Noodles",
           quantityText: "999 pack(s)",
-          descriptionAlert: undefined
+          descriptionAlert: undefined,
+          order: 2
         },
         {
           category: "chocolate",
           name: "🍫 Chocolate",
           quantityText: "$3,000",
-          descriptionAlert: undefined
+          descriptionAlert: undefined,
+          order: 3
         },
         {
           category: "vouchers",
           name: "Funfair Vouchers",
           quantityText: "20 qty",
-          descriptionAlert: undefined
+          descriptionAlert: undefined,
+          order: 4
         }
       ]
     });
@@ -181,7 +201,8 @@ describe("countTotalTransactionsAndByCategory", () => {
           category: "instant-noodles",
           name: "🍜 Instant Noodles",
           quantityText: "999 pack(s)",
-          descriptionAlert: undefined
+          descriptionAlert: undefined,
+          order: 2
         }
       ]
     });
@@ -201,7 +222,29 @@ describe("countTotalTransactionsAndByCategory", () => {
           category: "funny-category",
           name: "funny-category",
           quantityText: "999 qty",
-          descriptionAlert: undefined
+          descriptionAlert: undefined,
+          order: -1
+        }
+      ]
+    });
+  });
+
+  it("should have appeal alertDescription 'via appeal' if product is from an appeal flow", () => {
+    expect.assertions(1);
+    expect(
+      countTotalTransactionsAndByCategory(
+        pastTransactionsWithAppeal,
+        campaignPolicy
+      )
+    ).toStrictEqual({
+      summarisedTotalCount: 200,
+      summarisedTransactionHistory: [
+        {
+          category: "appeal-product",
+          name: "This Product is for Appeal",
+          quantityText: "200 qty",
+          descriptionAlert: "via appeal",
+          order: 6
         }
       ]
     });

--- a/src/hooks/useDailyStatistics/utils.ts
+++ b/src/hooks/useDailyStatistics/utils.ts
@@ -8,6 +8,7 @@ type SummarisedTransactions = {
     name: string;
     category: string;
     quantityText: string;
+    descriptionAlert?: string;
   }[];
   summarisedTotalCount: number;
 };
@@ -40,7 +41,12 @@ export const countTotalTransactionsAndByCategory = (
               type: "POSTFIX",
               label: " qty"
             }
-          )
+          ),
+          descriptionAlert:
+            policies?.find(item => item.category === key)?.categoryType ===
+            "APPEAL"
+              ? "via appeal"
+              : undefined
         });
         prev.summarisedTotalCount += totalQuantityInCategory;
         return prev;

--- a/src/hooks/useDailyStatistics/utils.ts
+++ b/src/hooks/useDailyStatistics/utils.ts
@@ -22,13 +22,16 @@ export const countTotalTransactionsAndByCategory = (
     .groupBy("category")
     .reduce<SummarisedTransactions>(
       (prev, transactionsByCategory, key) => {
+        const findItemByCategory = policies?.find(
+          item => item.category === key
+        );
         const totalQuantityInCategory = sumBy(
           transactionsByCategory,
           "quantity"
         );
         prev.summarisedTransactionHistory.push({
           name:
-            policies?.find(item => item.category === key)?.name ??
+            findItemByCategory?.name ??
             (() => {
               Sentry.captureException(
                 `Unable to find item category in policies: ${key}}`
@@ -38,17 +41,16 @@ export const countTotalTransactionsAndByCategory = (
           category: key,
           quantityText: formatQuantityText(
             totalQuantityInCategory,
-            policies?.find(item => item.category === key)?.quantity.unit || {
+            findItemByCategory?.quantity.unit || {
               type: "POSTFIX",
               label: " qty"
             }
           ),
           descriptionAlert:
-            policies?.find(item => item.category === key)?.categoryType ===
-            "APPEAL"
+            findItemByCategory?.categoryType === "APPEAL"
               ? "via appeal"
               : undefined,
-          order: policies?.find(item => item.category === key)?.order ?? -1
+          order: findItemByCategory?.order ?? -1
         });
         prev.summarisedTotalCount += totalQuantityInCategory;
         return prev;

--- a/src/hooks/useDailyStatistics/utils.ts
+++ b/src/hooks/useDailyStatistics/utils.ts
@@ -9,6 +9,7 @@ type SummarisedTransactions = {
     category: string;
     quantityText: string;
     descriptionAlert?: string;
+    order: number;
   }[];
   summarisedTotalCount: number;
 };
@@ -46,7 +47,8 @@ export const countTotalTransactionsAndByCategory = (
             policies?.find(item => item.category === key)?.categoryType ===
             "APPEAL"
               ? "via appeal"
-              : undefined
+              : undefined,
+          order: policies?.find(item => item.category === key)?.order ?? -1
         });
         prev.summarisedTotalCount += totalQuantityInCategory;
         return prev;


### PR DESCRIPTION
[notion](https://www.notion.so/Disabled-chevrons-for-future-date-in-redemption-statistics-and-sorting-will-be-by-sort-property-b3226495c3b34d4fa7eea588c5d6fc12)

Completing certain UI changes that were not mentioned/confirmed in previous story!

- [x]  Ensure stats order is standardised with policy order property
- [x]  Disable right chevron if date is > today
- [x]  add `via appeal` instead of `*chargeable` , applied to all appeal tt token items