### PR TITLE
fix: add checks for empty array in hasNoQuota

### DIFF
--- a/src/hooks/useQuota/useQuota.test.tsx
+++ b/src/hooks/useQuota/useQuota.test.tsx
@@ -246,6 +246,12 @@ const mockQuotaResSingleIdWithAppealProducts: Quota = {
   ],
 };
 
+const mockQuotaResSingleIdEmptyQuota: Quota = {
+  remainingQuota: [],
+  globalQuota: [],
+  localQuota: [],
+};
+
 /**
  * This should be used alongside `defaultNonAppealProducts`,
  * which assumes that `toilet-paper` is a non-appeal product,
@@ -398,6 +404,22 @@ describe("useQuota", () => {
           quantity: 15,
         },
       ]);
+    });
+
+    it("should have quota state be NO_QUOTA when remainingQuota received contains an empty array", async () => {
+      expect.assertions(3);
+      mockGetQuota.mockReturnValueOnce(mockQuotaResSingleIdEmptyQuota);
+
+      const ids = ["ID1"];
+      const { result, waitForNextUpdate } = renderHook(
+        () => useQuota(ids, key, endpoint),
+        { wrapper }
+      );
+      expect(result.current.quotaState).toBe("FETCHING_QUOTA");
+
+      await waitForNextUpdate();
+      expect(result.current.quotaState).toBe("NO_QUOTA");
+      expect(result.current.quotaResponse?.remainingQuota).toStrictEqual([]);
     });
 
     it("should set quota state to NOT_ELIGIBLE when NotEligibleError is thrown, and does not update quota response", async () => {

--- a/src/hooks/useQuota/useQuota.tsx
+++ b/src/hooks/useQuota/useQuota.tsx
@@ -74,10 +74,7 @@ const filterQuotaWithAvailableProducts = (
  * @returns true if there is no quota, otherwise false.
  */
 const hasNoQuota = (quota: Quota): boolean => {
-  return (
-    quota.remainingQuota.length <= 0 ||
-    quota.remainingQuota.every((item) => item.quantity === 0)
-  );
+  return quota.remainingQuota.every((item) => item.quantity === 0);
 };
 
 const hasInvalidQuota = (quota: Quota): boolean => {

--- a/src/hooks/useQuota/useQuota.tsx
+++ b/src/hooks/useQuota/useQuota.tsx
@@ -63,8 +63,21 @@ const filterQuotaWithAvailableProducts = (
   return filteredQuota;
 };
 
+/**
+ * Determines if there is no quota from a Quota object.
+ *
+ * There is no quota if:
+ *  - The remaining quota does not contain any items, or
+ *  - The remaining quota contains items, and all of their quantities are 0.
+ *
+ * @param quota a Quota object
+ * @returns true if there is no quota, otherwise false.
+ */
 const hasNoQuota = (quota: Quota): boolean => {
-  return quota.remainingQuota.every((item) => item.quantity === 0);
+  return (
+    quota.remainingQuota.length <= 0 ||
+    quota.remainingQuota.every((item) => item.quantity === 0)
+  );
 };
 
 const hasInvalidQuota = (quota: Quota): boolean => {


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

- An additional check in `hasNoQuota` to check for empty whether `remainingQuota` is empty before running `every` on it, since it returns true if the array is empty.

### Notes 

Note that we want `hasNoQuota` to return true when `remainingQuota` is either:
- empty, or
- all of the items have zero quantities

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
