### PR TITLE
use pcloudy Api Keys details from github secrets

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -32,6 +32,10 @@ jobs:
         run: npm install appium -g
       - name: Setup E2E Environment
         run: pip3 install -r requirements.txt
+        env:
+          HATS_DEVICE_FARM_REMOTE_URL: ${{ secrets.HATS_DEVICE_FARM_REMOTE_URL }}
+          HATS_DEVICE_FARM_USERNAME: ${{ secrets.HATS_DEVICE_FARM_USERNAME }}
+          HATS_DEVICE_FARM_API_KEY: ${{ secrets.HATS_DEVICE_FARM_API_KEY }}
       - name: Run E2E Tests
         run: ./e2e_run_all_tests_pCloudy.sh
       - name: Get Current Date


### PR DESCRIPTION
[Notion link] https://www.notion.so/Remove-pCloudy-API-Key-from-mobile-e2e-repo-and-refer-to-E2E_PCLOUDY_API_KEY-secret-in-GitHub-c8fdf1bddc304c1da031c2c1cca26605

This PR adds... 
1. Now the pCloudy API-keys and server details will be fetched from github secrets