### PR TITLE
feat: implement UNSUCCESSFUL cartState condition

### DIFF
--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -503,6 +503,35 @@ describe("useCart", () => {
       );
     });
 
+    it("should show unsuccessful cart state when token mismatch error is received (return-pod)", async () => {
+      expect.assertions(2);
+      const ids = ["ID1"];
+      const { result } = renderHook(
+        () => useCart(ids, key, endpoint, mockQuotaResSingleId.remainingQuota),
+        {
+          wrapper,
+        }
+      );
+
+      mockPostTransaction.mockRejectedValueOnce(
+        new Error("Token does not match the customer's last registered token")
+      );
+
+      await wait(() => {
+        result.current.updateCart("toilet-paper", 2, [
+          {
+            label: "first",
+            value: "first",
+            textInputType: "STRING",
+          },
+        ]);
+        result.current.checkoutCart();
+        expect(result.current.cartState).toBe("CHECKING_OUT");
+      });
+
+      expect(result.current.cartState).toBe("UNSUCCESSFUL");
+    });
+
     it("should set cartError when no item was selected", async () => {
       expect.assertions(3);
       const ids = ["ID1"];

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -24,7 +24,7 @@ export type CartItem = {
 
 export type Cart = CartItem[];
 
-type CartState = "DEFAULT" | "CHECKING_OUT" | "PURCHASED";
+type CartState = "DEFAULT" | "CHECKING_OUT" | "PURCHASED" | "UNSUCCESSFUL";
 
 export type CartHook = {
   cartState: CartState;
@@ -241,6 +241,11 @@ export const useCart = (
           setCartError(new Error(ERROR_MESSAGE.DUPLICATE_IDENTIFIER_INPUT));
         } else if (e.message === "Invalid Purchase Request: Item not found") {
           setCartError(new Error(ERROR_MESSAGE.INVALID_POD_IDENTIFIER));
+        } else if (
+          e.message ===
+          "Token does not match the customer's last registered token"
+        ) {
+          setCartState("UNSUCCESSFUL");
         } else if (
           e.message === "Invalid Purchase Request: Item already used"
         ) {


### PR DESCRIPTION
[Notion link](https://www.notion.so/Return-TT-Token-FrontEnd-Changes-69860c2451a94f89bba3c9fa34ac02f9) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- new cartState: UNSUCCESSFUL. This cartState is for the `tt return flow`. It will be triggered when a user attempts to return the wrong token

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [x] I've added/updated unit/integration tests
- [x] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
