### PR TITLE
fix: Multiple Campaign ID Validation 

### DIFF
--- a/src/components/CampaignInitialisation/CampaignInitialisationScreen.tsx
+++ b/src/components/CampaignInitialisation/CampaignInitialisationScreen.tsx
@@ -21,6 +21,7 @@ import * as config from "../../config";
 import { checkVersion } from "./utils";
 import { SessionError } from "../../services/helpers";
 import { AuthStoreContext } from "../../context/authStore";
+import { IdentificationContext } from "../../context/identification";
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -54,6 +55,8 @@ export const CampaignInitialisationScreen: FunctionComponent<NavigationProps> = 
       message: "CampaignInitialisationScreen",
     });
   }, []);
+
+  const { resetSelectedIdType } = useContext(IdentificationContext);
 
   const authCredentials: AuthCredentials = navigation.getParam(
     "authCredentials"
@@ -124,6 +127,9 @@ export const CampaignInitialisationScreen: FunctionComponent<NavigationProps> = 
   ]);
 
   const continueToNormalFlow = useCallback(() => {
+    // Reset IdentificationContext when adding or switching between campaigns
+    resetSelectedIdType();
+
     if (campaignConfig?.features?.flowType) {
       switch (campaignConfig?.features?.flowType) {
         case "DEFAULT":
@@ -145,6 +151,7 @@ export const CampaignInitialisationScreen: FunctionComponent<NavigationProps> = 
     authCredentials.operatorToken,
     campaignConfig?.features?.flowType,
     navigation,
+    resetSelectedIdType,
   ]);
 
   const [outdatedType, setOutdatedType] = useState<"BINARY" | "BUILD">();

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -169,9 +169,11 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
     // in the event the saved selection not found.. will always fall back to the first idType in array
     setSelectedIdType(
       selectionArray.some((selection) => {
-        return selection.label && selectedIdType.label
-          ? selection.label === selectedIdType.label
-          : false;
+        return (
+          selection.label &&
+          selectedIdType.label &&
+          selection.label === selectedIdType.label
+        );
       })
         ? selectedIdType
         : selectionArray[0]

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -168,9 +168,11 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
   useEffect(() => {
     // in the event the saved selection not found.. will always fall back to the first idType in array
     setSelectedIdType(
-      selectionArray.some(
-        (selection) => selection.label === selectedIdType.label
-      )
+      selectionArray.some((selection) => {
+        return selection.label && selectedIdType.label
+          ? selection.label === selectedIdType.label
+          : false;
+      })
         ? selectedIdType
         : selectionArray[0]
     );

--- a/src/context/identification.tsx
+++ b/src/context/identification.tsx
@@ -1,4 +1,9 @@
-import React, { createContext, FunctionComponent, useState } from "react";
+import React, {
+  createContext,
+  FunctionComponent,
+  useCallback,
+  useState,
+} from "react";
 import { IdentificationFlag } from "../types";
 
 export const defaultSelectedIdType: IdentificationFlag = {
@@ -28,8 +33,9 @@ export const IdentificationContextProvider: FunctionComponent = ({
     defaultSelectedIdType
   );
 
-  const resetSelectedIdType = (): void =>
+  const resetSelectedIdType = useCallback(() => {
     setSelectedIdType(defaultSelectedIdType);
+  }, []);
 
   return (
     <IdentificationContext.Provider

--- a/src/context/identification.tsx
+++ b/src/context/identification.tsx
@@ -12,11 +12,13 @@ export const defaultSelectedIdType: IdentificationFlag = {
 interface IdentificationContext {
   selectedIdType: IdentificationFlag;
   setSelectedIdType: (selectedIdType: IdentificationFlag) => void;
+  resetSelectedIdType: () => void;
 }
 
 export const IdentificationContext = createContext<IdentificationContext>({
   selectedIdType: defaultSelectedIdType,
   setSelectedIdType: (selectedIdType: IdentificationFlag) => undefined,
+  resetSelectedIdType: () => undefined,
 });
 
 export const IdentificationContextProvider: FunctionComponent = ({
@@ -26,9 +28,12 @@ export const IdentificationContextProvider: FunctionComponent = ({
     defaultSelectedIdType
   );
 
+  const resetSelectedIdType = (): void =>
+    setSelectedIdType(defaultSelectedIdType);
+
   return (
     <IdentificationContext.Provider
-      value={{ selectedIdType, setSelectedIdType }}
+      value={{ selectedIdType, setSelectedIdType, resetSelectedIdType }}
     >
       {children}
     </IdentificationContext.Provider>


### PR DESCRIPTION
[Notion link](https://www.notion.so/When-I-hv-multiple-distributions-campaigns-logged-in-switching-from-one-to-another-causes-validatio-7f7cf92215b6496baec0e1c56a818407) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->

- Fix that ensures the correct ID validation rules are loaded when switching between different campaigns.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers

### Why did this bug occur?

The condition used to determine if the existing validation rules should be used was always returning `true` since it was matching `undefined === undefined`. This resulted in the bug where the first loaded campaign's validation rules would always be used, instead of using each campaign's validation rules when changing between campaigns.