### PR TITLE
fix: error message when user retries submitting OTP too many times

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -403,5 +403,8 @@ export const en: Translations = {
       body: "Scan item again or get a new item from your in-charge.",
       primaryActionText: "OK",
     },
+    dynamicContentFallback: {
+      minutes: "a few",
+    },
   },
 };

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -126,7 +126,6 @@ export type Translations = {
       title: string;
       body?: string;
       primaryActionText: string;
-      secondaryActionText?: string;
     };
     cancelEntry: {
       title: string;
@@ -438,6 +437,9 @@ export type Translations = {
       title: string;
       body?: string;
       primaryActionText: string;
+    };
+    dynamicContentFallback: {
+      minutes: string;
     };
   };
 };

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -394,5 +394,8 @@ export const zh: Translations = {
       body: "请再次扫描物品或向您的负责人索取新的物品。",
       primaryActionText: "确定",
     },
+    dynamicContentFallback: {
+      minutes: "几",
+    },
   },
 };

--- a/src/components/Login/LoginOTPCard.tsx
+++ b/src/components/Login/LoginOTPCard.tsx
@@ -17,6 +17,7 @@ import {
   OTPWrongError,
   OTPExpiredError,
   OTPEmptyError,
+  LoginLockedError,
 } from "../../services/auth";
 import { Sentry } from "../../utils/errorTracking";
 import { AlertModalContext } from "../../context/alert";
@@ -86,6 +87,8 @@ export const LoginOTPCard: FunctionComponent<LoginOTPCard> = ({
     };
   }, [resendDisabledTime]);
 
+  const { i18nt } = useTranslate();
+
   const onValidateOTP = async (otp: string): Promise<void> => {
     setIsLoading(true);
     try {
@@ -112,6 +115,15 @@ export const LoginOTPCard: FunctionComponent<LoginOTPCard> = ({
         e instanceof OTPEmptyError
       ) {
         showErrorAlert(e);
+      } else if (e instanceof LoginLockedError) {
+        const matches = e.message.match(/\d+/g);
+        showErrorAlert(e, () => resetStage(), {
+          // We assume backend error message has the number of minutes for user to wait before retrying
+          // Adding a fallback in case this assumption fails
+          minutes:
+            (matches && matches[0]) ??
+            i18nt("errorMessages", "dynamicContentFallback", "minutes"),
+        });
       } else if (e instanceof LoginError) {
         showErrorAlert(e, () => resetStage());
       } else {
@@ -137,8 +149,6 @@ export const LoginOTPCard: FunctionComponent<LoginOTPCard> = ({
   const handleChange = (text: string): void => {
     /^\d*$/.test(text) && setOTPValue(text);
   };
-
-  const { i18nt } = useTranslate();
 
   return (
     <Card>


### PR DESCRIPTION
[Notion link](https://www.notion.so/Missing-translation-in-error-message-when-user-enters-wrong-OTP-too-many-times-9463bbf7d3fc4e51b4ec5b240a6af033)

This PR fixes the error message for when a user retries submitting OTP too many times.

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow (this is unhappy flow, which QEs already have stories for)