### PR TITLE
chore: freeze ubuntu image to 18.04 instead of latest

### DIFF
--- a/.github/workflows/deploy_branch_preview.yml
+++ b/.github/workflows/deploy_branch_preview.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   test:
     name: Lint & Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -36,7 +36,7 @@ jobs:
   deploy_branch_preview:
     name: Deploy Branch Preview
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -96,7 +96,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           APP_BUILD_VERSION: ${{ github.run_number }}
           APP_BINARY_VERSION: ${{ steps.latestBinaryVersion.outputs.version }}
-          DOMAIN_FORMAT: ${{ secrets.TEST_DOMAIN_FORMAT }} 
+          DOMAIN_FORMAT: ${{ secrets.TEST_DOMAIN_FORMAT }}
         run: expo publish --non-interactive --release-channel storybook-pr${{ github.event.number }}
       - name: Add Comment To PR
         uses: mshick/add-pr-comment@v1

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: Lint & Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -26,7 +26,7 @@ jobs:
   deploy_prod:
     name: Deploy To Production
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     outputs:
       releaseChannel: ${{ steps.releaseChannel.outputs.releaseChannel }}
       latestBinaryVersion: ${{ steps.latestBinaryVersion.outputs.version }}
@@ -78,7 +78,7 @@ jobs:
   create_release:
     name: Create Release
     needs: deploy_prod
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Fetch Tags
@@ -108,7 +108,7 @@ jobs:
           allowUpdates: true
   build_android:
     needs: [deploy_prod, create_release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: rlespinasse/github-slug-action@v2.x
@@ -149,7 +149,7 @@ jobs:
           tag: ${{ github.ref }}
   build_ios:
     needs: [deploy_prod, create_release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: rlespinasse/github-slug-action@v2.x

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Lint & Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -39,7 +39,7 @@ jobs:
   deploy_staging:
     name: Deploy to Staging
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Fetch Tags

--- a/.github/workflows/test_development_environment.yml
+++ b/.github/workflows/test_development_environment.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         node: [10, 12, 13]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test_development_environment.yml
+++ b/.github/workflows/test_development_environment.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-18.04, macOS-latest, windows-latest]
         node: [10, 12, 13]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   e2e_test:
     name: E2E PCloudy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This PR specifies the ubuntu version to 18.04, instead of using ubuntu-latest.

This is due to actions/virtual-environments#1816

There is an update that would point ubuntu-latest to ubuntu-20.x, as we're currently using 18, I thought of just fixing this at 18 first.

We can revisit this again to update this to ubuntu-latest once things have stabilised after migration haha

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [ ] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers