### PR TITLE
chore: useLayoutEffect to handle parent phone number updates

### DIFF
--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierPhoneNumberInput.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierPhoneNumberInput.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent, useState, useEffect } from "react";
+import React, {
+  FunctionComponent,
+  useState,
+  useEffect,
+  useLayoutEffect,
+} from "react";
 import {
   createFullNumber,
   parsePhoneNumber,
@@ -21,16 +26,7 @@ export const IdentifierPhoneNumberInput: FunctionComponent<{
   const [fullNumber, setFullNumber] = useState("");
   const prevFullNumber = usePrevious(fullNumber);
 
-  useEffect(() => {
-    setFullNumber(createFullNumber(countryCodeValue, phoneNumber));
-  }, [countryCodeValue, phoneNumber]);
-
-  useEffect(() => {
-    onPhoneNumberChange(fullNumber);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fullNumber]);
-
-  useEffect(() => {
+  useLayoutEffect(() => {
     // value was updated from parent
     if (value.length > 0 && prevFullNumber && value !== prevFullNumber) {
       try {
@@ -42,6 +38,15 @@ export const IdentifierPhoneNumberInput: FunctionComponent<{
       }
     }
   }, [value, prevFullNumber, countryCodeValue]);
+
+  useEffect(() => {
+    setFullNumber(createFullNumber(countryCodeValue, phoneNumber));
+  }, [countryCodeValue, phoneNumber]);
+
+  useEffect(() => {
+    onPhoneNumberChange(fullNumber);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fullNumber]);
 
   return (
     <View


### PR DESCRIPTION
Ensure that value from parent is handled before other useEffects by using useLayoutEffect

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
