### PR TITLE
chore(past-tx): move the logging of IDs to a breadcrumb

### DIFF
--- a/src/hooks/usePastTransaction/usePastTransaction.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.tsx
@@ -31,6 +31,12 @@ export const usePastTransaction = (
 
   useEffect(() => {
     const fetchPastTransactions = async (): Promise<void> => {
+      Sentry.addBreadcrumb({
+        category: "fetchPastTransactions",
+        message: JSON.stringify({
+          ids: ids.map((id) => id.slice(-4).padStart(id.length, "*")),
+        }),
+      });
       try {
         const pastTransactionsResponse = await getPastTransactions(
           ids,
@@ -41,11 +47,7 @@ export const usePastTransaction = (
         );
         setPastTransactionsResult(pastTransactionsResponse?.pastTransactions);
       } catch (error) {
-        Sentry.captureException(
-          `Unable to fetch past transactions: ${ids.map((id) =>
-            id.slice(-4).padStart(id.length, "*")
-          )}`
-        );
+        Sentry.captureException("Unable to fetch past transactions");
         setError(
           new PastTransactionError(ERROR_MESSAGE.PAST_TRANSACTIONS_ERROR)
         );


### PR DESCRIPTION
This ensures that the errors are logged in a single category on Sentry. Now they are scattered across many different categories.

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
