### PR TITLE
fix: Foreign numbers in PhoneNumberInput not formatting properly

### DIFF
--- a/src/utils/phoneNumberFormatter.test.ts
+++ b/src/utils/phoneNumberFormatter.test.ts
@@ -34,9 +34,9 @@ describe("formatPhoneNumber", () => {
   it("should format other region numbers", () => {
     expect.assertions(2);
     // USA
-    expect(formatPhoneNumber("5555551234", "1")).toBe("(555) 555-1234");
+    expect(formatPhoneNumber("5555551234", "1")).toBe("555-555-1234");
     // Malaysia
-    expect(formatPhoneNumber("312341234", "60")).toBe("03-1234 1234");
+    expect(formatPhoneNumber("312341234", "60")).toBe("3-1234 1234");
   });
 });
 
@@ -50,7 +50,7 @@ describe("stripPhoneNumberFormatting", () => {
     expect(stripped).toBe(testPhoneNumber);
     // USA
     formatted = formatPhoneNumber("5555551234", "1");
-    expect(formatted).toBe("(555) 555-1234");
+    expect(formatted).toBe("555-555-1234");
     stripped = stripPhoneNumberFormatting(formatted);
     expect(stripped).toBe("5555551234");
   });

--- a/src/utils/phoneNumberFormatter.ts
+++ b/src/utils/phoneNumberFormatter.ts
@@ -22,10 +22,20 @@ export const formatPhoneNumber = (
 
   if (phoneNumber.length === exampleNumber.length) {
     try {
-      return util.format(
+      /**
+       * Using `PhoneNumberFormat.INTERNATIONAL` because
+       * `PhoneNumberFormat.NATIONAL` was padding 0s to the
+       * start of the phone number.
+       */
+      let result = util.format(
         util.parse(phoneNumber, region),
-        PhoneNumberFormat.NATIONAL
+        PhoneNumberFormat.INTERNATIONAL
       );
+      const indexOfCountryCode =
+        result.indexOf(countryCode) + countryCode.length;
+      result = result.substring(indexOfCountryCode).trim();
+
+      return result;
     } catch (e) {
       return phoneNumber;
     }

--- a/src/utils/phoneNumberFormatter.ts
+++ b/src/utils/phoneNumberFormatter.ts
@@ -7,7 +7,11 @@ export const formatPhoneNumber = (
   countryCode = "65"
 ): string => {
   let region = util.getRegionCodeForCountryCode(Number.parseInt(countryCode));
-  region = region === "ZZ" ? "SG" : region;
+  // Defaults for when region is invalid
+  if (region === "ZZ") {
+    region = "SG";
+    countryCode = "65";
+  }
 
   const exampleNumber = util
     .getExampleNumber(region)


### PR DESCRIPTION
[Notion link](https://www.notion.so/Spacing-in-Contact-number-62a744454055462ca8a94ba2857bd9bc) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->

- A change from using `PhoneNumberFormat.NATIONAL` to `PhoneNumberFormat.INTERNATIONAL` as the former was padding some foreign numbers with 0 as per national standards.

### Problem

Using `PhoneNumberFormat.NATIONAL` for formatting resulted in some region phone numbers being padded at the start with 0 (e.g. `+44 008566434545` being padded with two 0s at the start) since by national standards, the numbers `+44 008566434545` and `+44 8566434545` are equivalent.

### Solution

By switching to `PhoneNumberFormat.INTERNATIONAL`, we preserve the original phone number since no padding of 0s will be performed. However, we will have to manipulate the international phone number in order to remove the country code prefix (e.g. `+44 8566434545` to `8566434545`).

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] ~I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components~
- [ ] ~I've added/updated unit/integration tests~
- [ ] ~I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow~
- [ ] ~I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)~
- [ ] ~I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)~
