### PR TITLE
fix: stay in current screen if error occurs in CustomerQuotaScreen

### DIFF
--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -222,7 +222,6 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
           default:
             showErrorAlert(cartError, () => {
               clearCartError();
-              navigation.goBack();
             });
         }
       } else {


### PR DESCRIPTION
[Notion link](https://www.notion.so/Error-in-Contact-Number-incorrectly-goes-back-to-Collect-Customer-Details-screen-999dd38b6f9e410fa20e9e717024ce69) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->

- Fix to default case when handling errors in `CustomerQuotaScreen` to stay in current screen instead of going back to the previous screen

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] ~I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components~
- [ ] ~I've added/updated unit/integration tests~
- [ ] ~I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow~
- [ ] ~I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)~
- [ ] ~I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)~
