### PR TITLE
fix: remove phone number length restriction

### DIFF
--- a/src/utils/phoneNumberFormatter.test.ts
+++ b/src/utils/phoneNumberFormatter.test.ts
@@ -26,17 +26,20 @@ describe("formatPhoneNumber", () => {
     expect(formatPhoneNumber(testShortPhoneNumber)).toBe(testShortPhoneNumber);
   });
 
-  it("should truncate and format numbers if they are too long", () => {
+  it("should not truncate and format numbers if they are too long", () => {
     expect.assertions(1);
-    expect(formatPhoneNumber(testLongPhoneNumber)).toBe(formattedPhoneNumber);
+    expect(formatPhoneNumber(testLongPhoneNumber)).toBe(testLongPhoneNumber);
   });
 
   it("should format other region numbers", () => {
-    expect.assertions(2);
+    expect.assertions(4);
     // USA
     expect(formatPhoneNumber("5555551234", "1")).toBe("555-555-1234");
     // Malaysia
     expect(formatPhoneNumber("312341234", "60")).toBe("3-1234 1234");
+    // China
+    expect(formatPhoneNumber("1065529988", "86")).toBe("10 6552 9988");
+    expect(formatPhoneNumber("16755585558", "86")).toBe("167 5558 5558");
   });
 });
 

--- a/src/utils/phoneNumberFormatter.ts
+++ b/src/utils/phoneNumberFormatter.ts
@@ -13,39 +13,25 @@ export const formatPhoneNumber = (
     countryCode = "65";
   }
 
-  const exampleNumber = util
-    .getExampleNumber(region)
-    .getNationalNumberOrDefault()
-    .toString();
-
   phoneNumber = stripPhoneNumberFormatting(phoneNumber);
-  phoneNumber =
-    phoneNumber.length > exampleNumber.length
-      ? phoneNumber.substring(0, exampleNumber.length)
-      : phoneNumber;
 
-  if (phoneNumber.length === exampleNumber.length) {
-    try {
-      /**
-       * Using `PhoneNumberFormat.INTERNATIONAL` because
-       * `PhoneNumberFormat.NATIONAL` was padding 0s to the
-       * start of the phone number.
-       */
-      let result = util.format(
-        util.parse(phoneNumber, region),
-        PhoneNumberFormat.INTERNATIONAL
-      );
-      const indexOfCountryCode =
-        result.indexOf(countryCode) + countryCode.length;
-      result = result.substring(indexOfCountryCode).trim();
+  try {
+    /**
+     * Using `PhoneNumberFormat.INTERNATIONAL` because
+     * `PhoneNumberFormat.NATIONAL` was padding 0s to the
+     * start of the phone number.
+     */
+    let result = util.format(
+      util.parse(phoneNumber, region),
+      PhoneNumberFormat.INTERNATIONAL
+    );
+    const indexOfCountryCode = result.indexOf(countryCode) + countryCode.length;
+    result = result.substring(indexOfCountryCode).trim();
 
-      return result;
-    } catch (e) {
-      return phoneNumber;
-    }
+    return result;
+  } catch (e) {
+    return phoneNumber;
   }
-
-  return phoneNumber;
 };
 
 export const stripPhoneNumberFormatting = (


### PR DESCRIPTION
This PR removes the formatting of phone numbers which go above the `exampleNumber`'s length.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [x] I've added/updated unit/integration tests

