### PR TITLE
feat: reduce app bundle size

### DIFF
--- a/src/components/CustomerAppeal/CustomerAppealScreen.tsx
+++ b/src/components/CustomerAppeal/CustomerAppealScreen.tsx
@@ -5,7 +5,7 @@ import React, {
   useEffect,
   useState,
 } from "react";
-import { transform } from "lodash";
+import transform from "lodash/transform";
 import { StyleSheet, View } from "react-native";
 import { NavigationProps } from "../../types";
 import { size } from "../../common/styles";

--- a/src/components/CustomerQuota/CheckoutSuccess/PurchasedItem.tsx
+++ b/src/components/CustomerQuota/CheckoutSuccess/PurchasedItem.tsx
@@ -5,7 +5,7 @@ import { formatQuantityText } from "../utils";
 import { View } from "react-native";
 import { AppText } from "../../Layout/AppText";
 import { ItemQuantities } from "../types";
-import { sum } from "lodash";
+import sum from "lodash/sum";
 import { sharedStyles } from "./sharedStyles";
 import { ProductContext } from "../../../context/products";
 

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -4,7 +4,8 @@ import React, {
   useContext,
   useEffect,
 } from "react";
-import { differenceInSeconds, compareDesc } from "date-fns";
+import differenceInSeconds from "date-fns/differenceInSeconds";
+import compareDesc from "date-fns/compareDesc";
 import { View, StyleSheet, ActivityIndicator } from "react-native";
 import { CustomerCard } from "../CustomerCard";
 import { AppText } from "../../Layout/AppText";

--- a/src/hooks/useCheckUpdates.tsx
+++ b/src/hooks/useCheckUpdates.tsx
@@ -1,7 +1,7 @@
 import * as Updates from "expo-updates";
 import { AsyncStorage } from "react-native";
 import { Sentry } from "../utils/errorTracking";
-import { differenceInMinutes } from "date-fns";
+import differenceInMinutes from "date-fns/differenceInMinutes";
 import { useContext, useCallback } from "react";
 import { ImportantMessageSetterContext } from "../context/importantMessage";
 

--- a/src/hooks/useQuota/useQuota.tsx
+++ b/src/hooks/useQuota/useQuota.tsx
@@ -2,7 +2,7 @@ import { useState, useContext, useCallback, useEffect } from "react";
 import { Sentry } from "../../utils/errorTracking";
 import { getQuota, NotEligibleError } from "../../services/quota";
 import { ProductContext } from "../../context/products";
-import { transform } from "lodash";
+import transform from "lodash/transform";
 import { Quota, CampaignPolicy, ItemQuota } from "../../types";
 import { usePrevious } from "../usePrevious";
 import { IdentificationContext } from "../../context/identification";

--- a/src/utils/dateTimeFormatter.ts
+++ b/src/utils/dateTimeFormatter.ts
@@ -1,5 +1,6 @@
-import { format, formatDistance } from "date-fns";
-import { zhCN } from "date-fns/locale";
+import format from "date-fns/format";
+import formatDistance from "date-fns/formatDistance";
+import  zhCN from "date-fns/locale/zh-CN";
 import i18n from "i18n-js";
 
 export const formatDateTime = (date: number | Date): string =>

--- a/src/utils/dateTimeFormatter.ts
+++ b/src/utils/dateTimeFormatter.ts
@@ -1,6 +1,6 @@
 import format from "date-fns/format";
 import formatDistance from "date-fns/formatDistance";
-import  zhCN from "date-fns/locale/zh-CN";
+import zhCN from "date-fns/locale/zh-CN";
 import i18n from "i18n-js";
 
 export const formatDateTime = (date: number | Date): string =>


### PR DESCRIPTION
Reduce from 3.99 MB to 3.27MB by importing correctly.

use npx react-native-bundle-visualizer to see difference

[Notion link](https://www.notion.so/701364d4fbbf4ec1801b766c589973b9?v=24aa9675206d4da9a171ca4073d81b5b&p=f03a9e120eb44586800b07e33c95ed6c) <!-- Remove this link if no relevant Notion link -->

The notion includes the explanation of this optimization technique used. 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
