### PR TITLE
fix: handle network errors when fetching campaign config

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -261,6 +261,11 @@ export const en: Translations = {
         "We are currently facing connectivity issues. Try restarting the app or contact Govtech if the problem persists.",
       primaryActionText: "Restart app",
     },
+    networkError: {
+      title: "Network error",
+      body: "You are offline. Try to connect and try again.",
+      primaryActionText: "Retry",
+    },
     wrongFormatCountryCode: {
       title: "Wrong format",
       body: "Enter a valid country code.",

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -271,6 +271,12 @@ export type Translations = {
       primaryActionText: string;
       secondaryActionText?: string;
     };
+    networkError: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+      secondaryActionText?: string;
+    };
     wrongFormatCountryCode: {
       title: string;
       body?: string;

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -254,6 +254,11 @@ export const zh: Translations = {
         "连接目前出现问题。请重启应用程序。如果问题持续出现，请联系政府科技局。",
       primaryActionText: "重启应用程序",
     },
+    networkError: {
+      title: "网络连接问题",
+      body: "您已断线。请尝试连接并重试。",
+      primaryActionText: "重试",
+    },
     wrongFormatCountryCode: {
       title: "格式错误",
       body: "请输入有效的国家代码。",

--- a/src/components/CampaignInitialisation/CampaignInitialisationScreen.tsx
+++ b/src/components/CampaignInitialisation/CampaignInitialisationScreen.tsx
@@ -113,7 +113,6 @@ export const CampaignInitialisationScreen: FunctionComponent<NavigationProps> = 
           navigation.navigate("CampaignLocationsScreen")
         );
       } else if (updateCampaignConfigError instanceof NetworkError) {
-        showErrorAlert(updateCampaignConfigError);
         throw updateCampaignConfigError;
       } else {
         throw updateCampaignConfigError; // Let ErrorBoundary handle

--- a/src/components/CampaignInitialisation/CampaignInitialisationScreen.tsx
+++ b/src/components/CampaignInitialisation/CampaignInitialisationScreen.tsx
@@ -19,7 +19,7 @@ import { AlertModalContext } from "../../context/alert";
 import { CampaignConfigsStoreContext } from "../../context/campaignConfigsStore";
 import * as config from "../../config";
 import { checkVersion } from "./utils";
-import { SessionError } from "../../services/helpers";
+import { NetworkError, SessionError } from "../../services/helpers";
 import { AuthStoreContext } from "../../context/authStore";
 import { IdentificationContext } from "../../context/identification";
 
@@ -112,6 +112,9 @@ export const CampaignInitialisationScreen: FunctionComponent<NavigationProps> = 
         showErrorAlert(updateCampaignConfigError, () =>
           navigation.navigate("CampaignLocationsScreen")
         );
+      } else if (updateCampaignConfigError instanceof NetworkError) {
+        showErrorAlert(updateCampaignConfigError);
+        throw updateCampaignConfigError;
       } else {
         throw updateCampaignConfigError; // Let ErrorBoundary handle
       }

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -2,14 +2,15 @@ import React, { Component, ReactNode } from "react";
 import { Sentry } from "../../utils/errorTracking";
 import { ErrorBoundaryContent } from "./ErrorBoundaryContent";
 import { formatDateTime } from "../../utils/dateTimeFormatter";
+import { camelCase } from "lodash";
 
