### PR TITLE
chore: allow manual e2e workflow runs

### DIFF
--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -12,6 +12,8 @@ on:
       - master
     types:
       - completed
+  # Allow manual runs
+  workflow_dispatch:
 
 jobs:
   e2e_test:


### PR DESCRIPTION
GitHub actions now support manually triggered workflows. Have enabled this for e2e tests so that we can run it on the fly.
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch

Example:
![image](https://user-images.githubusercontent.com/577802/105971201-3b05ed00-60c5-11eb-901e-20efe5e6792a.png)
