### PR TITLE
feat: handle new error message from backend whitelist

### DIFF
--- a/src/hooks/useQuota/useQuota.test.tsx
+++ b/src/hooks/useQuota/useQuota.test.tsx
@@ -389,10 +389,10 @@ const wrapper: FunctionComponent<{ products?: CampaignPolicy[] }> = ({
   products = defaultProducts,
   children,
 }) => (
-    <ProductContextProvider products={products}>
-      {children}
-    </ProductContextProvider>
-  );
+  <ProductContextProvider products={products}>
+    {children}
+  </ProductContextProvider>
+);
 
 describe("useQuota", () => {
   beforeEach(() => {

--- a/src/hooks/useQuota/useQuota.test.tsx
+++ b/src/hooks/useQuota/useQuota.test.tsx
@@ -371,9 +371,16 @@ const mockQuotaResSingleIdNoQuotaWithAppealProducts: Quota = {
   ],
 };
 
-const mockIdNotEligible: any = (id: string) => {
+const mockUserNotEligible: any = (id: string) => {
   if (!eligibleIds.includes(id)) {
     const errorMessage = "User is not eligible";
+    throw new NotEligibleError(errorMessage);
+  }
+};
+
+const mockIdNotEligible: any = (id: string) => {
+  if (!eligibleIds.includes(id)) {
+    const errorMessage = "id is not eligible";
     throw new NotEligibleError(errorMessage);
   }
 };
@@ -382,10 +389,10 @@ const wrapper: FunctionComponent<{ products?: CampaignPolicy[] }> = ({
   products = defaultProducts,
   children,
 }) => (
-  <ProductContextProvider products={products}>
-    {children}
-  </ProductContextProvider>
-);
+    <ProductContextProvider products={products}>
+      {children}
+    </ProductContextProvider>
+  );
 
 describe("useQuota", () => {
   beforeEach(() => {
@@ -510,7 +517,37 @@ describe("useQuota", () => {
       expect(result.current.quotaResponse).toBeUndefined();
     });
 
-    it("should set quota state to NOT_ELIGIBLE when NotEligibleError is thrown, and does not update existing quota response", async () => {
+    it("should set quota state to NOT_ELIGIBLE when NotEligibleError is thrown and error message is 'User is not eligible', and does not update existing quota response", async () => {
+      expect.assertions(4);
+
+      let ids = ["ID1"];
+      mockGetQuota.mockResolvedValueOnce(mockQuotaResSingleId);
+      const { result, waitForNextUpdate, rerender } = renderHook(
+        () => useQuota(ids, key, endpoint),
+        {
+          wrapper,
+        }
+      );
+      await waitForNextUpdate();
+
+      expect(result.current.quotaState).toBe("DEFAULT");
+      expect(result.current.allQuotaResponse).toStrictEqual(
+        mockQuotaResSingleId
+      );
+
+      ids = ["ID_NOT_ELIGIBLE"];
+      mockGetQuota.mockImplementationOnce(() => {
+        mockUserNotEligible(ids[0]);
+      });
+      rerender();
+
+      expect(result.current.quotaState).toBe("NOT_ELIGIBLE");
+      expect(result.current.allQuotaResponse).toStrictEqual(
+        mockQuotaResSingleId
+      );
+    });
+
+    it("should set quota state to NOT_ELIGIBLE when NotEligibleError is thrown and error message is 'id is not eligible', and does not update existing quota response", async () => {
       expect.assertions(4);
 
       let ids = ["ID1"];

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -217,7 +217,15 @@ export const liveGetQuota = async (
     if (e instanceof ValidationError) {
       Sentry.captureException(e);
     }
-    if (e.message === "User is not eligible") {
+    // Currently the standalone mystique throws "User is not eligible" if not whitelisted,
+    // however, the new eligibility check on our backend throw "id is not eligible"
+    // This will be a current stop-gap measure to handle both types of eligibilty
+    // As we move forward, we will move towards using the new eligibilty check and
+    // phase out from the standalone mystique
+    if (
+      e.message === "User is not eligible" ||
+      e.message === "id is not eligible"
+    ) {
       throw new NotEligibleError(e.message);
     } else if (e instanceof SessionError) {
       throw e;


### PR DESCRIPTION
This PR adds an additional check for the `NotEligibleError`.
Currently, new distributions will start using the backend whitelisting, instead of mystique. However the backend whitelist is currently throwing a slightly different error compared to the standalone mystique.
We will cater for both error messages for now, as the backend whitelist error message is currently handled on other distributions.

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
~I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components~
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
~I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)~
~I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)~