-type State = { hasError: boolean; errorMessage?: string };
+type State = { hasError: boolean; errorName?: string };
 
 export class ErrorBoundary extends Component<unknown, State> {
   state: State = { hasError: false };
 
   static getDerivedStateFromError(error: Error): State {
-    return { hasError: true, errorMessage: error.name };
+    return { hasError: true, errorName: error.name };
   }
 
   componentDidCatch(error: Error): void {
@@ -21,11 +22,12 @@ export class ErrorBoundary extends Component<unknown, State> {
   }
 
   render(): ReactNode {
-    const error = `(${this.state.errorMessage} ${formatDateTime(Date.now())})`;
+    const error = `(${this.state.errorName} ${formatDateTime(Date.now())})`;
 
     return this.state.hasError ? (
       <ErrorBoundaryContent
-        error={this.state.errorMessage ? error : undefined}
+        error={this.state.errorName ? error : undefined}
+        errorName={this.state.errorName}
       />
     ) : (
       this.props.children

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -2,7 +2,6 @@ import React, { Component, ReactNode } from "react";
 import { Sentry } from "../../utils/errorTracking";
 import { ErrorBoundaryContent } from "./ErrorBoundaryContent";
 import { formatDateTime } from "../../utils/dateTimeFormatter";
-import { camelCase } from "lodash";
 
 type State = { hasError: boolean; errorName?: string };
 

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,7 +1,6 @@
 import React, { Component, ReactNode } from "react";
 import { Sentry } from "../../utils/errorTracking";
 import { ErrorBoundaryContent } from "./ErrorBoundaryContent";
-import { formatDateTime } from "../../utils/dateTimeFormatter";
 
 type State = { hasError: boolean; errorName?: string };
 
@@ -21,13 +20,8 @@ export class ErrorBoundary extends Component<unknown, State> {
   }
 
   render(): ReactNode {
-    const error = `(${this.state.errorName} ${formatDateTime(Date.now())})`;
-
     return this.state.hasError ? (
-      <ErrorBoundaryContent
-        error={this.state.errorName ? error : undefined}
-        errorName={this.state.errorName}
-      />
+      <ErrorBoundaryContent errorName={this.state.errorName} />
     ) : (
       this.props.children
     );

--- a/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
@@ -50,23 +50,45 @@ const styles = StyleSheet.create({
 
 export const ErrorBoundaryContent: FunctionComponent<{
   error?: string;
-}> = ({ error }) => {
+  errorName?: string;
+}> = ({ error, errorName }) => {
   const { i18nt } = useTranslate();
+
+  let header, body, restartButtonText;
+
+  switch (errorName) {
+    case "NetworkError": {
+      header = i18nt("errorMessages", "networkError", "title");
+      body = i18nt("errorMessages", "networkError", "body");
+      restartButtonText = i18nt(
+        "errorMessages",
+        "networkError",
+        "primaryActionText"
+      );
+      break;
+    }
+    default: {
+      header = i18nt("errorMessages", "systemError", "title");
+      body = i18nt("errorMessages", "systemError", "body");
+      restartButtonText = i18nt(
+        "errorMessages",
+        "systemError",
+        "primaryActionText"
+      );
+    }
+  }
+
   return (
     <View style={styles.wrapper}>
       <View style={styles.content}>
         <AlertIcon style={styles.icon} width={size(5)} height={size(5)} />
-        <AppText style={styles.heading}>
-          {i18nt("errorMessages", "systemError", "title")}
-        </AppText>
-        <AppText style={styles.body}>
-          {i18nt("errorMessages", "systemError", "body")}
-        </AppText>
+        <AppText style={styles.heading}>{header}</AppText>
+        <AppText style={styles.body}>{body}</AppText>
         {error && <AppText style={styles.errorDescription}>{error}</AppText>}
       </View>
       <View style={styles.restartButton}>
         <DarkButton
-          text={i18nt("errorMessages", "systemError", "primaryActionText")}
+          text={restartButtonText}
           onPress={() => Updates.reloadAsync()}
           fullWidth={true}
         />

--- a/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundaryContent.tsx
@@ -6,6 +6,7 @@ import * as Updates from "expo-updates";
 import { DarkButton } from "../Layout/Buttons/DarkButton";
 import AlertIcon from "../../../assets/icons/alert.svg";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
+import { formatDateTime } from "../../utils/dateTimeFormatter";
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -49,10 +50,13 @@ const styles = StyleSheet.create({
 });
 
 export const ErrorBoundaryContent: FunctionComponent<{
-  error?: string;
   errorName?: string;
-}> = ({ error, errorName }) => {
+}> = ({ errorName }) => {
   const { i18nt } = useTranslate();
+
+  const errorDescription = errorName
+    ? `(${errorName} ${formatDateTime(Date.now())})`
+    : undefined;
 
   let header, body, restartButtonText;
 
@@ -84,7 +88,9 @@ export const ErrorBoundaryContent: FunctionComponent<{
         <AlertIcon style={styles.icon} width={size(5)} height={size(5)} />
         <AppText style={styles.heading}>{header}</AppText>
         <AppText style={styles.body}>{body}</AppText>
-        {error && <AppText style={styles.errorDescription}>{error}</AppText>}
+        {errorDescription && (
+          <AppText style={styles.errorDescription}>{errorDescription}</AppText>
+        )}
       </View>
       <View style={styles.restartButton}>
         <DarkButton

--- a/src/services/campaignConfig/campaignConfig.ts
+++ b/src/services/campaignConfig/campaignConfig.ts
@@ -1,6 +1,11 @@
 import { IS_MOCK } from "../../config";
 import { CampaignConfig, ConfigHashes } from "../../types";
-import { fetchWithValidator, ValidationError, SessionError } from "../helpers";
+import {
+  fetchWithValidator,
+  ValidationError,
+  SessionError,
+  NetworkError,
+} from "../helpers";
 import { Sentry } from "../../utils/errorTracking";
 import i18n from "i18n-js";
 
@@ -35,6 +40,8 @@ const liveGetCampaignConfig = async (
     if (e instanceof ValidationError) {
       Sentry.captureException(e);
     } else if (e instanceof SessionError) {
+      throw e;
+    } else if (e instanceof NetworkError) {
       throw e;
     }
     throw new CampaignConfigError(e.message);

--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -16,12 +16,24 @@ export class SessionError extends Error {
   }
 }
 
+export class NetworkError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NetworkError";
+  }
+}
+
 export async function fetchWithValidator<T, O, I>(
   validator: Type<T, O, I>,
   requestInfo: RequestInfo,
   init?: RequestInit
 ): Promise<T> {
-  const response = await fetch(requestInfo, init);
+  let response: Response;
+  try {
+    response = await fetch(requestInfo, init);
+  } catch (e) {
+    throw new NetworkError(e.message);
+  }
 
   const json = await response.json();
   if (!response.ok) {

--- a/storybook/stories/ErrorBoundary/ErrorBoundary.tsx
+++ b/storybook/stories/ErrorBoundary/ErrorBoundary.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react-native";
 import { ErrorBoundaryContent } from "../../../src/components/ErrorBoundary/ErrorBoundaryContent";
-import { formatDateTime } from "../../../src/utils/dateTimeFormatter";
 
 storiesOf("ErrorBoundary", module).add("ErrorBoundary", () => (
-  <ErrorBoundaryContent error={`(LoginError ${formatDateTime(Date.now())})`} />
+  <ErrorBoundaryContent errorName={`LoginError`} />
 ));


### PR DESCRIPTION
[Notion link](https://www.notion.so/FE-App-opening-error-systemErrorConnectivityIssues-06a63d77c8c346a19f49755b22a1dc43) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->

- Added new error type `NetworkError`, which is thrown when `fetch` fails in `fetchWithValidator`.
- Added error handling for `NetworkError` when fetching campaign configuration.

Previously, if the device is offline, an error dialog will be shown to the user. Upon dismissal of the error dialog, the user will be met with a perpetual loading screen. 

This fix changes this behavior by allowing the `ErrorBoundary` to catch the errors above (i.e. network errors), and providing the user with a screen where they are able to restart the application if needed, or report the error. 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
