### PR TITLE
feat: create unique accessibility labels for each identifier

### DIFF
--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierPhoneNumberInput.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierPhoneNumberInput.tsx
@@ -61,7 +61,15 @@ export const IdentifierPhoneNumberInput: FunctionComponent<{
         mobileNumberValue={phoneNumber}
         onChangeCountryCode={setCountryCodeValue}
         onChangeMobileNumber={setPhoneNumber}
-        accessibilityLabel="item-field-phone-number"
+        accessibilityLabel={
+          label
+            ? label
+                .trim()
+                .replace(/\s/g, "-")
+                .toLowerCase()
+                .concat("-phone-number")
+            : "item-field-phone-number"
+        }
       />
     </View>
   );

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierTextInput.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierTextInput.tsx
@@ -26,7 +26,9 @@ export const IdentifierTextInput: FunctionComponent<{
       onChange={({ nativeEvent: { text } }) => onChange(text)}
       keyboardType={type === "NUMBER" ? "phone-pad" : "default"}
       accessibilityLabel={
-        label.trim().replaceAll(" ", "-").toLowerCase() + "-text"
+        label
+          ? label.trim().replaceAll(" ", "-").toLowerCase().concat("-text")
+          : "item-field-text"
       }
     />
   </View>

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierTextInput.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierTextInput.tsx
@@ -25,7 +25,9 @@ export const IdentifierTextInput: FunctionComponent<{
       editable={editable}
       onChange={({ nativeEvent: { text } }) => onChange(text)}
       keyboardType={type === "NUMBER" ? "phone-pad" : "default"}
-      accessibilityLabel="item-field-text"
+      accessibilityLabel={
+        label.trim().replaceAll(" ", "-").toLowerCase() + "-text"
+      }
     />
   </View>
 );

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierTextInput.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierTextInput.tsx
@@ -27,7 +27,7 @@ export const IdentifierTextInput: FunctionComponent<{
       keyboardType={type === "NUMBER" ? "phone-pad" : "default"}
       accessibilityLabel={
         label
-          ? label.trim().replace(" ", "-").toLowerCase().concat("-text")
+          ? label.trim().replace(/\s/g, "-").toLowerCase().concat("-text")
           : "item-field-text"
       }
     />

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierTextInput.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierTextInput.tsx
@@ -27,7 +27,7 @@ export const IdentifierTextInput: FunctionComponent<{
       keyboardType={type === "NUMBER" ? "phone-pad" : "default"}
       accessibilityLabel={
         label
-          ? label.trim().replaceAll(" ", "-").toLowerCase().concat("-text")
+          ? label.trim().replace(" ", "-").toLowerCase().concat("-text")
           : "item-field-text"
       }
     />


### PR DESCRIPTION
This PR uses label in accessibilityLabel for IdentifierTextInput and IdentifierPhoneNumberInput. This allows us to differentiate each identifierInput, as each of them will have a unique accessibilityLabel. This would help the e2e tests and reduce reliance on indexes and order of the identifiers.

Current behaviour:
- all text input type that is `PHONE_NUMBER` will have an accessibility label of `item-field-phone-number`
- all other text input type will have an accessibility label of `item-field-text`

New behaviour:
- for text input type with `PHONE_NUMBER`, if label is present, we will now format as `<label>-phone-number`. E.g. `Main Contact` will result in `main-contact-phone-number`
- for all other text input, we will now format as `<label>-text`. E.g. `Designation` will result in `designation-text`
- if label is not present, the above default values will be used isntead.


[Notion link](notion-link-here) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [ ] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)