### PR TITLE
chore: ensure tags are fetched properly

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -81,6 +81,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Fetch Tags
+        run: git fetch --prune --unshallow --tags -f
       - uses: rlespinasse/github-slug-action@v2.x
       - name: Set tag variables
         id: setTags


### PR DESCRIPTION
Tags were not being fetched properly in `create_release`, so `git tag` was returning only the latest tag, causing the changelog generation to fail.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
