### PR TITLE
chore(past-tx): handle unmounted error when fetching

### DIFF
--- a/src/components/Layout/Stepper.tsx
+++ b/src/components/Layout/Stepper.tsx
@@ -186,7 +186,7 @@ export const Stepper: FunctionComponent<Stepper> = ({
   const delayedClampAndRoundDown = useRef(
     debounce<typeof clampAndRoundDown>((...props) => {
       const num = clampAndRoundDown(...props);
-      if (isMounted.current) {
+      if (isMounted()) {
         setInternalValue(`${num}`);
       }
       return num;

--- a/src/hooks/useIsMounted.tsx
+++ b/src/hooks/useIsMounted.tsx
@@ -1,11 +1,12 @@
-import { useRef, useEffect, MutableRefObject } from "react";
+import { useRef, useEffect, useCallback } from "react";
 
-export const useIsMounted = (): MutableRefObject<boolean> => {
-  const isMounted = useRef(false);
+export const useIsMounted = (): (() => boolean) => {
+  const mountedRef = useRef(false);
+  const isMounted = useCallback(() => mountedRef.current, []);
   useEffect(() => {
-    isMounted.current = true;
+    mountedRef.current = true;
     return () => {
-      isMounted.current = false;
+      mountedRef.current = false;
     };
   }, []);
   return isMounted;

--- a/src/hooks/usePastTransaction/usePastTransaction.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useContext } from "react";
 import { PastTransactionsResult } from "../../types";
 import { usePrevious } from "../usePrevious";
+import { useIsMounted } from "../useIsMounted";
 import {
   getPastTransactions,
   PastTransactionError,
@@ -22,6 +23,7 @@ export const usePastTransaction = (
   categories?: string[],
   getAllTransactions = false
 ): PastTransactionHook => {
+  const isMounted = useIsMounted();
   const [pastTransactionsResult, setPastTransactionsResult] = useState<
     PastTransactionsResult["pastTransactions"] | null
   >(null);
@@ -47,14 +49,18 @@ export const usePastTransaction = (
           categories,
           getAllTransactions
         );
-        setPastTransactionsResult(pastTransactionsResponse?.pastTransactions);
+        if (isMounted()) {
+          setPastTransactionsResult(pastTransactionsResponse?.pastTransactions);
+        }
       } catch (error) {
         Sentry.captureException("Unable to fetch past transactions");
         setError(
           new PastTransactionError(ERROR_MESSAGE.PAST_TRANSACTIONS_ERROR)
         );
       } finally {
-        setLoading(false);
+        if (isMounted()) {
+          setLoading(false);
+        }
       }
     };
 
@@ -71,6 +77,7 @@ export const usePastTransaction = (
     getAllTransactions,
     selectedIdType,
     prevIds,
+    isMounted,
   ]);
 
   return {


### PR DESCRIPTION
#~NOTE: Rebase commits once the target PR is merged~

There's been a yellow box warning whenever past transactions is called on the checkout success screen.
```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in %s.%s, a useEffect cleanup function,
    in CheckoutSuccessCard (at CustomerQuotaScreen.tsx:282)
    in RCTView (at CustomerQuotaScreen.tsx:270)
    in RCTView (at ScrollView.js:1063)
    in RCTScrollView (at ScrollView.js:1196)
    in ScrollView (at KeyboardAvoidingScrollView.tsx:24)
    in RCTView (at KeyboardAvoidingView.js:218)
    in KeyboardAvoidingView (at KeyboardAvoidingScrollView.tsx:20)
    in KeyboardAvoidingScrollView (at CustomerQuotaScreen.tsx:267)
```

This occurs when `usePastTransaction` is re-rendered when past transactions is being fetched. When the response arrives for the first render, the component has already unmounted, so the state cannot be updated.

This PR updates the logic to make use of `useIsMounted` to check if the component is mounted and available for state updates.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
