### PR TITLE
feat: add filtering by categories for past transactions

### DIFF
--- a/src/hooks/usePastTransaction/usePastTransaction.test.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.test.tsx
@@ -110,6 +110,35 @@ const mockPastTransactions: PastTransactionsResult = {
   ],
 };
 
+const mockPastTransactionsWithSameCategory: PastTransactionsResult = {
+  pastTransactions: [
+    {
+      category: "specs",
+      quantity: 1,
+      identifierInputs: [
+        {
+          ...defaultIdentifier,
+          label: "first",
+          value: "AAA987654321",
+        },
+      ],
+      transactionTime: new Date(1596530356430),
+    },
+    {
+      category: "specs",
+      quantity: 1,
+      identifierInputs: [
+        {
+          ...defaultIdentifier,
+          label: "first",
+          value: "AAA123456789",
+        },
+      ],
+      transactionTime: new Date(1596530356220),
+    },
+  ],
+};
+
 const mockEmptyPastTransactions: PastTransactionsResult = {
   pastTransactions: [],
 };
@@ -216,6 +245,56 @@ describe("usePastTransaction", () => {
         ERROR_MESSAGE.PAST_TRANSACTIONS_ERROR
       );
       expect(result.current.loading).toStrictEqual(false);
+    });
+  });
+
+  describe("fetch past transactions filtered by categories", () => {
+    it("should populate past transactions with transactions of the same categories", async () => {
+      expect.assertions(4);
+
+      mockGetPastTransactions.mockReturnValueOnce(
+        mockPastTransactionsWithSameCategory
+      );
+
+      const categories = ["specs"];
+
+      const { result, waitForNextUpdate } = renderHook(
+        () => usePastTransaction(ids, key, endpoint, categories),
+        { wrapper }
+      );
+
+      expect(result.current.loading).toStrictEqual(true);
+
+      await waitForNextUpdate();
+
+      expect(result.current.pastTransactionsResult).toStrictEqual([
+        {
+          category: "specs",
+          quantity: 1,
+          identifierInputs: [
+            {
+              ...defaultIdentifier,
+              label: "first",
+              value: "AAA987654321",
+            },
+          ],
+          transactionTime: new Date(1596530356430),
+        },
+        {
+          category: "specs",
+          quantity: 1,
+          identifierInputs: [
+            {
+              ...defaultIdentifier,
+              label: "first",
+              value: "AAA123456789",
+            },
+          ],
+          transactionTime: new Date(1596530356220),
+        },
+      ]);
+      expect(result.current.loading).toStrictEqual(false);
+      expect(result.current.error).toBeNull();
     });
   });
 });

