### PR TITLE
fix: added scroll view for nav drawer

### DIFF
--- a/src/components/Layout/DrawerNavigation.tsx
+++ b/src/components/Layout/DrawerNavigation.tsx
@@ -164,7 +164,7 @@ export const DrawerNavigationComponent: FunctionComponent<DrawerContentComponent
             borderTopWidth: 1,
             flex: 1,
             justifyContent: "space-between",
-            minHeight: HEIGHT * 0.6,
+            minHeight: HEIGHT * 0.55,
           }}
         >
           <View>

--- a/src/components/Layout/DrawerNavigation.tsx
+++ b/src/components/Layout/DrawerNavigation.tsx
@@ -5,6 +5,7 @@ import {
   TouchableOpacity,
   View,
   ScrollView,
+  Platform,
 } from "react-native";
 import {
   DrawerContentComponentProps,
@@ -171,7 +172,12 @@ export const DrawerNavigationComponent: FunctionComponent<DrawerContentComponent
             accessibilityLabel="drawer-nav-logout-button"
           />
         </View>
-        <View style={{ marginTop: size(10), marginBottom: size(4) }}>
+        <View
+          style={{
+            marginTop: Platform.OS === "ios" ? 360 : 125,
+            marginBottom: size(4),
+          }}
+        >
           <BottomNavigationLink onPress={showHelpModal}>
             {i18nt("navigationDrawer", "helpSupport")}
           </BottomNavigationLink>

--- a/src/components/Layout/DrawerNavigation.tsx
+++ b/src/components/Layout/DrawerNavigation.tsx
@@ -5,7 +5,7 @@ import {
   TouchableOpacity,
   View,
   ScrollView,
-  Platform,
+  Dimensions,
 } from "react-native";
 import {
   DrawerContentComponentProps,
@@ -20,6 +20,8 @@ import { useDrawerContext, DrawerButton } from "../../context/drawer";
 import Constants from "expo-constants";
 import { AlertModalContext, CONFIRMATION_MESSAGE } from "../../context/alert";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
+
+const { height: HEIGHT } = Dimensions.get("window");
 
 const styles = StyleSheet.create({
   container: {
@@ -154,30 +156,30 @@ export const DrawerNavigationComponent: FunctionComponent<DrawerContentComponent
         </TouchableOpacity>
       </View>
 
-      <ScrollView>
+      <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
         <View
           style={{
             marginTop: size(3),
             borderTopColor: color("grey", 20),
             borderTopWidth: 1,
+            flex: 1,
+            justifyContent: "space-between",
+            minHeight: HEIGHT * 0.6,
           }}
         >
-          {drawerButtons.map((button) => (
-            <DrawerButtonComponent {...button} key={button.label} />
-          ))}
-          <DrawerButtonComponent
-            icon="logout"
-            label={i18nt("navigationDrawer", "logout")}
-            onPress={onPressLogout}
-            accessibilityLabel="drawer-nav-logout-button"
-          />
+          <View>
+            {drawerButtons.map((button) => (
+              <DrawerButtonComponent {...button} key={button.label} />
+            ))}
+            <DrawerButtonComponent
+              icon="logout"
+              label={i18nt("navigationDrawer", "logout")}
+              onPress={onPressLogout}
+              accessibilityLabel="drawer-nav-logout-button"
+            />
+          </View>
         </View>
-        <View
-          style={{
-            marginTop: Platform.OS === "ios" ? 360 : 125,
-            marginBottom: size(4),
-          }}
-        >
+        <View>
           <BottomNavigationLink onPress={showHelpModal}>
             {i18nt("navigationDrawer", "helpSupport")}
           </BottomNavigationLink>

--- a/src/components/Layout/DrawerNavigation.tsx
+++ b/src/components/Layout/DrawerNavigation.tsx
@@ -13,6 +13,7 @@ import { useDrawerContext, DrawerButton } from "../../context/drawer";
 import Constants from "expo-constants";
 import { AlertModalContext, CONFIRMATION_MESSAGE } from "../../context/alert";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
+import { ScrollView } from "react-native-gesture-handler";
 
 const styles = StyleSheet.create({
   container: {
@@ -126,70 +127,72 @@ export const DrawerNavigationComponent: FunctionComponent<DrawerContentComponent
 
   return (
     <View style={{ flex: 1, marginBottom: size(2) }}>
-      <View
-        style={{
-          marginTop: size(8),
-          marginRight: size(2),
-          alignItems: "flex-end",
-        }}
-      >
-        <TouchableOpacity
-          onPress={onPressCloseDrawer}
+      <ScrollView>
+        <View
           style={{
-            padding: size(1),
+            marginTop: size(8),
+            marginRight: size(2),
+            alignItems: "flex-end",
           }}
         >
-          <MaterialCommunityIcons
-            name="close"
-            size={size(3)}
-            color={color("blue", 50)}
+          <TouchableOpacity
+            onPress={onPressCloseDrawer}
+            style={{
+              padding: size(1),
+            }}
+          >
+            <MaterialCommunityIcons
+              name="close"
+              size={size(3)}
+              color={color("blue", 50)}
+            />
+          </TouchableOpacity>
+        </View>
+        <View
+          style={{
+            marginTop: size(3),
+            borderTopColor: color("grey", 20),
+            borderTopWidth: 1,
+          }}
+        >
+          {drawerButtons.map((button) => (
+            <DrawerButtonComponent {...button} key={button.label} />
+          ))}
+          <DrawerButtonComponent
+            icon="logout"
+            label={i18nt("navigationDrawer", "logout")}
+            onPress={onPressLogout}
+            accessibilityLabel="drawer-nav-logout-button"
           />
-        </TouchableOpacity>
-      </View>
-      <View
-        style={{
-          marginTop: size(3),
-          borderTopColor: color("grey", 20),
-          borderTopWidth: 1,
-        }}
-      >
-        {drawerButtons.map((button) => (
-          <DrawerButtonComponent {...button} key={button.label} />
-        ))}
-        <DrawerButtonComponent
-          icon="logout"
-          label={i18nt("navigationDrawer", "logout")}
-          onPress={onPressLogout}
-          accessibilityLabel="drawer-nav-logout-button"
-        />
-      </View>
-      <View style={{ marginTop: "auto", marginBottom: size(4) }}>
-        <BottomNavigationLink onPress={showHelpModal}>
-          {i18nt("navigationDrawer", "helpSupport")}
-        </BottomNavigationLink>
-        <BottomNavigationLink
-          onPress={() => {
-            Linking.openURL("https://www.supplyally.gov.sg/terms-of-use");
-          }}
-        >
-          {i18nt("navigationDrawer", "termsOfUse")}
-        </BottomNavigationLink>
-        <BottomNavigationLink
-          onPress={() => {
-            Linking.openURL("https://www.supplyally.gov.sg/privacy");
-          }}
-        >
-          {i18nt("navigationDrawer", "privacyStatement")}
-        </BottomNavigationLink>
-        <BottomNavigationLink
-          onPress={() => {
-            Linking.openURL("https://www.tech.gov.sg/report_vulnerability");
-          }}
-        >
-          {i18nt("navigationDrawer", "reportVulnerability")}
-        </BottomNavigationLink>
-        <AppText style={styles.bottomVersionText}>{version}</AppText>
-      </View>
+        </View>
+        <View style={{ marginTop: "auto", marginBottom: size(4) }}>
+          <BottomNavigationLink onPress={showHelpModal}>
+            {i18nt("navigationDrawer", "helpSupport")}
+          </BottomNavigationLink>
+          <BottomNavigationLink
+            onPress={() => {
+              Linking.openURL("https://www.supplyally.gov.sg/terms-of-use");
+            }}
+          >
+            {i18nt("navigationDrawer", "termsOfUse")}
+          </BottomNavigationLink>
+          <BottomNavigationLink
+            onPress={() => {
+              Linking.openURL("https://www.supplyally.gov.sg/privacy");
+            }}
+          >
+            {i18nt("navigationDrawer", "privacyStatement")}
+          </BottomNavigationLink>
+          <BottomNavigationLink
+            onPress={() => {
+              Linking.openURL("https://www.tech.gov.sg/report_vulnerability");
+            }}
+          >
+            {i18nt("navigationDrawer", "reportVulnerability")}
+          </BottomNavigationLink>
+          <AppText style={styles.bottomVersionText}>{version}</AppText>
+        </View>
+      </ScrollView>
     </View>
   );
 };

--- a/src/components/Layout/DrawerNavigation.tsx
+++ b/src/components/Layout/DrawerNavigation.tsx
@@ -1,5 +1,11 @@
 import React, { FunctionComponent, useCallback, useContext } from "react";
-import { Linking, StyleSheet, TouchableOpacity, View } from "react-native";
+import {
+  Linking,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  ScrollView,
+} from "react-native";
 import {
   DrawerContentComponentProps,
   DrawerActions,
@@ -13,7 +19,6 @@ import { useDrawerContext, DrawerButton } from "../../context/drawer";
 import Constants from "expo-constants";
 import { AlertModalContext, CONFIRMATION_MESSAGE } from "../../context/alert";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
-import { ScrollView } from "react-native-gesture-handler";
 
 const styles = StyleSheet.create({
   container: {
@@ -127,27 +132,28 @@ export const DrawerNavigationComponent: FunctionComponent<DrawerContentComponent
 
   return (
     <View style={{ flex: 1, marginBottom: size(2) }}>
-      <ScrollView>
-        <View
+      <View
+        style={{
+          marginTop: size(8),
+          marginRight: size(2),
+          alignItems: "flex-end",
+        }}
+      >
+        <TouchableOpacity
+          onPress={onPressCloseDrawer}
           style={{
-            marginTop: size(8),
-            marginRight: size(2),
-            alignItems: "flex-end",
+            padding: size(1),
           }}
         >
-          <TouchableOpacity
-            onPress={onPressCloseDrawer}
-            style={{
-              padding: size(1),
-            }}
-          >
-            <MaterialCommunityIcons
-              name="close"
-              size={size(3)}
-              color={color("blue", 50)}
-            />
-          </TouchableOpacity>
-        </View>
+          <MaterialCommunityIcons
+            name="close"
+            size={size(3)}
+            color={color("blue", 50)}
+          />
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView>
         <View
           style={{
             marginTop: size(3),
@@ -165,7 +171,7 @@ export const DrawerNavigationComponent: FunctionComponent<DrawerContentComponent
             accessibilityLabel="drawer-nav-logout-button"
           />
         </View>
-        <View style={{ marginTop: "auto", marginBottom: size(4) }}>
+        <View style={{ marginTop: size(10), marginBottom: size(4) }}>
           <BottomNavigationLink onPress={showHelpModal}>
             {i18nt("navigationDrawer", "helpSupport")}
           </BottomNavigationLink>

--- a/src/components/Layout/DrawerNavigation.tsx
+++ b/src/components/Layout/DrawerNavigation.tsx
@@ -5,7 +5,6 @@ import {
   TouchableOpacity,
   View,
   ScrollView,
-  Dimensions,
 } from "react-native";
 import {
   DrawerContentComponentProps,
@@ -20,8 +19,6 @@ import { useDrawerContext, DrawerButton } from "../../context/drawer";
 import Constants from "expo-constants";
 import { AlertModalContext, CONFIRMATION_MESSAGE } from "../../context/alert";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
-
-const { height: HEIGHT } = Dimensions.get("window");
 
 const styles = StyleSheet.create({
   container: {
@@ -156,15 +153,18 @@ export const DrawerNavigationComponent: FunctionComponent<DrawerContentComponent
         </TouchableOpacity>
       </View>
 
-      <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+      <ScrollView
+        contentContainerStyle={{
+          flexGrow: 1,
+          justifyContent: "space-between",
+        }}
+      >
         <View
           style={{
             marginTop: size(3),
             borderTopColor: color("grey", 20),
             borderTopWidth: 1,
-            flex: 1,
-            justifyContent: "space-between",
-            minHeight: HEIGHT * 0.55,
+            marginBottom: size(4),
           }}
         >
           <View>
@@ -179,7 +179,7 @@ export const DrawerNavigationComponent: FunctionComponent<DrawerContentComponent
             />
           </View>
         </View>
-        <View>
+        <View style={{ marginBottom: size(4) }}>
           <BottomNavigationLink onPress={showHelpModal}>
             {i18nt("navigationDrawer", "helpSupport")}
           </BottomNavigationLink>


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

Related to: [Bug: IOS & Android Scale Right Tab](https://www.notion.so/701364d4fbbf4ec1801b766c589973b9?v=24aa9675206d4da9a171ca4073d81b5b&p=9c15e648671e482ba2b53071cc0c2412)

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)


- To scale at max font and max display size for IOS & Android.

**For IOS**

Max Font & Max Display Size:

![iosmax](https://user-images.githubusercontent.com/65886071/99471824-598f8f80-2982-11eb-954b-d4c1dfc51436.jpeg)

Default:
![iosdefault](https://user-images.githubusercontent.com/65886071/99471833-5f857080-2982-11eb-8dc4-37237d312791.jpeg)

**Android**
Max Font & Max Display Size:

Note: Scaled Help & Support to appear within view so that users will know and can scroll down.

<img width="285" alt="Screenshot 2020-11-18 at 9 35 04 AM" src="https://user-images.githubusercontent.com/65886071/99471861-6d3af600-2982-11eb-96de-df4613143f3d.png">


Alternative:
<img width="275" alt="Screenshot 2020-11-18 at 9 35 25 AM" src="https://user-images.githubusercontent.com/65886071/99471972-a1161b80-2982-11eb-9f3c-9d338a8e30da.png">

Default:
<img width="283" alt="Screenshot 2020-11-18 at 9 33 25 AM" src="https://user-images.githubusercontent.com/65886071/99472034-c2770780-2982-11eb-8005-90adefb7ec43.png">

**Dynamic Scaling**

ScrollView is parent view, the parent view wouldn't allow more height so when specify with flexGrow, the container can grow up to flex 1. 
So when the View set to flex 1 , then it can take the space.

-using const { height: HEIGHT } = Dimensions.get("window"); 
- with minHeight: HEIGHT * 0.6  
- This will always be minimum at 60% of the screen height. 

If the phone is really small, and the screen is made bigger, then it will always have the space. If is a large screen, with justifyContent:"space-between", there will be space.

- Removed marginBottom so that the bottom section is adjusted to the bottom.