### PR TITLE
Fix: use past transactions missing flag

### DIFF
--- a/src/components/CustomerQuota/ItemsSelection/AddonsItems.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/AddonsItems.tsx
@@ -37,7 +37,8 @@ export const AddonsItems: FunctionComponent<{
     ids,
     sessionToken,
     endpoint,
-    categoryFilter ? [categoryFilter] : undefined
+    categoryFilter ? [categoryFilter] : undefined,
+    true
   );
 
   const { showErrorAlert } = useContext(AlertModalContext);

--- a/src/hooks/usePastTransaction/usePastTransaction.test.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.test.tsx
@@ -139,6 +139,59 @@ const mockPastTransactionsWithSameCategory: PastTransactionsResult = {
   ],
 };
 
+const mockPastTransactionsWithGetAllTransactions: PastTransactionsResult = {
+  pastTransactions: [
+    {
+      category: "specs",
+      quantity: 1,
+      identifierInputs: [
+        {
+          ...defaultIdentifier,
+          label: "first",
+          value: "AAA987654321",
+        },
+      ],
+      transactionTime: new Date(1596530356430),
+    },
+    {
+      category: "specs-lost",
+      quantity: 1,
+      identifierInputs: [
+        {
+          ...defaultIdentifier,
+          label: "first",
+          value: "AAA987654322",
+        },
+      ],
+      transactionTime: new Date(1596530356431),
+    },
+    {
+      category: "specs-lost",
+      quantity: 1,
+      identifierInputs: [
+        {
+          ...defaultIdentifier,
+          label: "first",
+          value: "AAA987654323",
+        },
+      ],
+      transactionTime: new Date(1596530356432),
+    },
+    {
+      category: "specs-lost",
+      quantity: -1,
+      identifierInputs: [
+        {
+          ...defaultIdentifier,
+          label: "first",
+          value: "AAA987654323",
+        },
+      ],
+      transactionTime: new Date(1596530356432),
+    },
+  ],
+};
+
 const mockEmptyPastTransactions: PastTransactionsResult = {
   pastTransactions: [],
 };
@@ -291,6 +344,77 @@ describe("usePastTransaction", () => {
             },
           ],
           transactionTime: new Date(1596530356220),
+        },
+      ]);
+      expect(result.current.loading).toStrictEqual(false);
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("fetch all past transactions", () => {
+    it("should populate past transactions with all transactions", async () => {
+      expect.assertions(4);
+      mockGetPastTransactions.mockReturnValue(
+        mockPastTransactionsWithGetAllTransactions
+      );
+
+      const { result, waitForNextUpdate } = renderHook(
+        () => usePastTransaction(ids, key, endpoint, undefined, true),
+        { wrapper }
+      );
+
+      expect(result.current.loading).toStrictEqual(true);
+
+      await waitForNextUpdate();
+
+      expect(result.current.pastTransactionsResult).toStrictEqual([
+        {
+          category: "specs",
+          quantity: 1,
+          identifierInputs: [
+            {
+              ...defaultIdentifier,
+              label: "first",
+              value: "AAA987654321",
+            },
+          ],
+          transactionTime: new Date(1596530356430),
+        },
+        {
+          category: "specs-lost",
+          quantity: 1,
+          identifierInputs: [
+            {
+              ...defaultIdentifier,
+              label: "first",
+              value: "AAA987654322",
+            },
+          ],
+          transactionTime: new Date(1596530356431),
+        },
+        {
+          category: "specs-lost",
+          quantity: 1,
+          identifierInputs: [
+            {
+              ...defaultIdentifier,
+              label: "first",
+              value: "AAA987654323",
+            },
+          ],
+          transactionTime: new Date(1596530356432),
+        },
+        {
+          category: "specs-lost",
+          quantity: -1,
+          identifierInputs: [
+            {
+              ...defaultIdentifier,
+              label: "first",
+              value: "AAA987654323",
+            },
+          ],
+          transactionTime: new Date(1596530356432),
         },
       ]);
       expect(result.current.loading).toStrictEqual(false);

--- a/src/hooks/usePastTransaction/usePastTransaction.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.tsx
@@ -19,7 +19,8 @@ export const usePastTransaction = (
   ids: string[],
   authKey: string,
   endpoint: string,
-  categories?: string[]
+  categories?: string[],
+  getAllTransactions = false
 ): PastTransactionHook => {
   const [pastTransactionsResult, setPastTransactionsResult] = useState<
     PastTransactionsResult["pastTransactions"] | null
@@ -37,7 +38,8 @@ export const usePastTransaction = (
           selectedIdType,
           authKey,
           endpoint,
-          categories
+          categories,
+          getAllTransactions
         );
         setPastTransactionsResult(pastTransactionsResponse?.pastTransactions);
       } catch (error) {
@@ -59,7 +61,15 @@ export const usePastTransaction = (
       setError(null);
       fetchPastTransactions();
     }
-  }, [authKey, endpoint, ids, categories, selectedIdType, prevIds]);
+  }, [
+    authKey,
+    endpoint,
+    ids,
+    categories,
+    getAllTransactions,
+    selectedIdType,
+    prevIds,
+  ]);
 
   return {
     pastTransactionsResult,

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -347,7 +347,8 @@ export const livePastTransactions = async (
   identificationFlag: IdentificationFlag,
   key: string,
   endpoint: string,
-  categories?: string[]
+  categories?: string[],
+  getAllTransactions = false
 ): Promise<PastTransactionsResult> => {
   let response;
   if (ids.length === 0) {
@@ -365,6 +366,7 @@ export const livePastTransactions = async (
         body: JSON.stringify({
           ids,
           identificationFlag,
+          getAllTransactions,
           categories,
         }),
       }

--- a/src/services/quota/quota.test.tsx
+++ b/src/services/quota/quota.test.tsx
@@ -446,6 +446,7 @@ describe("quota", () => {
           body: JSON.stringify({
             ids: ["S0000000J"],
             identificationFlag,
+            getAllTransactions: false,
             categories,
           }),
           headers: { Authorization: key },


### PR DESCRIPTION
[Notion link](notion-link-here) <!-- Remove this link if no relevant Notion link -->

This PR adds `getAllTransactions` flag to `usePastTransactions` in accordance to the updated BE `getGroupTransactions` function. Also, updates the affected unit tests
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
