### PR TITLE
chore: move statistics button

### DIFF
--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -11,6 +11,7 @@ import {
   Keyboard,
   Vibration,
   BackHandler,
+  TouchableOpacity,
 } from "react-native";
 import { size, fontSize, borderRadius, color } from "../../common/styles";
 import { Card } from "../Layout/Card";
@@ -45,7 +46,6 @@ import {
   IdentificationContext,
   defaultSelectedIdType,
 } from "../../context/identification";
-import { TouchableOpacity } from "react-native-gesture-handler";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
 
 const styles = StyleSheet.create({
@@ -80,8 +80,10 @@ const styles = StyleSheet.create({
     marginBottom: size(3),
   },
   statsButton: {
-    marginTop: size(6),
-    marginBottom: size(9),
+    paddingHorizontal: size(4),
+    paddingVertical: size(3),
+    marginTop: size(3),
+    marginBottom: size(6),
     flexDirection: "row",
     alignSelf: "center",
   },

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -80,7 +80,7 @@ const styles = StyleSheet.create({
     marginBottom: size(3),
   },
   statsButton: {
-    marginTop: size(4),
+    marginTop: size(2),
     flexDirection: "row",
     alignSelf: "center",
   },

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -74,7 +74,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: size(4),
     paddingVertical: size(3),
     marginTop: size(3),
-    marginBottom: size(6),
+    marginBottom: size(3),
     flexDirection: "row",
     alignSelf: "center",
   },

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -283,26 +283,26 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
               {i18nt("collectCustomerDetailsScreen", "checkEligibleItems")}
             </AppText>
             {getInputComponent()}
-            <TouchableOpacity
-              onPress={onPressStatistics}
-              style={styles.statsButton}
-            >
-              <MaterialCommunityIcons
-                style={styles.statsIcon}
-                name="poll"
-                size={size(2)}
-                color={color("blue", 50)}
-              />
-              <AppText
-                style={styles.statsText}
-                accessibilityLabel="go-to-statistics"
-                testID="go-to-statistics"
-                accessible={true}
-              >
-                Go to statistics
-              </AppText>
-            </TouchableOpacity>
           </Card>
+          <TouchableOpacity
+            onPress={onPressStatistics}
+            style={styles.statsButton}
+          >
+            <MaterialCommunityIcons
+              style={styles.statsIcon}
+              name="poll"
+              size={size(2)}
+              color={color("blue", 50)}
+            />
+            <AppText
+              style={styles.statsText}
+              accessibilityLabel="go-to-statistics"
+              testID="go-to-statistics"
+              accessible={true}
+            >
+              Go to statistics
+            </AppText>
+          </TouchableOpacity>
           <FeatureToggler feature="HELP_MODAL">
             <HelpButton onPress={showHelpModal} />
           </FeatureToggler>

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -13,7 +13,7 @@ import {
   BackHandler,
   TouchableOpacity,
 } from "react-native";
-import { size, fontSize, borderRadius, color } from "../../common/styles";
+import { size, fontSize, color } from "../../common/styles";
 import { Card } from "../Layout/Card";
 import { AppText } from "../Layout/AppText";
 import { TopBackground } from "../Layout/TopBackground";
@@ -69,15 +69,6 @@ const styles = StyleSheet.create({
     marginBottom: size(3),
     flexGrow: 1,
     flexShrink: 1,
-  },
-  manageButton: {
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: borderRadius(2),
-    padding: size(1),
-    marginRight: -size(1),
-    marginTop: -size(0.5),
-    marginBottom: size(3),
   },
   statsButton: {
     paddingHorizontal: size(4),

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -80,16 +80,15 @@ const styles = StyleSheet.create({
     marginBottom: size(3),
   },
   statsButton: {
-    marginTop: size(2),
+    marginTop: size(6),
+    marginBottom: size(9),
     flexDirection: "row",
     alignSelf: "center",
   },
   statsText: {
-    marginTop: size(4),
     fontSize: fontSize(0),
   },
   statsIcon: {
-    marginTop: size(4),
     alignSelf: "center",
     marginRight: size(0.5),
   },


### PR DESCRIPTION
[Notion link](https://www.notion.so/TT-Token-passport-holder-Submit-button-label-and-Repositioning-of-Go-to-Statistics-button-Frontend--9bc9bccea65e4f328a7238cc6da7a166)

This PR moves the statistics button to be outside the card. Have also reduced the top margin.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components (_no new components_)
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