--- a/src/hooks/usePastTransaction/usePastTransaction.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useContext } from "react";
+import { useEffect, useState, useContext, useCallback } from "react";
 import { PastTransactionsResult } from "../../types";
 import { usePrevious } from "../usePrevious";
 import {
@@ -10,6 +10,8 @@ import { ERROR_MESSAGE } from "../../context/alert";
 import { IdentificationContext } from "../../context/identification";
 
 export type PastTransactionHook = {
+  updateCategories: (categories: string[]) => void;
+  resetCategories: () => void;
   pastTransactionsResult: PastTransactionsResult["pastTransactions"] | null;
   loading: boolean;
   error: PastTransactionError | null;
@@ -27,6 +29,25 @@ export const usePastTransaction = (
   const [error, setError] = useState<PastTransactionError | null>(null);
   const prevIds = usePrevious(ids);
   const { selectedIdType } = useContext(IdentificationContext);
+  const [categories, setCategories] = useState<string[]>();
+
+  /**
+   * Updates what category of transactions to retrieve history for
+   */
+  const updateCategories: PastTransactionHook["updateCategories"] = useCallback(
+    (categories) => {
+      if (categories.length > 0) {
+        setCategories(categories);
+      } else {
+        setCategories(undefined);
+      }
+    },
+    []
+  );
+
+  const resetCategories: PastTransactionHook["resetCategories"] = useCallback(() => {
+    setCategories(undefined);
+  }, []);
 
   useEffect(() => {
     const fetchPastTransactions = async (): Promise<void> => {
@@ -35,7 +56,8 @@ export const usePastTransaction = (
           ids,
           selectedIdType,
           authKey,
-          endpoint
+          endpoint,
+          categories
         );
         setPastTransactionsResult(pastTransactionsResponse?.pastTransactions);
       } catch (error) {
@@ -57,9 +79,11 @@ export const usePastTransaction = (
       setError(null);
       fetchPastTransactions();
     }
-  }, [authKey, endpoint, ids, selectedIdType, prevIds]);
+  }, [authKey, endpoint, ids, selectedIdType, prevIds, categories]);
 
   return {
+    updateCategories,
+    resetCategories,
     pastTransactionsResult,
     loading,
     error,

--- a/src/hooks/usePastTransaction/usePastTransaction.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useContext, useCallback } from "react";
+import { useEffect, useState, useContext } from "react";
 import { PastTransactionsResult } from "../../types";
 import { usePrevious } from "../usePrevious";
 import {
@@ -10,8 +10,6 @@ import { ERROR_MESSAGE } from "../../context/alert";
 import { IdentificationContext } from "../../context/identification";
 
 export type PastTransactionHook = {
-  updateCategories: (categories: string[]) => void;
-  resetCategories: () => void;
   pastTransactionsResult: PastTransactionsResult["pastTransactions"] | null;
   loading: boolean;
   error: PastTransactionError | null;
@@ -20,7 +18,8 @@ export type PastTransactionHook = {
 export const usePastTransaction = (
   ids: string[],
   authKey: string,
-  endpoint: string
+  endpoint: string,
+  categories?: string[]
 ): PastTransactionHook => {
   const [pastTransactionsResult, setPastTransactionsResult] = useState<
     PastTransactionsResult["pastTransactions"] | null
@@ -29,25 +28,6 @@ export const usePastTransaction = (
   const [error, setError] = useState<PastTransactionError | null>(null);
   const prevIds = usePrevious(ids);
   const { selectedIdType } = useContext(IdentificationContext);
-  const [categories, setCategories] = useState<string[]>();
-
-  /**
-   * Updates what category of transactions to retrieve history for
-   */
-  const updateCategories: PastTransactionHook["updateCategories"] = useCallback(
-    (categories) => {
-      if (categories.length > 0) {
-        setCategories(categories);
-      } else {
-        setCategories(undefined);
-      }
-    },
-    []
-  );
-
-  const resetCategories: PastTransactionHook["resetCategories"] = useCallback(() => {
-    setCategories(undefined);
-  }, []);
 
   useEffect(() => {
     const fetchPastTransactions = async (): Promise<void> => {
@@ -79,11 +59,9 @@ export const usePastTransaction = (
       setError(null);
       fetchPastTransactions();
     }
-  }, [authKey, endpoint, ids, selectedIdType, prevIds, categories]);
+  }, [authKey, endpoint, ids, categories, selectedIdType, prevIds]);
 
   return {
-    updateCategories,
-    resetCategories,
     pastTransactionsResult,
     loading,
     error,

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -346,7 +346,8 @@ export const livePastTransactions = async (
   ids: string[],
   identificationFlag: IdentificationFlag,
   key: string,
-  endpoint: string
+  endpoint: string,
+  categories?: string[]
 ): Promise<PastTransactionsResult> => {
   let response;
   if (ids.length === 0) {
@@ -364,6 +365,7 @@ export const livePastTransactions = async (
         body: JSON.stringify({
           ids,
           identificationFlag,
+          categories,
         }),
       }
     );


### PR DESCRIPTION
[Notion link](https://www.notion.so/After-return-TT-Token-non-chargeable-transaction-history-are-removed-from-view-but-retains-Chargea-6ea0b27743e7433c96432fb373b3d3cb) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->

- added hooks for updating and resetting categories
- altered API call to transaction history endpoint

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
