### PR TITLE
chore: "check" instead of "submit" for passport input

### DIFF
--- a/src/components/CustomerDetails/ManualPassportInput.tsx
+++ b/src/components/CustomerDetails/ManualPassportInput.tsx
@@ -6,6 +6,7 @@ import { DarkButton } from "../Layout/Buttons/DarkButton";
 import { DropdownFilterInput } from "../DropdownFilterModal/DropdownFilterInput";
 import { nationalityItems } from "../DropdownFilterModal/nationalityItems";
 import { DropdownItem } from "../DropdownFilterModal/DropdownFilterModal";
+import { useTranslate } from "../../hooks/useTranslate/useTranslate";
 
 const styles = StyleSheet.create({
   centeredView: {
@@ -34,6 +35,8 @@ export const ManualPassportInput: FunctionComponent<ManualPassportInput> = ({
   setIdInput,
   submitId,
 }) => {
+  const { i18nt } = useTranslate();
+
   const [selectedCountry, setSelectedCountry] = useState<DropdownItem>();
   const [passportNum, setPassportNum] = useState<string>();
 
@@ -75,7 +78,11 @@ export const ManualPassportInput: FunctionComponent<ManualPassportInput> = ({
       </View>
       <View style={styles.inputAndButtonWrapper}>
         <View style={styles.inputWrapper}>
-          <DarkButton fullWidth={true} text="Submit" onPress={submitId} />
+          <DarkButton
+            fullWidth={true}
+            text={i18nt("collectCustomerDetailsScreen", "check")}
+            onPress={submitId}
+          />
         </View>
       </View>
     </View>

--- a/src/components/CustomerDetails/ManualPassportInput.tsx
+++ b/src/components/CustomerDetails/ManualPassportInput.tsx
@@ -82,6 +82,7 @@ export const ManualPassportInput: FunctionComponent<ManualPassportInput> = ({
             fullWidth={true}
             text={i18nt("collectCustomerDetailsScreen", "check")}
             onPress={submitId}
+            accessibilityLabel="identity-details-check-button-passport"
           />
         </View>
       </View>


### PR DESCRIPTION
[Notion link](https://www.notion.so/TT-Token-passport-holder-Submit-button-label-and-Repositioning-of-Go-to-Statistics-button-Frontend--9bc9bccea65e4f328a7238cc6da7a166)

This PR updates the passport input tab to make use of translations so that it follows the normal nric input tab

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [x] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
