### PR TITLE
fix: cart quota not updating

### DIFF
--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -58,6 +58,8 @@ const mockQuotaResSingleId: Quota = {
   ],
 };
 
+const mockQuotaResSingleIdSingleItem = [mockQuotaResSingleId.remainingQuota[0]];
+
 const mockQuotaResMultipleIds: Quota = {
   remainingQuota: [
     {
@@ -639,8 +641,7 @@ describe("useCart", () => {
 
       const ids = ["ID1"];
       const { result } = renderHook(
-        () =>
-          useCart(ids, key, endpoint, [mockQuotaResSingleId.remainingQuota[0]]),
+        () => useCart(ids, key, endpoint, mockQuotaResSingleIdSingleItem),
         {
           wrapper,
           initialProps: {
@@ -880,8 +881,7 @@ describe("useCart", () => {
         </ProductContextProvider>
       );
       const { result } = renderHook(
-        () =>
-          useCart(ids, key, endpoint, [mockQuotaResSingleId.remainingQuota[0]]),
+        () => useCart(ids, key, endpoint, mockQuotaResSingleIdSingleItem),
         {
           wrapper: MobileNumberIdentifierProductWrapper,
         }
@@ -952,8 +952,7 @@ describe("useCart", () => {
         </ProductContextProvider>
       );
       const { result } = renderHook(
-        () =>
-          useCart(ids, key, endpoint, [mockQuotaResSingleId.remainingQuota[0]]),
+        () => useCart(ids, key, endpoint, mockQuotaResSingleIdSingleItem),
         {
           wrapper: InvalidIdentifierProductWrapper,
         }

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -133,7 +133,8 @@ export const useCart = (
   useEffect(() => {
     if (
       cartQuota &&
-      (prevCartQuota != cartQuota ||
+      (!prevCartQuota ||
+        prevCartQuota != cartQuota ||
         prevIds !== ids ||
         prevProducts !== products)
     ) {

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -125,10 +125,11 @@ export const useCart = (
 
   /**
    * Update the cart when:
-   *  1. First quota is retrieved on initialisation (i.e. no previous cart quota)
-   *  2. When quota response changes
-   *  3. When quota is updated (i.e. products or ids change)
-   * Items 2 and 3 can occur at the same time.
+   *  1. An incoming cart quota exists, AND
+   *  2. There is no existing cart quota, OR
+   *  3. The incoming cart quota is different from the existing cart quota, OR
+   *  4. The customer IDs have changed, OR
+   *  5. The products in the cart have changed
    */
   useEffect(() => {
     if (

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -133,7 +133,9 @@ export const useCart = (
   useEffect(() => {
     if (
       cartQuota &&
-      (!prevCartQuota || prevIds !== ids || prevProducts !== products)
+      (prevCartQuota != cartQuota ||
+        prevIds !== ids ||
+        prevProducts !== products)
     ) {
       if (!hasInvalidRemainingQuota(cartQuota)) {
         /**


### PR DESCRIPTION
[Notion link](https://www.notion.so/When-selecting-2-NRICs-in-Engineering-Good-campaign-the-checkbox-does-not-turn-into-a-stepper-826f45042f4e4b3b815bb8341f22e3ea) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->

- Cart quota now updates whenever the quota response changes

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
