### PR TITLE
feat: refactoring punctuations to translation texts.

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -4,7 +4,7 @@ export const en: Translations = {
   loginScanCard: {
     loginWithQR: "Login with your unique QR code provided by your in-charge.",
     scanToLogin: "Scan to login",
-    needHelp: "Need help",
+    needHelp: "Need help?",
     askQuestion: "Ask a question",
   },
   loginMobileNumberCard: {
@@ -72,12 +72,10 @@ export const en: Translations = {
     remove: "Remove",
   },
   checkoutSuccessScreen: {
-    redeemed: "Redeemed",
-    redeemedItems: "Item(s) redeemed",
-    returned: "Returned",
-    returnedItems: "Item(s) returned",
+    redeemed: "Redeemed!",
+    redeemedItems: "Item(s) redeemed:",
     nextIdentity: "Next identity",
-    previouslyRedeemedItems: "Item(s) redeemed previously",
+    previouslyRedeemedItems: "Item(s) redeemed previously:",
     redeemedAgo: "Redeemed %{time} ago",
     redeemedOn: "Redeemed on %{time}",
     previouslyRedeemed: "Previously redeemed",

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -71,8 +71,6 @@ export type Translations = {
   checkoutSuccessScreen: {
     redeemed: string;
     redeemedItems: string;
-    returned: string;
-    returnedItems: string;
     nextIdentity: string;
     previouslyRedeemedItems: string;
     redeemedAgo: string;

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -4,7 +4,7 @@ export const zh: Translations = {
   loginScanCard: {
     loginWithQR: "请使用您专属的QR码登录",
     scanToLogin: "扫描QR码",
-    needHelp: "需要协助",
+    needHelp: "需要协助?",
     askQuestion: "问问题",
   },
   loginMobileNumberCard: {
@@ -71,12 +71,10 @@ export const zh: Translations = {
     remove: "清除",
   },
   checkoutSuccessScreen: {
-    redeemed: "已领取",
-    redeemedItems: "已领取物品",
-    returned: "物品已退回",
-    returnedItems: "已退回的物品",
+    redeemed: "已领取!",
+    redeemedItems: "已领取物品:",
     nextIdentity: "下一个证件",
-    previouslyRedeemedItems: "已领取物品",
+    previouslyRedeemedItems: "已领取物品:",
     redeemedAgo: "在 %{time} 已领取",
     redeemedOn: "在 %{time} 已领取",
     previouslyRedeemed: "已领取过",

--- a/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
+++ b/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
@@ -219,7 +219,7 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
                   "checkoutSuccessTitle",
                   undefined,
                   i18nt("checkoutSuccessScreen", "redeemed")
-                )}!`}
+                )}`}
               </AppText>
               {showGlobalQuota && firstGlobalQuota!.quotaRefreshTime ? (
                 <UsageQuotaTitle
@@ -234,7 +234,7 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
                   "checkoutSuccessDescription",
                   undefined,
                   i18nt("checkoutSuccessScreen", "redeemedItems")
-                )}:`}
+                )}`}
               </AppText>
               <View style={styles.checkoutItemsList}>
                 {loading ? (

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -203,7 +203,7 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
                       "checkoutSuccessPreviousItems",
                       undefined,
                       i18nt("checkoutSuccessScreen", "previouslyRedeemedItems")
-                    )}:`}
+                    )}`}
                   </AppText>
                   {transactionsByCategoryList.map(
                     (

--- a/src/components/Layout/Buttons/HelpButton.tsx
+++ b/src/components/Layout/Buttons/HelpButton.tsx
@@ -28,7 +28,7 @@ export const HelpButton: FunctionComponent<{ onPress: () => void }> = ({
         }}
       >
         <Feather name="compass" size={size(1.5)} color={color("blue", 40)} />
-        {` ${i18nt("loginScanCard", "needHelp")}? `}
+        {` ${i18nt("loginScanCard", "needHelp")} `}
       </AppText>
     </TouchableOpacity>
   );


### PR DESCRIPTION
[Notion link](https://www.notion.so/Translation-c13n-and-i18n-standardisation-a249a80094c946d490ba479f6ed58fae) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- refactors punctuations into translations file ( `en.ts` and `zh.ts` )
- updated `c13n/en` parameter store for `pr471`

Currently, c13nt method is only used in several components:
- NotEligibleCard
    - notEligibleDescription
- CheckoutSuccessCard
    - checkoutSuccessTitle
    - checkoutSuccessDescription
- CheckoutUnsuccessfulCard
    - checkoutUnsuccessfulTitle
    - checkoutUnsuccessfulDescription
- NoQuotaCard
    - chechkoutSuccessPreviousItems
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [x] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [x] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
