### PR TITLE
chore: identifier scan button should only show an icon

### DIFF
--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanButton.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanButton.tsx
@@ -9,12 +9,12 @@ export const IdentifierScanButton: FunctionComponent<{
   disabled: boolean;
   fullWidth: boolean;
   onPress: () => void;
-  text: string;
-}> = ({ disabled, fullWidth, onPress, text }) => (
+}> = ({ disabled, fullWidth, onPress }) => (
   <View style={sharedStyles.buttonWrapper}>
     <DarkButton
-      text={text}
-      icon={<Feather name="maximize" size={size(2)} color={color("grey", 0)} />}
+      icon={
+        <Feather name="maximize" size={size(2.5)} color={color("grey", 0)} />
+      }
       disabled={disabled}
       fullWidth={fullWidth}
       onPress={onPress}

--- a/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemIdentifier.tsx
@@ -33,7 +33,7 @@ export const ItemIdentifier: FunctionComponent<{
   const [shouldShowCamera, setShouldShowCamera] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const { showErrorAlert } = useContext(AlertModalContext);
-  const { c13nt, i18nt } = useTranslate();
+  const { c13nt } = useTranslate();
 
   const { label, textInput, scanButton } = identifier;
 
@@ -77,10 +77,6 @@ export const ItemIdentifier: FunctionComponent<{
             disabled={scanButton.disabled}
             fullWidth={!textInput.visible}
             onPress={() => setShouldShowCamera(true)}
-            text={
-              (scanButton.text && c13nt(scanButton.text)) ??
-              i18nt("customerQuotaScreen", "quotaIdentifierButtonScan")
-            }
           />
         )}
       </View>

--- a/src/components/Layout/Buttons/DarkButton.tsx
+++ b/src/components/Layout/Buttons/DarkButton.tsx
@@ -6,7 +6,7 @@ import { ActivityIndicator, View } from "react-native";
 
 export interface DarkButton {
   onPress?: () => void;
-  text: string;
+  text?: string;
   fullWidth?: boolean;
   isLoading?: boolean;
   icon?: ReactElement;
@@ -35,16 +35,20 @@ export const DarkButton: FunctionComponent<DarkButton> = ({
       <ActivityIndicator size="small" color={color("grey", 0)} />
     ) : (
       <View style={{ flexDirection: "row", alignItems: "center" }}>
-        {icon && <View style={{ marginRight: size(1) }}>{icon}</View>}
-        <AppText
-          style={{
-            color: color("grey", 0),
-            fontFamily: "brand-bold",
-            textAlign: "center",
-          }}
-        >
-          {text}
-        </AppText>
+        {icon && (
+          <View style={text ? { marginRight: size(1) } : {}}>{icon}</View>
+        )}
+        {text ? (
+          <AppText
+            style={{
+              color: color("grey", 0),
+              fontFamily: "brand-bold",
+              textAlign: "center",
+            }}
+          >
+            {text}
+          </AppText>
+        ) : null}
       </View>
     )}
   </BaseButton>

--- a/src/components/Layout/PhoneNumberInput.tsx
+++ b/src/components/Layout/PhoneNumberInput.tsx
@@ -39,8 +39,7 @@ const styles = StyleSheet.create({
     fontFamily: "brand-regular",
   },
   hyphen: {
-    marginRight: size(1),
-    marginLeft: size(1),
+    marginHorizontal: size(0.5),
     fontSize: fontSize(3),
   },
   numberWrapper: {


### PR DESCRIPTION
[Notion link](https://www.notion.so/Phone-number-scanning-68b12284ee2e40f9bf4fdc37e00b07ae)

This PR removes the text from the scan buttons when inputting identifier inputs. Purpose is to ensure there's sufficient space for phone number fields

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
