### PR TITLE
feat: support barcode type 39 and 128

### DIFF
--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanModal.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanModal.tsx
@@ -16,15 +16,21 @@ export const IdentifierScanModal: FunctionComponent<{
     }
   };
 
-  let barcodeType = BarCodeScanner.Constants.BarCodeType.qr;
-  if (type === "CODE_128")
-    barcodeType = BarCodeScanner.Constants.BarCodeType.code128;
-  else if (type === "CODE_39")
-    barcodeType = BarCodeScanner.Constants.BarCodeType.code39;
-  // the idea is to drop the BARCODE type after we have updated this to prod
-  // without creating breaking changes, hence we currently support both types
-  else if (type === "BARCODE")
-    barcodeType = BarCodeScanner.Constants.BarCodeType.code39;
+  let barcodeType;
+  switch (type) {
+    case "CODE_128":
+      barcodeType = BarCodeScanner.Constants.BarCodeType.code128;
+      break;
+    // the idea is to drop the BARCODE type after we have updated this to prod
+    // without creating breaking changes, hence we currently support both types
+    case "CODE_39":
+    case "BARCODE":
+      barcodeType = BarCodeScanner.Constants.BarCodeType.code39;
+      break;
+    default:
+      barcodeType = BarCodeScanner.Constants.BarCodeType.qr;
+      break;
+  }
 
   return (
     <Modal

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanModal.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierScanModal.tsx
@@ -16,10 +16,15 @@ export const IdentifierScanModal: FunctionComponent<{
     }
   };
 
-  const barcodeType =
-    type === "BARCODE"
-      ? BarCodeScanner.Constants.BarCodeType.code39
-      : BarCodeScanner.Constants.BarCodeType.qr;
+  let barcodeType = BarCodeScanner.Constants.BarCodeType.qr;
+  if (type === "CODE_128")
+    barcodeType = BarCodeScanner.Constants.BarCodeType.code128;
+  else if (type === "CODE_39")
+    barcodeType = BarCodeScanner.Constants.BarCodeType.code39;
+  // the idea is to drop the BARCODE type after we have updated this to prod
+  // without creating breaking changes, hence we currently support both types
+  else if (type === "BARCODE")
+    barcodeType = BarCodeScanner.Constants.BarCodeType.code39;
 
   return (
     <Modal

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,12 @@ const TextInputType = t.union([
   t.literal("PAYMENT_RECEIPT"),
 ]);
 
-const ScanButtonType = t.union([t.literal("QR"), t.literal("BARCODE")]);
+const ScanButtonType = t.union([
+  t.literal("QR"),
+  t.literal("BARCODE"),
+  t.literal("CODE_128"),
+  t.literal("CODE_39"),
+]);
 
 const PolicyIdentifier = t.intersection([
   t.type({


### PR DESCRIPTION
Currently type BARCODE defaults to code_39. This PR introduces 2 new types code_39 and code_128 to make the barcode type more explicit.

[Notion link](https://www.notion.so/Update-policy-to-charge-lost-TT-Tokens-if-it-s-lost-for-a-2nd-time-Enter-Payment-receipt-number-28a3cb5dfdbc4e9e95a21a1b1490db0a) <!-- Remove this link if no relevant Notion link -->

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [ ] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow