### PR TITLE
fix: issue with mergeWithCart using the quotaResponse incorrectly

### DIFF
--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -23,13 +23,11 @@ const mockQuotaResSingleId: Quota = {
   remainingQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 2,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 15,
       transactionTime,
     },
@@ -37,13 +35,11 @@ const mockQuotaResSingleId: Quota = {
   globalQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 2,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 15,
       transactionTime,
     },
@@ -51,13 +47,11 @@ const mockQuotaResSingleId: Quota = {
   localQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
@@ -68,13 +62,11 @@ const mockQuotaResMultipleIds: Quota = {
   remainingQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 4,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 30,
       transactionTime,
     },
@@ -82,13 +74,11 @@ const mockQuotaResMultipleIds: Quota = {
   globalQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 4,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 30,
       transactionTime,
     },
@@ -96,13 +86,11 @@ const mockQuotaResMultipleIds: Quota = {
   localQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
@@ -113,13 +101,11 @@ const mockQuotaResSingleIdInvalidQuota: Quota = {
   remainingQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: -1,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 15,
       transactionTime,
     },
@@ -127,13 +113,11 @@ const mockQuotaResSingleIdInvalidQuota: Quota = {
   globalQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: -1,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 15,
       transactionTime,
     },
@@ -141,13 +125,11 @@ const mockQuotaResSingleIdInvalidQuota: Quota = {
   localQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
@@ -158,10 +140,12 @@ const mockPostTransactionResult: PostTransactionResult = {
   transactions: [
     {
       transaction: [
-        { category: "toilet-paper", identifierInputs: [], quantity: 1 },
+        {
+          category: "toilet-paper",
+          quantity: 1,
+        },
         {
           category: "chocolate",
-          identifierInputs: [],
           quantity: 5,
         },
       ],
@@ -174,26 +158,11 @@ const mockQuotaResSingleIdAlert: Quota = {
   remainingQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [
-        {
-          label: "first",
-          value: "first identifier",
-          textInputType: "STRING",
-          scanButtonType: "BARCODE",
-        },
-        {
-          label: "last",
-          value: "last identifier",
-          textInputType: "STRING",
-          scanButtonType: "BARCODE",
-        },
-      ],
       quantity: 8,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 15,
       transactionTime,
     },
@@ -201,26 +170,11 @@ const mockQuotaResSingleIdAlert: Quota = {
   globalQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [
-        {
-          label: "first",
-          value: "first identifier",
-          textInputType: "STRING",
-          scanButtonType: "BARCODE",
-        },
-        {
-          label: "last",
-          value: "last identifier",
-          textInputType: "STRING",
-          scanButtonType: "BARCODE",
-        },
-      ],
       quantity: 8,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 15,
       transactionTime,
     },
@@ -228,31 +182,31 @@ const mockQuotaResSingleIdAlert: Quota = {
   localQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [
-        {
-          label: "first",
-          value: "first identifier",
-          textInputType: "STRING",
-          scanButtonType: "BARCODE",
-        },
-        {
-          label: "last",
-          value: "last identifier",
-          textInputType: "STRING",
-          scanButtonType: "BARCODE",
-        },
-      ],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
   ],
 };
+
+const defaultProductsIdentifierInputsForCart = [
+  {
+    label: "first",
+    scanButtonType: "BARCODE",
+    textInputType: "STRING",
+    value: "",
+  },
+  {
+    label: "last",
+    scanButtonType: "BARCODE",
+    textInputType: "STRING",
+    value: "",
+  },
+];
 
 const wrapper: FunctionComponent<{ products?: CampaignPolicy[] }> = ({
   children,
@@ -282,7 +236,7 @@ describe("useCart", () => {
         {
           category: "toilet-paper",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           quantity: 1,
           lastTransactionTime: transactionTime,
           maxQuantity: 2,
@@ -290,7 +244,7 @@ describe("useCart", () => {
         {
           category: "chocolate",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           quantity: 0,
           lastTransactionTime: transactionTime,
           maxQuantity: 15,
@@ -305,7 +259,7 @@ describe("useCart", () => {
         {
           category: "toilet-paper",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 4,
           quantity: 1,
@@ -313,7 +267,7 @@ describe("useCart", () => {
         {
           category: "chocolate",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 30,
           quantity: 0,
@@ -356,7 +310,7 @@ describe("useCart", () => {
         {
           category: "toilet-paper",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 2,
           quantity: 1,
@@ -364,7 +318,7 @@ describe("useCart", () => {
         {
           category: "chocolate",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 15,
           quantity: 5,
@@ -391,7 +345,7 @@ describe("useCart", () => {
         {
           category: "toilet-paper",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 2,
           quantity: 1,
@@ -399,7 +353,7 @@ describe("useCart", () => {
         {
           category: "chocolate",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 15,
           quantity: 0,
@@ -425,7 +379,7 @@ describe("useCart", () => {
         {
           category: "toilet-paper",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 2,
           quantity: 1,
@@ -433,7 +387,7 @@ describe("useCart", () => {
         {
           category: "chocolate",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 15,
           quantity: 0,
@@ -461,7 +415,7 @@ describe("useCart", () => {
         {
           category: "toilet-paper",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 2,
           quantity: 1,
@@ -469,7 +423,7 @@ describe("useCart", () => {
         {
           category: "chocolate",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 15,
           quantity: 0,
@@ -490,8 +444,20 @@ describe("useCart", () => {
       );
 
       await wait(() => {
-        result.current.updateCart("toilet-paper", 2);
-        result.current.updateCart("chocolate", 5);
+        result.current.updateCart("toilet-paper", 2, [
+          {
+            label: "first",
+            value: "first",
+            textInputType: "STRING",
+          },
+        ]);
+        result.current.updateCart("chocolate", 5, [
+          {
+            label: "last",
+            value: "last",
+            textInputType: "STRING",
+          },
+        ]);
       });
 
       mockPostTransaction.mockReturnValueOnce(mockPostTransactionResult);
@@ -506,7 +472,13 @@ describe("useCart", () => {
         {
           category: "toilet-paper",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: [
+            {
+              label: "first",
+              textInputType: "STRING",
+              value: "first",
+            },
+          ],
           lastTransactionTime: transactionTime,
           maxQuantity: 2,
           quantity: 2,
@@ -514,7 +486,13 @@ describe("useCart", () => {
         {
           category: "chocolate",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: [
+            {
+              label: "last",
+              textInputType: "STRING",
+              value: "last",
+            },
+          ],
           lastTransactionTime: transactionTime,
           maxQuantity: 15,
           quantity: 5,
@@ -548,7 +526,7 @@ describe("useCart", () => {
         {
           category: "toilet-paper",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 2,
           quantity: 0,
@@ -556,7 +534,7 @@ describe("useCart", () => {
         {
           category: "chocolate",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 15,
           quantity: 0,
@@ -619,7 +597,7 @@ describe("useCart", () => {
         {
           category: "chocolate",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 15,
           quantity: 0,
@@ -742,7 +720,7 @@ describe("useCart", () => {
         {
           category: "chocolate",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 15,
           quantity: 0,
@@ -998,8 +976,20 @@ describe("useCart", () => {
       );
 
       await wait(() => {
-        result.current.updateCart("toilet-paper", 2);
-        result.current.updateCart("chocolate", 5);
+        result.current.updateCart("toilet-paper", 2, [
+          {
+            label: "first",
+            value: "first",
+            textInputType: "STRING",
+          },
+        ]);
+        result.current.updateCart("chocolate", 5, [
+          {
+            label: "last",
+            value: "last",
+            textInputType: "STRING",
+          },
+        ]);
       });
 
       mockPostTransaction.mockRejectedValueOnce(new Error());
@@ -1016,7 +1006,13 @@ describe("useCart", () => {
         {
           category: "toilet-paper",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: [
+            {
+              label: "first",
+              textInputType: "STRING",
+              value: "first",
+            },
+          ],
           lastTransactionTime: transactionTime,
           maxQuantity: 2,
           quantity: 2,
@@ -1024,7 +1020,13 @@ describe("useCart", () => {
         {
           category: "chocolate",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: [
+            {
+              label: "last",
+              textInputType: "STRING",
+              value: "last",
+            },
+          ],
           lastTransactionTime: transactionTime,
           maxQuantity: 15,
           quantity: 5,
@@ -1093,13 +1095,13 @@ describe("useCart", () => {
           identifierInputs: [
             {
               label: "first",
-              value: "first identifier",
+              value: "",
               textInputType: "STRING",
               scanButtonType: "BARCODE",
             },
             {
               label: "last",
-              value: "last identifier",
+              value: "",
               textInputType: "STRING",
               scanButtonType: "BARCODE",
             },
@@ -1111,7 +1113,7 @@ describe("useCart", () => {
         {
           category: "chocolate",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 15,
           quantity: 0,
@@ -1159,13 +1161,13 @@ describe("useCart", () => {
           identifierInputs: [
             {
               label: "first",
-              value: "first identifier",
+              value: "",
               textInputType: "STRING",
               scanButtonType: "BARCODE",
             },
             {
               label: "last",
-              value: "last identifier",
+              value: "",
               textInputType: "STRING",
               scanButtonType: "BARCODE",
             },
@@ -1177,7 +1179,7 @@ describe("useCart", () => {
         {
           category: "chocolate",
           descriptionAlert: undefined,
-          identifierInputs: [],
+          identifierInputs: defaultProductsIdentifierInputsForCart,
           lastTransactionTime: transactionTime,
           maxQuantity: 15,
           quantity: 0,

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -61,56 +61,49 @@ const mergeWithCart = (
 
       return productOneOrder - productTwoOrder;
     })
-    .map(
-      ({
-        category,
-        quantity: remainingQuantity,
-        transactionTime,
-        identifierInputs,
-      }) => {
-        remainingQuantity = Math.max(remainingQuantity, 0);
-        const [existingItem] = getItem(cart, category);
+    .map(({ category, quantity: remainingQuantity, transactionTime }) => {
+      remainingQuantity = Math.max(remainingQuantity, 0);
+      const [existingItem] = getItem(cart, category);
 
-        const product = getProduct(category);
-        const defaultQuantity = product?.quantity.default || 0;
-        const defaultIdentifierInputs =
-          product?.identifiers?.map(
-            ({ label, textInput, scanButton, validationRegex }) => ({
-              label: label,
-              value: "",
-              ...(textInput.type ? { textInputType: textInput.type } : {}),
-              ...(scanButton.type ? { scanButtonType: scanButton.type } : {}),
-              ...(validationRegex ? { validationRegex } : {}),
-            })
-          ) || [];
+      const product = getProduct(category);
+      const defaultQuantity = product?.quantity.default || 0;
+      const identifierInputs =
+        product?.identifiers?.map(
+          ({ label, textInput, scanButton, validationRegex }) => ({
+            label: label,
+            value: "",
+            ...(textInput.type ? { textInputType: textInput.type } : {}),
+            ...(scanButton.type ? { scanButtonType: scanButton.type } : {}),
+            ...(validationRegex ? { validationRegex } : {}),
+          })
+        ) || [];
 
-        let descriptionAlert: string | undefined = undefined;
-        if (product && product.alert) {
-          const expandedQuota = product.quantity.limit - remainingQuantity;
-          descriptionAlert =
-            expandedQuota >= product.alert.threshold
-              ? product.alert.label
-              : undefined;
-        }
-
-        const checkoutLimit = product?.quantity.checkoutLimit;
-        const maxQuantity = checkoutLimit
-          ? Math.min(remainingQuantity, checkoutLimit)
-          : remainingQuantity;
-
-        return {
-          category,
-          quantity: Math.min(
-            maxQuantity,
-            existingItem?.quantity || defaultQuantity
-          ),
-          maxQuantity,
-          descriptionAlert,
-          lastTransactionTime: transactionTime,
-          identifierInputs: identifierInputs || defaultIdentifierInputs,
-        };
+      let descriptionAlert: string | undefined = undefined;
+      if (product && product.alert) {
+        const expandedQuota = product.quantity.limit - remainingQuantity;
+        descriptionAlert =
+          expandedQuota >= product.alert.threshold
+            ? product.alert.label
+            : undefined;
       }
-    );
+
+      const checkoutLimit = product?.quantity.checkoutLimit;
+      const maxQuantity = checkoutLimit
+        ? Math.min(remainingQuantity, checkoutLimit)
+        : remainingQuantity;
+
+      return {
+        category,
+        quantity: Math.min(
+          maxQuantity,
+          existingItem?.quantity || defaultQuantity
+        ),
+        maxQuantity,
+        descriptionAlert,
+        lastTransactionTime: transactionTime,
+        identifierInputs,
+      };
+    });
 };
 
 export const useCart = (

--- a/src/hooks/useQuota/useQuota.test.tsx
+++ b/src/hooks/useQuota/useQuota.test.tsx
@@ -22,13 +22,11 @@ const mockQuotaResSingleId: Quota = {
   remainingQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 2,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 15,
       transactionTime,
     },
@@ -36,13 +34,11 @@ const mockQuotaResSingleId: Quota = {
   globalQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 2,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 15,
       transactionTime,
     },
@@ -50,13 +46,11 @@ const mockQuotaResSingleId: Quota = {
   localQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
@@ -67,36 +61,30 @@ const mockQuotaResMultipleIds: Quota = {
   remainingQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 4,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 30,
     },
   ],
   globalQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 4,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 30,
     },
   ],
   localQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
     },
   ],
@@ -106,26 +94,11 @@ const mockQuotaResSingleIdWithIdentifiers: Quota = {
   remainingQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [
-        {
-          label: "first",
-          value: "first identifier",
-          textInputType: "STRING",
-          scanButtonType: "BARCODE",
-        },
-        {
-          label: "last",
-          value: "last identifier",
-          textInputType: "STRING",
-          scanButtonType: "BARCODE",
-        },
-      ],
       quantity: 1,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 15,
       transactionTime,
     },
@@ -133,26 +106,11 @@ const mockQuotaResSingleIdWithIdentifiers: Quota = {
   globalQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [
-        {
-          label: "first",
-          value: "first identifier",
-          textInputType: "STRING",
-          scanButtonType: "BARCODE",
-        },
-        {
-          label: "last",
-          value: "last identifier",
-          textInputType: "STRING",
-          scanButtonType: "BARCODE",
-        },
-      ],
       quantity: 1,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 15,
       transactionTime,
     },
@@ -160,26 +118,11 @@ const mockQuotaResSingleIdWithIdentifiers: Quota = {
   localQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [
-        {
-          label: "first",
-          value: "first identifier",
-          textInputType: "STRING",
-          scanButtonType: "BARCODE",
-        },
-        {
-          label: "last",
-          value: "last identifier",
-          textInputType: "STRING",
-          scanButtonType: "BARCODE",
-        },
-      ],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
@@ -190,13 +133,11 @@ const mockQuotaResSingleIdNoQuota: Quota = {
   remainingQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 0,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 0,
       transactionTime,
     },
@@ -204,13 +145,11 @@ const mockQuotaResSingleIdNoQuota: Quota = {
   globalQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 0,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 0,
       transactionTime,
     },
@@ -218,13 +157,11 @@ const mockQuotaResSingleIdNoQuota: Quota = {
   localQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
@@ -235,13 +172,11 @@ const mockQuotaResSingleIdInvalidQuota: Quota = {
   remainingQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: -1,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 15,
       transactionTime,
     },
@@ -249,13 +184,11 @@ const mockQuotaResSingleIdInvalidQuota: Quota = {
   globalQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: -1,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 15,
       transactionTime,
     },
@@ -263,13 +196,11 @@ const mockQuotaResSingleIdInvalidQuota: Quota = {
   localQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
@@ -280,13 +211,11 @@ const mockQuotaResSingleIdWithAppealProducts: Quota = {
   remainingQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 1,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 0,
       transactionTime,
     },
@@ -294,13 +223,11 @@ const mockQuotaResSingleIdWithAppealProducts: Quota = {
   globalQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 1,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 0,
       transactionTime,
     },
@@ -308,13 +235,11 @@ const mockQuotaResSingleIdWithAppealProducts: Quota = {
   localQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
@@ -330,13 +255,11 @@ const mockQuotaResSingleIdNoQuotaWithAppealProducts: Quota = {
   remainingQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 0,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 1,
       transactionTime,
     },
@@ -344,13 +267,11 @@ const mockQuotaResSingleIdNoQuotaWithAppealProducts: Quota = {
   globalQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: 0,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: 1,
       transactionTime,
     },
@@ -358,13 +279,11 @@ const mockQuotaResSingleIdNoQuotaWithAppealProducts: Quota = {
   localQuota: [
     {
       category: "toilet-paper",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },
     {
       category: "chocolate",
-      identifierInputs: [],
       quantity: Number.MAX_SAFE_INTEGER,
       transactionTime,
     },

--- a/src/hooks/useQuota/useQuota.test.tsx
+++ b/src/hooks/useQuota/useQuota.test.tsx
@@ -335,26 +335,11 @@ describe("useQuota", () => {
       expect(result.current.quotaResponse?.remainingQuota).toStrictEqual([
         {
           category: "toilet-paper",
-          identifierInputs: [
-            {
-              label: "first",
-              value: "first identifier",
-              textInputType: "STRING",
-              scanButtonType: "BARCODE",
-            },
-            {
-              label: "last",
-              value: "last identifier",
-              textInputType: "STRING",
-              scanButtonType: "BARCODE",
-            },
-          ],
           transactionTime,
           quantity: 1,
         },
         {
           category: "chocolate",
-          identifierInputs: [],
           transactionTime,
           quantity: 15,
         },
@@ -377,13 +362,11 @@ describe("useQuota", () => {
       expect(result.current.quotaResponse?.remainingQuota).toStrictEqual([
         {
           category: "toilet-paper",
-          identifierInputs: [],
           transactionTime,
           quantity: 0,
         },
         {
           category: "chocolate",
-          identifierInputs: [],
           transactionTime,
           quantity: 0,
         },
@@ -406,13 +389,11 @@ describe("useQuota", () => {
       expect(result.current.quotaResponse?.remainingQuota).toStrictEqual([
         {
           category: "toilet-paper",
-          identifierInputs: [],
           transactionTime,
           quantity: -1,
         },
         {
           category: "chocolate",
-          identifierInputs: [],
           transactionTime,
           quantity: 15,
         },
@@ -555,13 +536,11 @@ describe("useQuota", () => {
       expect(result.current.quotaResponse?.remainingQuota).toStrictEqual([
         {
           category: "toilet-paper",
-          identifierInputs: [],
           transactionTime,
           quantity: 2,
         },
         {
           category: "chocolate",
-          identifierInputs: [],
           transactionTime,
           quantity: 15,
         },
@@ -574,12 +553,10 @@ describe("useQuota", () => {
       expect(result.current.quotaResponse?.remainingQuota).toStrictEqual([
         {
           category: "toilet-paper",
-          identifierInputs: [],
           quantity: 4,
         },
         {
           category: "chocolate",
-          identifierInputs: [],
           quantity: 30,
         },
       ]);
@@ -599,13 +576,11 @@ describe("useQuota", () => {
       expect(result.current.quotaResponse?.remainingQuota).toStrictEqual([
         {
           category: "toilet-paper",
-          identifierInputs: [],
           transactionTime,
           quantity: 2,
         },
         {
           category: "chocolate",
-          identifierInputs: [],
           transactionTime,
           quantity: 15,
         },
@@ -632,13 +607,11 @@ describe("useQuota", () => {
       expect(result.current.quotaResponse?.remainingQuota).toStrictEqual([
         {
           category: "toilet-paper",
-          identifierInputs: [],
           transactionTime,
           quantity: 2,
         },
         {
           category: "chocolate",
-          identifierInputs: [],
           transactionTime,
           quantity: 15,
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,7 +190,6 @@ const ItemQuota = t.intersection([
   t.partial({
     quotaRefreshTime: t.number,
     transactionTime: DateFromNumber,
-    identifierInputs: t.array(IdentifierInput),
   }),
 ]);
 


### PR DESCRIPTION
The quota endpoint returns an identifierInputs field that represents the values of the latest transaction. In `mergeWithCart` we were treating those values as the template for the identifierInputs. This meant that we were incorrectly using the latest transaction values as the initialised value for the cart.

This works for most cases since the identifier inputs returned from the last transaction will match the identifier inputs from the latest transaction. However, the assumption isn't always valid and this PR corrects this logic.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
