### PR TITLE
feat: to show alert modal for validation of tt-token issuance

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -398,5 +398,10 @@ export const en: Translations = {
       body: "Enter valid email address",
       primaryActionText: "OK",
     },
+    invalidDeviceCode: {
+      title: "Invalid Input",
+      body: "Scan item again or get a new item from your in-charge.",
+      primaryActionText: "Ok",
+    },
   },
 };

--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -399,9 +399,9 @@ export const en: Translations = {
       primaryActionText: "OK",
     },
     invalidDeviceCode: {
-      title: "Invalid Input",
+      title: "Invalid input",
       body: "Scan item again or get a new item from your in-charge.",
-      primaryActionText: "Ok",
+      primaryActionText: "OK",
     },
   },
 };

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -434,5 +434,10 @@ export type Translations = {
       primaryActionText: string;
       secondaryActionText?: string;
     };
+    invalidDeviceCode: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+    };
   };
 };

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -389,5 +389,10 @@ export const zh: Translations = {
       body: "请输入有效的邮件地址",
       primaryActionText: "确定",
     },
+    invalidDeviceCode: {
+      title: "输入无效",
+      body: "请再次扫描物品或向您的负责人索取新的物品。",
+      primaryActionText: "确定",
+    },
   },
 };

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -31,6 +31,7 @@ export enum ERROR_MESSAGE {
   MISSING_VOUCHER_INPUT = "Enter a voucher code.",
   INVALID_POD_INPUT = "Scan a valid device code.",
   MISSING_POD_INPUT = "Scan a device code.",
+  INVALID_IDENTIFIER = "Scan item again or get a new item from your in-charge.",
   INVALID_PHONE_NUMBER = "Enter a valid contact number.",
   INVALID_COUNTRY_CODE = "Enter a valid country code.",
   INVALID_PHONE_AND_COUNTRY_CODE = "Enter a valid country code and contact number.",
@@ -92,6 +93,7 @@ const messageToTranslationKeyMappings: Record<string, string> = {
   [ERROR_MESSAGE.MISSING_VOUCHER_INPUT]: "incompleteEntryVoucherCode",
   [ERROR_MESSAGE.INVALID_POD_INPUT]: "wrongFormatNotValidDeviceCode",
   [ERROR_MESSAGE.MISSING_POD_INPUT]: "incompleteEntryScanDeviceCode",
+  [ERROR_MESSAGE.INVALID_IDENTIFIER]: "invalidDeviceCode",
   [ERROR_MESSAGE.INVALID_PHONE_NUMBER]: "wrongFormatContactNumber",
   [ERROR_MESSAGE.INVALID_COUNTRY_CODE]: "wrongFormatCountryCode",
   [ERROR_MESSAGE.INVALID_PHONE_AND_COUNTRY_CODE]:

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -31,7 +31,7 @@ export enum ERROR_MESSAGE {
   MISSING_VOUCHER_INPUT = "Enter a voucher code.",
   INVALID_POD_INPUT = "Scan a valid device code.",
   MISSING_POD_INPUT = "Scan a device code.",
-  INVALID_IDENTIFIER = "Scan item again or get a new item from your in-charge.",
+  INVALID_POD_IDENTIFIER = "Scan item again or get a new item from your in-charge.",
   INVALID_PHONE_NUMBER = "Enter a valid contact number.",
   INVALID_COUNTRY_CODE = "Enter a valid country code.",
   INVALID_PHONE_AND_COUNTRY_CODE = "Enter a valid country code and contact number.",
@@ -93,7 +93,7 @@ const messageToTranslationKeyMappings: Record<string, string> = {
   [ERROR_MESSAGE.MISSING_VOUCHER_INPUT]: "incompleteEntryVoucherCode",
   [ERROR_MESSAGE.INVALID_POD_INPUT]: "wrongFormatNotValidDeviceCode",
   [ERROR_MESSAGE.MISSING_POD_INPUT]: "incompleteEntryScanDeviceCode",
-  [ERROR_MESSAGE.INVALID_IDENTIFIER]: "invalidDeviceCode",
+  [ERROR_MESSAGE.INVALID_POD_IDENTIFIER]: "invalidDeviceCode",
   [ERROR_MESSAGE.INVALID_PHONE_NUMBER]: "wrongFormatContactNumber",
   [ERROR_MESSAGE.INVALID_COUNTRY_CODE]: "wrongFormatCountryCode",
   [ERROR_MESSAGE.INVALID_PHONE_AND_COUNTRY_CODE]:

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -246,8 +246,8 @@ export const useCart = (
           e.message === "Invalid Purchase Request: Duplicate identifier inputs"
         ) {
           setCartError(new Error(ERROR_MESSAGE.DUPLICATE_IDENTIFIER_INPUT));
-        } else if (e.message === "Invalid Purchase Request: item not found") {
-          setCartError(new Error(ERROR_MESSAGE.INVALID_IDENTIFIER));
+        } else if (e.message === "Invalid Purchase Request: Item not found") {
+          setCartError(new Error(ERROR_MESSAGE.INVALID_POD_IDENTIFIER));
         } else if (e instanceof SessionError) {
           setCartError(e);
         } else {

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -246,6 +246,8 @@ export const useCart = (
           e.message === "Invalid Purchase Request: Duplicate identifier inputs"
         ) {
           setCartError(new Error(ERROR_MESSAGE.DUPLICATE_IDENTIFIER_INPUT));
+        } else if (e.message === "Invalid Purchase Request: item not found") {
+          setCartError(new Error(ERROR_MESSAGE.INVALID_IDENTIFIER));
         } else if (e instanceof SessionError) {
           setCartError(e);
         } else {


### PR DESCRIPTION
[Notion link](https://www.notion.so/To-show-alert-in-FE-TT-Token-issuance-6c4a83cabae740e5b8a4a8173167a97c) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- to show the alert modal, when the tt-token validation failed 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
