### PR TITLE
Phrasing and grammatical updates for error messages

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -147,12 +147,12 @@ export const en: Translations = {
     },
     incompleteEntryDeviceCode: {
       title: "Incomplete entry",
-      body: "Enter device code.",
+      body: "Enter a device code.",
       primaryActionText: "OK",
     },
     incompleteEntryContactNumber: {
       title: "Incomplete entry",
-      body: "Enter contact number",
+      body: "Enter a contact number.",
       primaryActionText: "OK",
     },
     incompleteEntrySelectCheckbox: {
@@ -292,37 +292,37 @@ export const en: Translations = {
     },
     alreadyUsedCode: {
       title: "Already Used",
-      body: "Enter unique code details",
+      body: "Enter or scan a unique code.",
       primaryActionText: "OK",
     },
     alreadyUsedItem: {
       title: "Already Used",
-      body: "Scan another item that is not tagged to any ID number",
+      body: "Scan another item that is not tagged to any ID number.",
       primaryActionText: "OK",
     },
     wrongFormatCode: {
       title: "Wrong format",
-      body: "Enter or scan valid code details",
+      body: "Enter or scan valid code details.",
       primaryActionText: "OK",
     },
     incompleteEntryCode: {
       title: "Incomplete entry",
-      body: "Enter or scan code details",
+      body: "Enter or scan code details.",
       primaryActionText: "OK",
     },
     wrongFormatNotValidDeviceCode: {
       title: "Wrong format",
-      body: "Scan valid device code",
+      body: "Scan a valid device code.",
       primaryActionText: "OK",
     },
     incompleteEntryScanDeviceCode: {
       title: "Incomplete entry",
-      body: "Scan device code",
+      body: "Scan a device code.",
       primaryActionText: "OK",
     },
     wrongFormatContactNumber: {
       title: "Wrong format",
-      body: "Enter valid contact number",
+      body: "Enter a valid contact number.",
       primaryActionText: "OK",
     },
     insufficientQuota: {
@@ -390,7 +390,7 @@ export const en: Translations = {
     },
     wrongFormatEmailAddress: {
       title: "Wrong format",
-      body: "Enter valid email address",
+      body: "Enter a valid email address.",
       primaryActionText: "OK",
     },
     invalidDeviceCode: {


### PR DESCRIPTION
More standardization of error messages was done 

[Notion link](https://www.notion.so/Correct-phrasing-and-grammar-for-error-dialog-messages-829d750c98a8425ebf37a3d18ce8a9d8)

This PR adds standardization to current error dialog messages that apply to all distributions. Phrasing for 1 of the error messages has been corrected as well. 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
