### PR TITLE
feat: phone number scanning

### DIFF
--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierPhoneNumberInput.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierPhoneNumberInput.tsx
@@ -1,29 +1,61 @@
 import React, { FunctionComponent, useState, useEffect } from "react";
-import { createFullNumber } from "../../../../utils/validatePhoneNumbers";
+import {
+  createFullNumber,
+  parsePhoneNumber,
+} from "../../../../utils/validatePhoneNumbers";
+import { stripPhoneNumberFormatting } from "../../../../utils/phoneNumberFormatter";
 import { View } from "react-native";
 import { PhoneNumberInput } from "../../../Layout/PhoneNumberInput";
 import { sharedStyles } from "./sharedStyles";
+import { usePrevious } from "../../../../hooks/usePrevious";
+import { size } from "../../../../common/styles";
 
 export const IdentifierPhoneNumberInput: FunctionComponent<{
+  addMarginRight: boolean;
   label: string;
   onPhoneNumberChange: (text: string) => void;
-}> = ({ label, onPhoneNumberChange }) => {
+  value: string;
+}> = ({ addMarginRight, label, onPhoneNumberChange, value }) => {
   const [countryCodeValue, setCountryCodeValue] = useState("+65");
   const [phoneNumber, setPhoneNumber] = useState("");
+  const [fullNumber, setFullNumber] = useState("");
+  const prevFullNumber = usePrevious(fullNumber);
 
   useEffect(() => {
-    onPhoneNumberChange(createFullNumber(countryCodeValue, phoneNumber));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    setFullNumber(createFullNumber(countryCodeValue, phoneNumber));
   }, [countryCodeValue, phoneNumber]);
 
+  useEffect(() => {
+    onPhoneNumberChange(fullNumber);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fullNumber]);
+
+  useEffect(() => {
+    // value was updated from parent
+    if (value.length > 0 && prevFullNumber && value !== prevFullNumber) {
+      try {
+        const parsedPhoneNumber = parsePhoneNumber(value);
+        setCountryCodeValue(`+${parsedPhoneNumber.getCountryCodeOrDefault()}`);
+        setPhoneNumber(`${parsedPhoneNumber.getNationalNumberOrDefault()}`);
+      } catch (e) {
+        setPhoneNumber(stripPhoneNumberFormatting(value));
+      }
+    }
+  }, [value, prevFullNumber, countryCodeValue]);
+
   return (
-    <View style={[sharedStyles.inputWrapper]}>
+    <View
+      style={[
+        sharedStyles.inputWrapper,
+        ...(addMarginRight ? [{ marginRight: size(1) }] : []),
+      ]}
+    >
       <PhoneNumberInput
         countryCodeValue={countryCodeValue}
         label={label}
         mobileNumberValue={phoneNumber}
-        onChangeCountryCode={(text: string) => setCountryCodeValue(text)}
-        onChangeMobileNumber={(text: string) => setPhoneNumber(text)}
+        onChangeCountryCode={setCountryCodeValue}
+        onChangeMobileNumber={setPhoneNumber}
         accessibilityLabel="item-field-phone-number"
       />
     </View>

--- a/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
@@ -59,8 +59,10 @@ export const ItemIdentifier: FunctionComponent<{
         {textInput.visible &&
           (textInput.type === "PHONE_NUMBER" ? (
             <IdentifierPhoneNumberInput
+              addMarginRight={scanButton.visible}
               label={c13nt(label)}
               onPhoneNumberChange={onManualInput}
+              value={inputValue}
             />
           ) : (
             <IdentifierTextInput

--- a/src/components/Layout/PhoneNumberInput.tsx
+++ b/src/components/Layout/PhoneNumberInput.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent } from "react";
+import React, {
+  FunctionComponent,
+  useState,
+  useEffect,
+  useCallback,
+} from "react";
 import { View, TextInput, StyleSheet } from "react-native";
 import { AppText } from "./AppText";
 import { size, color, borderRadius, fontSize } from "../../common/styles";
@@ -43,9 +48,6 @@ const styles = StyleSheet.create({
     marginLeft: size(1),
     fontSize: fontSize(3),
   },
-  numberWrapper: {
-    marginBottom: size(2),
-  },
   label: {
     fontFamily: "brand-bold",
   },
@@ -69,9 +71,32 @@ export const PhoneNumberInput: FunctionComponent<{
   onSubmit = () => {},
   accessibilityLabel = "phone-number",
 }) => {
-  const countryCode = countryCodeValue.substr(1);
+  const [formattedNumber, setFormattedNumber] = useState(mobileNumberValue);
+
+  const onChangeNumberInput = useCallback(
+    (text: string): void => {
+      onChangeMobileNumber(stripPhoneNumberFormatting(text));
+    },
+    [onChangeMobileNumber]
+  );
+
+  useEffect(() => {
+    const formatted = formatPhoneNumber(mobileNumberValue, countryCodeValue);
+    setFormattedNumber(formatted);
+    /**
+     * Changes in country code may cause the format to be different and
+     * the parent needs to be informed of the state change.
+     * e.g. Initially country code is "+1", while number is "6588888888".
+     * The input will show "658-888-8888". On changing country code to "+65",
+     * the format updates to "8888 8888", but the parent's state is
+     * still "6588888888". This ensures that the parent's state becomes
+     * "88888888".
+     */
+    onChangeNumberInput(formatted);
+  }, [countryCodeValue, mobileNumberValue, onChangeNumberInput]);
+
   return (
-    <View style={styles.numberWrapper}>
+    <View>
       <AppText
         style={styles.label}
         accessibilityLabel={`${accessibilityLabel}-label`}
@@ -85,18 +110,14 @@ export const PhoneNumberInput: FunctionComponent<{
           style={styles.countryCode}
           keyboardType="phone-pad"
           value={countryCodeValue}
-          onChangeText={(text) => onChangeCountryCode(text)}
+          onChangeText={onChangeCountryCode}
         />
         <AppText style={styles.hyphen}>-</AppText>
         <TextInput
           style={styles.numberInput}
           keyboardType="phone-pad"
-          value={formatPhoneNumber(mobileNumberValue, countryCode)}
-          onChangeText={(text) => {
-            onChangeMobileNumber(
-              stripPhoneNumberFormatting(formatPhoneNumber(text, countryCode))
-            );
-          }}
+          value={formattedNumber}
+          onChangeText={onChangeNumberInput}
           onSubmitEditing={onSubmit}
           accessibilityLabel={`${accessibilityLabel}-input`}
           testID={`${accessibilityLabel}-input`}

--- a/src/utils/validatePhoneNumbers.tsx
+++ b/src/utils/validatePhoneNumbers.tsx
@@ -1,7 +1,38 @@
-import { PhoneNumberUtil } from "google-libphonenumber";
+import { PhoneNumberUtil, PhoneNumber } from "google-libphonenumber";
+
+const DEFAULT_COUNTRY_CODE = "+65";
 
 export const createFullNumber = (countryCode: string, number: string): string =>
   `${countryCode}${number}`.replace(/\s/g, "");
+
+/**
+ * Parses a given number. Does not check if the number is valid for
+ * the particular country.
+ *
+ * @param phoneNumber
+ * A string that may or may not start with `+`.
+ * Should consist only of numbers or `+`.
+ *
+ * @param countryCode
+ * Should be specified if phoneNumber does not start with `+`.
+ * If unspecified, will default to +65.
+ */
+export const parsePhoneNumber = (
+  phoneNumber: string,
+  countryCode?: string
+): PhoneNumber => {
+  const phoneNumberUtil = new PhoneNumberUtil();
+  if (phoneNumber.startsWith("+")) {
+    return phoneNumberUtil.parse(phoneNumber);
+  } else {
+    return phoneNumberUtil.parse(
+      phoneNumber,
+      phoneNumberUtil.getRegionCodeForCountryCode(
+        Number.parseInt(countryCode || DEFAULT_COUNTRY_CODE) // Using OR operator to support fallbacks for blank countryCodes
+      )
+    );
+  }
+};
 
 export const fullPhoneNumberValidator = (fullNumber: string): boolean => {
   try {


### PR DESCRIPTION
[Notion link](https://www.notion.so/Phone-number-scanning-68b12284ee2e40f9bf4fdc37e00b07ae) <!-- Remove this link if no relevant Notion link -->

This PR adds ability to scan a phone number.
* Fixes alignment issue when the scan button is enabled
* Add logic to handle the scanning of the following types of numbers:
  * `91234567`: no country code, will default to SG
  * `+65 81234567`, `+12024561414`: has country code, will update the country code input to match what was scanned
  * `65 91234567`, `6581234567`, `12024561414`: has country code without `+` sign, will default to SG.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
