### PR TITLE
chore: CI changelog improvements

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -82,11 +82,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: rlespinasse/github-slug-action@v2.x
+      - name: Set tag variables
+        id: setTags
+        run: |
+          MATCHING_TAGS=$(git tag --sort=-version:refname | grep -m2 -E '^prod-[0-9]+\.[0-9]+\.[0-9]+$')
+          echo ::set-output name=latestTag::$(echo "${MATCHING_TAGS}" | head -n1)
+          echo ::set-output name=previousTag::$(echo "${MATCHING_TAGS}" | tail -n1)
       - name: Generate Changelog
         id: changelog
         uses: metcalfc/changelog-generator@v0.4.0
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
+          head-ref: ${{ steps.setTags.outputs.latestTag }}
+          base-ref: ${{ steps.setTags.outputs.previousTag }}
       - name: Creating Release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
Currently trying to rerun a failed `create release` github action fails as the changelog action errors out. By setting the explicit `head-ref` and `base-ref`, we let the action know the exact changelog to generate, and update the old one if need be. This allows us to rerun the failed actions multiple times.


- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
