### PR TITLE
chore: remove unused if block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4405,13 +4405,24 @@
       }
     },
     "@testing-library/react-hooks": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.2.1.tgz",
-      "integrity": "sha512-1OB6Ksvlk6BCJA1xpj8/WWz0XVd1qRcgqdaFAq+xeC6l61Ucj0P6QpA5u+Db/x9gU4DCX8ziR5b66Mlfg0M2RA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.4.2.tgz",
+      "integrity": "sha512-RfPG0ckOzUIVeIqlOc1YztKgFW+ON8Y5xaSPbiBkfj9nMkkiLhLeBXT5icfPX65oJV/zCZu4z8EVnUc6GY9C5A==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.5.4",
-        "@types/testing-library__react-hooks": "^3.0.0"
+        "@types/testing-library__react-hooks": "^3.4.0"
+      },
+      "dependencies": {
+        "@types/testing-library__react-hooks": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.1.tgz",
+          "integrity": "sha512-G4JdzEcq61fUyV6wVW9ebHWEiLK2iQvaBuCHHn9eMSbZzVh4Z4wHnUGIvQOYCCYeu5DnUtFyNYuAAgbSaO/43Q==",
+          "dev": true,
+          "requires": {
+            "@types/react-test-renderer": "*"
+          }
+        }
       }
     },
     "@testing-library/react-native": {

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -212,11 +212,6 @@ export const useCart = (
       const transactions = Object.values(cart)
         .filter(({ quantity }) => quantity)
         .map(({ category, quantity, identifierInputs }) => {
-          if (
-            identifierInputs.length > 0 &&
-            identifierInputs.some((identifierInput) => !identifierInput.value)
-          ) {
-          }
           allIdentifierInputs.push(...identifierInputs);
           return { category, quantity, identifierInputs };
         });


### PR DESCRIPTION
This PR removes an empty `if` block which honestly I am not sure why/how it got in :-( But here are some links:
* [Original PR which used this `if` block](https://github.com/rationally-app/mobile-application/pull/49/files#diff-bd918fb9c4a235da78054870ecaf899a7c46d43ab54320821be7c2f0d4b73561R206)
* [Second PR which removed the contents of the `if` block](https://github.com/rationally-app/mobile-application/pull/86/files#diff-bd918fb9c4a235da78054870ecaf899a7c46d43ab54320821be7c2f0d4b73561R247)

I am quite very sure the `if` block is not needed tho, and everything seems to be working fine as well.

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
