### PR TITLE
feat: only show payment receipt field upon chargeable

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -268,7 +268,7 @@ export const en: Translations = {
     },
     wrongPaymentReceiptNumber: {
       title: "Wrong format",
-      body: "Enter a payment receipt number.",
+      body: "Enter a valid payment receipt number.",
       primaryActionText: "OK",
     },
     wrongFormatCountryCode: {

--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -266,6 +266,11 @@ export const en: Translations = {
       body: "You are offline. Try to connect and try again.",
       primaryActionText: "Retry",
     },
+    wrongPaymentReceiptNumber: {
+      title: "Wrong format",
+      body: "Enter a payment receipt number.",
+      primaryActionText: "OK",
+    },
     wrongFormatCountryCode: {
       title: "Wrong format",
       body: "Enter a valid country code.",

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -281,7 +281,6 @@ export type Translations = {
       title: string;
       body?: string;
       primaryActionText: string;
-      secondaryActionText?: string;
     };
     wrongFormatCountryCode: {
       title: string;

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -277,6 +277,12 @@ export type Translations = {
       primaryActionText: string;
       secondaryActionText?: string;
     };
+    wrongPaymentReceiptNumber: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+      secondaryActionText?: string;
+    };
     wrongFormatCountryCode: {
       title: string;
       body?: string;

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -259,6 +259,11 @@ export const zh: Translations = {
       body: "您已断线。请尝试连接并重试。",
       primaryActionText: "重试",
     },
+    wrongPaymentReceiptNumber: {
+      title: "格式错误",
+      body: "请输入付款收据编号。",
+      primaryActionText: "确定",
+    },
     wrongFormatCountryCode: {
       title: "格式错误",
       body: "请输入有效的国家代码。",

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -261,7 +261,7 @@ export const zh: Translations = {
     },
     wrongPaymentReceiptNumber: {
       title: "格式错误",
-      body: "请输入付款收据编号。",
+      body: "请输入有效的付款收据编号。",
       primaryActionText: "确定",
     },
     wrongFormatCountryCode: {

--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -28,8 +28,8 @@ export const Item: FunctionComponent<{
     item.label.includes("receipt number")
   );
 
-  // let newIdentifiers = identifiers;
-  // const newCartItem = cartItem;
+  const newIdentifiers = identifiers;
+  const newCartItem = cartItem;
 
   // these idenfitifiers should only be shown if this redemption is chargeable
   // so we remove them if otherwise
@@ -47,13 +47,8 @@ export const Item: FunctionComponent<{
     //   (identifier) => identifier.label != "Payment receipt number"
     // );
 
-    const removedFromCart = cartItem.identifierInputs.splice(
-      indexOfReceiptField,
-      1
-    );
-    const removedFromIden = identifiers.splice(indexOfReceiptField, 1);
-    console.log(removedFromCart);
-    console.log(removedFromIden);
+    newCartItem.identifierInputs.splice(indexOfReceiptField, 1);
+    newIdentifiers.splice(indexOfReceiptField, 1);
   }
 
   return (
@@ -77,9 +72,9 @@ export const Item: FunctionComponent<{
       )}
       {cartItem.maxQuantity > 0 && identifiers.length > 0 && (
         <ItemIdentifiersCard
-          cartItem={cartItem}
+          cartItem={newCartItem}
           updateCart={updateCart}
-          identifiers={identifiers}
+          identifiers={newIdentifiers}
         />
       )}
     </View>

--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -45,8 +45,8 @@ const isPodChargeable = (
  * Shape of identifiers and cartItem.identifierInputs are slightly different and
  * hence require to filter separately
  *
- * @param newIdentifiers identifiers that can be modified
- * @param newCartItem cartItem containing identifiers that can be modified
+ * @param identifiers identifiers that can be modified
+ * @param cartItem cartItem containing identifiers that can be modified
  */
 const removePaymentReceiptField = (
   identifiers: PolicyIdentifier[],

--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -24,23 +24,36 @@ export const Item: FunctionComponent<{
   const { getProduct } = useContext(ProductContext);
   const identifiers = getProduct(cartItem.category)?.identifiers || [];
 
-  let newIdentifiers = identifiers;
-  const newCartItem = cartItem;
+  const indexOfReceiptField = identifiers.findIndex((item) =>
+    item.label.includes("receipt number")
+  );
 
+  // let newIdentifiers = identifiers;
+  // const newCartItem = cartItem;
+
+  // these idenfitifiers should only be shown if this redemption is chargeable
+  // so we remove them if otherwise
   if (
     identifiers.length > 0 &&
     cartItem.category.includes("lost") &&
-    cartItem.descriptionAlert !== "*chargeable"
+    cartItem.descriptionAlert !== "*chargeable" &&
+    indexOfReceiptField != -1
   ) {
     console.log("test");
-    console.log(cartItem.category);
-    console.log(identifiers);
-    newIdentifiers = identifiers.filter(
-      (identifier) => identifier.label != "Payment receipt number"
+    // newCartItem.identifierInputs = newCartItem.identifierInputs.filter(
+    //   (identifier) => identifier.label != "Payment receipt number"
+    // );
+    // newIdentifiers = identifiers.filter(
+    //   (identifier) => identifier.label != "Payment receipt number"
+    // );
+
+    const removedFromCart = cartItem.identifierInputs.splice(
+      indexOfReceiptField,
+      1
     );
-    newCartItem.identifierInputs = newCartItem.identifierInputs.filter(
-      (identifier) => identifier.label != "Payment receipt number"
-    );
+    const removedFromIden = identifiers.splice(indexOfReceiptField, 1);
+    console.log(removedFromCart);
+    console.log(removedFromIden);
   }
 
   return (
@@ -62,11 +75,11 @@ export const Item: FunctionComponent<{
           updateCart={updateCart}
         />
       )}
-      {newCartItem.maxQuantity > 0 && newIdentifiers.length > 0 && (
+      {cartItem.maxQuantity > 0 && identifiers.length > 0 && (
         <ItemIdentifiersCard
-          cartItem={newCartItem}
+          cartItem={cartItem}
           updateCart={updateCart}
-          identifiers={newIdentifiers}
+          identifiers={identifiers}
         />
       )}
     </View>

--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -24,6 +24,16 @@ export const Item: FunctionComponent<{
   const { getProduct } = useContext(ProductContext);
   const identifiers = getProduct(cartItem.category)?.identifiers || [];
 
+  if (
+    identifiers.length > 0 &&
+    cartItem.category.includes("lost") &&
+    cartItem.descriptionAlert !== "*chargeable"
+  ) {
+    console.log("test");
+    console.log(cartItem.category);
+    console.log(identifiers);
+  }
+
   return (
     <View style={styles.cartItemComponent}>
       {cartItem.maxQuantity === 0 ? (

--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -39,14 +39,6 @@ export const Item: FunctionComponent<{
     cartItem.descriptionAlert !== "*chargeable" &&
     indexOfReceiptField != -1
   ) {
-    console.log("test");
-    // newCartItem.identifierInputs = newCartItem.identifierInputs.filter(
-    //   (identifier) => identifier.label != "Payment receipt number"
-    // );
-    // newIdentifiers = identifiers.filter(
-    //   (identifier) => identifier.label != "Payment receipt number"
-    // );
-
     newCartItem.identifierInputs.splice(indexOfReceiptField, 1);
     newIdentifiers.splice(indexOfReceiptField, 1);
   }

--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -24,23 +24,22 @@ export const Item: FunctionComponent<{
   const { getProduct } = useContext(ProductContext);
   const identifiers = getProduct(cartItem.category)?.identifiers || [];
 
-  const indexOfReceiptField = identifiers.findIndex((item) =>
-    item.label.includes("receipt number")
-  );
-
-  const newIdentifiers = identifiers;
+  let newIdentifiers = identifiers;
   const newCartItem = cartItem;
 
-  // these idenfitifiers should only be shown if this redemption is chargeable
-  // so we remove them if otherwise
+  // these identifiers should only be shown if this redemption is chargeable
+  // so we will filter them out if otherwise
   if (
     identifiers.length > 0 &&
     cartItem.category.includes("lost") &&
-    cartItem.descriptionAlert !== "*chargeable" &&
-    indexOfReceiptField != -1
+    cartItem.descriptionAlert !== "*chargeable"
   ) {
-    newCartItem.identifierInputs.splice(indexOfReceiptField, 1);
-    newIdentifiers.splice(indexOfReceiptField, 1);
+    newIdentifiers = identifiers.filter(
+      (identifier) => identifier.label != "Payment receipt number"
+    );
+    newCartItem.identifierInputs = newCartItem.identifierInputs.filter(
+      (identifier) => identifier.label != "Payment receipt number"
+    );
   }
 
   return (

--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -49,21 +49,21 @@ const isPodChargeable = (
  * @param newCartItem cartItem containing identifiers that can be modified
  */
 const removePaymentReceiptField = (
-  newIdentifiers: PolicyIdentifier[],
-  newCartItem: CartItem
+  identifiers: PolicyIdentifier[],
+  cartItem: CartItem
 ): {
   newIdentifiers: PolicyIdentifier[];
   newCartItem: CartItem;
 } => {
-  newIdentifiers = newIdentifiers.filter(
+  identifiers = identifiers.filter(
     (identifier: { label: string }) =>
       identifier.label != "Payment receipt number"
   );
-  newCartItem.identifierInputs = newCartItem.identifierInputs.filter(
+  cartItem.identifierInputs = cartItem.identifierInputs.filter(
     (identifier) => identifier.label != "Payment receipt number"
   );
 
-  return { newIdentifiers, newCartItem };
+  return { newIdentifiers: identifiers, newCartItem: cartItem };
 };
 
 export const Item: FunctionComponent<{

--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -18,7 +18,7 @@ const styles = StyleSheet.create({
 
 /**
  * Check if the campaign contains tt-token
- * to indicate pod camapaign
+ * to indicate pod campaign
  *
  * @param cartItemCategory category of item
  */
@@ -101,13 +101,13 @@ export const Item: FunctionComponent<{
           updateCart={updateCart}
         />
       ) : (
-        <ItemStepper
-          ids={ids}
-          isChargeable={isChargeable}
-          cartItem={cartItem}
-          updateCart={updateCart}
-        />
-      )}
+            <ItemStepper
+              ids={ids}
+              isChargeable={isChargeable}
+              cartItem={cartItem}
+              updateCart={updateCart}
+            />
+          )}
       {cartItem.maxQuantity > 0 && identifiers.length > 0 && (
         <ItemIdentifiersCard
           cartItem={newCartItem}

--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -101,13 +101,13 @@ export const Item: FunctionComponent<{
           updateCart={updateCart}
         />
       ) : (
-            <ItemStepper
-              ids={ids}
-              isChargeable={isChargeable}
-              cartItem={cartItem}
-              updateCart={updateCart}
-            />
-          )}
+        <ItemStepper
+          ids={ids}
+          isChargeable={isChargeable}
+          cartItem={cartItem}
+          updateCart={updateCart}
+        />
+      )}
       {cartItem.maxQuantity > 0 && identifiers.length > 0 && (
         <ItemIdentifiersCard
           cartItem={newCartItem}

--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -24,6 +24,9 @@ export const Item: FunctionComponent<{
   const { getProduct } = useContext(ProductContext);
   const identifiers = getProduct(cartItem.category)?.identifiers || [];
 
+  let newIdentifiers = identifiers;
+  const newCartItem = cartItem;
+
   if (
     identifiers.length > 0 &&
     cartItem.category.includes("lost") &&
@@ -32,6 +35,12 @@ export const Item: FunctionComponent<{
     console.log("test");
     console.log(cartItem.category);
     console.log(identifiers);
+    newIdentifiers = identifiers.filter(
+      (identifier) => identifier.label != "Payment receipt number"
+    );
+    newCartItem.identifierInputs = newCartItem.identifierInputs.filter(
+      (identifier) => identifier.label != "Payment receipt number"
+    );
   }
 
   return (
@@ -53,11 +62,11 @@ export const Item: FunctionComponent<{
           updateCart={updateCart}
         />
       )}
-      {cartItem.maxQuantity > 0 && identifiers.length > 0 && (
+      {newCartItem.maxQuantity > 0 && newIdentifiers.length > 0 && (
         <ItemIdentifiersCard
-          cartItem={cartItem}
+          cartItem={newCartItem}
           updateCart={updateCart}
-          identifiers={identifiers}
+          identifiers={newIdentifiers}
         />
       )}
     </View>

--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -31,7 +31,7 @@ export const Item: FunctionComponent<{
   // so we will filter them out if otherwise
   if (
     identifiers.length > 0 &&
-    cartItem.category.includes("lost") &&
+    cartItem.category.includes("tt-token-lost") &&
     cartItem.descriptionAlert !== "*chargeable"
   ) {
     newIdentifiers = identifiers.filter(

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -36,6 +36,7 @@ export enum ERROR_MESSAGE {
   INVALID_PHONE_NUMBER = "Enter a valid contact number.",
   INVALID_COUNTRY_CODE = "Enter a valid country code.",
   INVALID_PHONE_AND_COUNTRY_CODE = "Enter a valid country code and contact number.",
+  INVALID_PAYMENT_RECEIPT_NUMBER = "Enter a payment receipt number.",
   MISSING_SELECTION = "Select at least one item to checkout.",
   AUTH_FAILURE_INVALID_TOKEN = "Get a new QR code from your in-charge.",
   AUTH_FAILURE_INVALID_FORMAT = "Scan QR code again or get a new QR code from your in-charge.",
@@ -100,6 +101,7 @@ const messageToTranslationKeyMappings: Record<string, string> = {
   [ERROR_MESSAGE.INVALID_COUNTRY_CODE]: "wrongFormatCountryCode",
   [ERROR_MESSAGE.INVALID_PHONE_AND_COUNTRY_CODE]:
     "wrongFormatCountryCodePhoneNumber",
+  [ERROR_MESSAGE.INVALID_PAYMENT_RECEIPT_NUMBER]: "wrongPaymentReceiptNumber",
   [ERROR_MESSAGE.MISSING_SELECTION]: "incompleteEntry",
   [ERROR_MESSAGE.AUTH_FAILURE_INVALID_TOKEN]: "expiredQR",
   [ERROR_MESSAGE.AUTH_FAILURE_INVALID_FORMAT]: "invalidInputQR",

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -36,7 +36,7 @@ export enum ERROR_MESSAGE {
   INVALID_PHONE_NUMBER = "Enter a valid contact number.",
   INVALID_COUNTRY_CODE = "Enter a valid country code.",
   INVALID_PHONE_AND_COUNTRY_CODE = "Enter a valid country code and contact number.",
-  INVALID_PAYMENT_RECEIPT_NUMBER = "Enter a payment receipt number.",
+  INVALID_PAYMENT_RECEIPT_NUMBER = "Enter a valid payment receipt number.",
   MISSING_SELECTION = "Select at least one item to checkout.",
   AUTH_FAILURE_INVALID_TOKEN = "Get a new QR code from your in-charge.",
   AUTH_FAILURE_INVALID_FORMAT = "Scan QR code again or get a new QR code from your in-charge.",

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ const TextInputType = t.union([
   t.literal("STRING"),
   t.literal("NUMBER"),
   t.literal("PHONE_NUMBER"),
+  t.literal("PAYMENT_RECEIPT"),
 ]);
 
 const ScanButtonType = t.union([t.literal("QR"), t.literal("BARCODE")]);

--- a/src/utils/validateIdentifierInputs.test.ts
+++ b/src/utils/validateIdentifierInputs.test.ts
@@ -37,6 +37,12 @@ describe("validateIdentifierInputs", () => {
           value: "+13475679064",
           textInputType: "PHONE_NUMBER",
         },
+        {
+          label: "some payment receipt",
+          value: "1234acbd5678qwer1234",
+          validationRegex: "^[a-zA-Z0-9]{1,20}$",
+          textInputType: "PAYMENT_RECEIPT",
+        },
       ])
     ).toBe(true);
   });
@@ -190,11 +196,28 @@ describe("validateIdentifierInputs", () => {
     ).toThrow("Enter or scan a different code.");
   });
 
-  it("should throw the specific error if the identifierInput is payment receipt number", () => {
-    expect.assertions(1);
+  it("should throw the specific error if the textInputType is payment receipt", () => {
+    expect.assertions(2);
+
     expect(() =>
       validateIdentifierInputs([
-        { label: "Payment receipt number", value: "", textInputType: "STRING" },
+        {
+          label: "Payment receipt number",
+          value: "",
+          textInputType: "PAYMENT_RECEIPT",
+          validationRegex: "^[a-zA-Z0-9]{1,20}$",
+        },
+      ])
+    ).toThrow("Enter a valid payment receipt number.");
+
+    expect(() =>
+      validateIdentifierInputs([
+        {
+          label: "Payment receipt number",
+          value: "abcdqwer12345678qwer2", //21 characters
+          textInputType: "PAYMENT_RECEIPT",
+          validationRegex: "^[a-zA-Z0-9]{1,20}$",
+        },
       ])
     ).toThrow("Enter a valid payment receipt number.");
   });

--- a/src/utils/validateIdentifierInputs.test.ts
+++ b/src/utils/validateIdentifierInputs.test.ts
@@ -197,7 +197,7 @@ describe("validateIdentifierInputs", () => {
   });
 
   it("should throw the specific error if the textInputType is payment receipt", () => {
-    expect.assertions(2);
+    expect.assertions(4);
 
     expect(() =>
       validateIdentifierInputs([
@@ -214,7 +214,29 @@ describe("validateIdentifierInputs", () => {
       validateIdentifierInputs([
         {
           label: "Payment receipt number",
-          value: "abcdqwer12345678qwer2", //21 characters
+          value: "abcdqwer12345678qwer2", // 21 characters
+          textInputType: "PAYMENT_RECEIPT",
+          validationRegex: "^[a-zA-Z0-9]{1,20}$",
+        },
+      ])
+    ).toThrow("Enter a valid payment receipt number.");
+
+    expect(() =>
+      validateIdentifierInputs([
+        {
+          label: "Payment receipt number",
+          value: "     ",
+          textInputType: "PAYMENT_RECEIPT",
+          validationRegex: "^[a-zA-Z0-9]{1,20}$",
+        },
+      ])
+    ).toThrow("Enter a valid payment receipt number.");
+
+    expect(() =>
+      validateIdentifierInputs([
+        {
+          label: "Payment receipt number",
+          value: "//asd.;'[",
           textInputType: "PAYMENT_RECEIPT",
           validationRegex: "^[a-zA-Z0-9]{1,20}$",
         },

--- a/src/utils/validateIdentifierInputs.test.ts
+++ b/src/utils/validateIdentifierInputs.test.ts
@@ -196,6 +196,6 @@ describe("validateIdentifierInputs", () => {
       validateIdentifierInputs([
         { label: "Payment receipt number", value: "", textInputType: "STRING" },
       ])
-    ).toThrow("Enter a payment receipt number.");
+    ).toThrow("Enter a valid payment receipt number.");
   });
 });

--- a/src/utils/validateIdentifierInputs.test.ts
+++ b/src/utils/validateIdentifierInputs.test.ts
@@ -189,4 +189,13 @@ describe("validateIdentifierInputs", () => {
       ])
     ).toThrow("Enter or scan a different code.");
   });
+
+  it("should throw the specific error if the identifierInput is payment receipt number", () => {
+    expect.assertions(1);
+    expect(() =>
+      validateIdentifierInputs([
+        { label: "Payment receipt number", value: "", textInputType: "STRING" },
+      ])
+    ).toThrow("Enter a payment receipt number.");
+  });
 });

--- a/src/utils/validateIdentifierInputs.ts
+++ b/src/utils/validateIdentifierInputs.ts
@@ -17,8 +17,17 @@ const isUniqueList = (list: string[]): boolean =>
 export const validateIdentifierInputs = (
   identifierInputs: IdentifierInput[]
 ): boolean => {
-  for (const { value, validationRegex, textInputType } of identifierInputs) {
+  for (const {
+    label,
+    value,
+    validationRegex,
+    textInputType,
+  } of identifierInputs) {
     //TODO: switch between different errors based on campaign config
+    // TODO: can set the validation regex here once it's confirmed
+    if (label === "Payment receipt number" && !value) {
+      throw new Error(ERROR_MESSAGE.INVALID_PAYMENT_RECEIPT_NUMBER);
+    }
     if (!value) {
       throw new Error(ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT);
     }

--- a/src/utils/validateIdentifierInputs.ts
+++ b/src/utils/validateIdentifierInputs.ts
@@ -23,7 +23,7 @@ export const validateIdentifierInputs = (
     validationRegex,
     textInputType,
   } of identifierInputs) {
-    //TODO: switch between different errors based on campaign config
+    // TODO: switch between different errors based on campaign config
     // TODO: can set the validation regex here once it's confirmed
     if (label === "Payment receipt number" && !value) {
       throw new Error(ERROR_MESSAGE.INVALID_PAYMENT_RECEIPT_NUMBER);

--- a/src/utils/validateIdentifierInputs.ts
+++ b/src/utils/validateIdentifierInputs.ts
@@ -19,7 +19,6 @@ export const validateIdentifierInputs = (
   identifierInputs: IdentifierInput[]
 ): boolean => {
   for (const { value, validationRegex, textInputType } of identifierInputs) {
-    // TODO: switch between different errors based on campaign config
     if (
       textInputType === "PAYMENT_RECEIPT" &&
       (!value ||

--- a/src/utils/validateIdentifierInputs.ts
+++ b/src/utils/validateIdentifierInputs.ts
@@ -3,6 +3,7 @@ import { fullPhoneNumberValidator } from "./validatePhoneNumbers";
 import { ERROR_MESSAGE } from "../context/alert";
 
 const defaultPhoneNumberValidationRegex = "^\\+[0-9]*$";
+const defaultPaymentReceiptValidationRegex = "^[a-zA-Z0-9]{1,20}$";
 
 const isMatchRegex = (text: string, regex?: string): boolean => {
   if (!regex) {
@@ -17,20 +18,24 @@ const isUniqueList = (list: string[]): boolean =>
 export const validateIdentifierInputs = (
   identifierInputs: IdentifierInput[]
 ): boolean => {
-  for (const {
-    label,
-    value,
-    validationRegex,
-    textInputType,
-  } of identifierInputs) {
+  for (const { value, validationRegex, textInputType } of identifierInputs) {
     // TODO: switch between different errors based on campaign config
-    // TODO: can set the validation regex here once it's confirmed
-    if (label === "Payment receipt number" && !value) {
+    if (
+      textInputType === "PAYMENT_RECEIPT" &&
+      (!value ||
+        !isMatchRegex(
+          value,
+          validationRegex
+            ? validationRegex
+            : defaultPaymentReceiptValidationRegex
+        ))
+    ) {
       throw new Error(ERROR_MESSAGE.INVALID_PAYMENT_RECEIPT_NUMBER);
     }
     if (!value) {
       throw new Error(ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT);
     }
+
     if (textInputType === "NUMBER" && isNaN(Number(value))) {
       throw new Error(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
     }


### PR DESCRIPTION
[Notion link](https://www.notion.so/Update-policy-to-charge-lost-TT-Tokens-if-it-s-lost-for-a-2nd-time-Enter-Payment-receipt-number-28a3cb5dfdbc4e9e95a21a1b1490db0a) <!-- Remove this link if no relevant Notion link -->

This PR adds the payment receipt field in IdentifierInputs if it's chargeable. Relies on backend api PR532. WIP!

Will be using filter instead of splice, mainly because `splice` makes changes to the `policies` 
```
Array.splice - will change the Array itself. (use: myArray.splice)
Array.filter - will return the filtered Array. (use: myFilteredArray = Array.filter)
```
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)