### PR TITLE
chore: add chinese translations for labels

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -26,6 +26,9 @@ export const en: Translations = {
     or: "OR",
     enterIdNumber: "Enter ID Number",
     check: "Check",
+    goToStatistics: "Go to statistics",
+    nationalityInputLabel: "Nationality (non-Singaporean)",
+    passportInputLabel: "Passport number",
   },
   idScanner: {
     enterIdManually: "Enter ID manually",

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -23,6 +23,9 @@ export type Translations = {
     or: string;
     enterIdNumber: string;
     check: string;
+    goToStatistics: string;
+    nationalityInputLabel: string;
+    passportInputLabel: string;
   };
   idScanner: {
     enterIdManually: string;

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -25,6 +25,9 @@ export const zh: Translations = {
     or: "或",
     enterIdNumber: "输入证件号码",
     check: "查看",
+    goToStatistics: "前往统计",
+    nationalityInputLabel: "国籍 (非新加坡人)",
+    passportInputLabel: "护照号码",
   },
   idScanner: {
     enterIdManually: "输入证件号码",

--- a/src/components/CustomerAppeal/ReasonSelection/ReasonItem.tsx
+++ b/src/components/CustomerAppeal/ReasonSelection/ReasonItem.tsx
@@ -40,7 +40,11 @@ export const ReasonItem: FunctionComponent<{
     >
       <View style={styles.reasonLayout}>
         <AppText>{c13nt(description)}</AppText>
-        <AppText style={styles.reasonAlert}>{descriptionAlert ?? ""}</AppText>
+        <AppText style={styles.reasonAlert}>
+          {descriptionAlert
+            ? c13nt(descriptionAlert, undefined, descriptionAlert)
+            : ""}
+        </AppText>
       </View>
     </TouchableOpacity>
   );

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -293,7 +293,7 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
               testID="go-to-statistics"
               accessible={true}
             >
-              Go to statistics
+              {i18nt("collectCustomerDetailsScreen", "goToStatistics")}
             </AppText>
           </TouchableOpacity>
           <FeatureToggler feature="HELP_MODAL">

--- a/src/components/CustomerDetails/ManualPassportInput.tsx
+++ b/src/components/CustomerDetails/ManualPassportInput.tsx
@@ -55,7 +55,10 @@ export const ManualPassportInput: FunctionComponent<ManualPassportInput> = ({
       <View style={styles.inputAndButtonWrapper}>
         <View style={styles.inputWrapper}>
           <DropdownFilterInput
-            label="Nationality (non-Singaporean)"
+            label={i18nt(
+              "collectCustomerDetailsScreen",
+              "nationalityInputLabel"
+            )}
             placeholder="Search country"
             value={selectedCountry?.name}
             dropdownItems={nationalityItems}
@@ -66,7 +69,7 @@ export const ManualPassportInput: FunctionComponent<ManualPassportInput> = ({
       <View style={styles.inputAndButtonWrapper}>
         <View style={styles.inputWrapper}>
           <InputWithLabel
-            label="Passport number"
+            label={i18nt("collectCustomerDetailsScreen", "passportInputLabel")}
             value={passportNum ? passportNum : undefined}
             onChange={({ nativeEvent: { text } }) => setPassportNum(text)}
             onSubmitEditing={submitId}


### PR DESCRIPTION
[Notion link](https://www.notion.so/Chinese-translation-for-labels-Go-to-Statistics-Chargeable-Nationality-and-Passport-number-8078778d817e44f0bfa1029be3e50d6a) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- new i18nt
  - `collectCustomerDetailsScreen.goToStatistics`
  - `collectCustomerDetailsScreen.nationalityInputLabel`
  - `collectCustomerDetailsScreen.passportInputLabel`
- new c13nt for campaign specific description alert.
  - *chargeable

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [x] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [x] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
