### PR TITLE
feat: toggle endpoints versions using feature flag

### DIFF
--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -9,6 +9,7 @@ import { ProductContext, ProductContextValue } from "../../context/products";
 import { usePrevious } from "../usePrevious";
 import { hasInvalidRemainingQuota } from "../useQuota/useQuota";
 import { DescriptionAlertTypes } from "../../components/CustomerQuota/ItemsSelection/ShowAddonsToggle";
+import { CampaignConfigContext } from "../../context/campaignConfig";
 
 export type CartItem = {
   category: string;
@@ -125,7 +126,7 @@ export const useCart = (
   const prevProducts = usePrevious(products);
   const prevIds = usePrevious(ids);
   const prevCartQuota = usePrevious(cartQuota);
-
+  const { features } = useContext(CampaignConfigContext);
   /**
    * Update the cart when:
    *  1. An incoming cart quota exists, AND
@@ -237,6 +238,7 @@ export const useCart = (
           key: authKey,
           transactions,
           endpoint,
+          apiVersion: features?.apiVersion,
         });
         setCheckoutResult(transactionResponse);
         setCartState("PURCHASED");
@@ -266,7 +268,7 @@ export const useCart = (
     };
 
     checkout();
-  }, [authKey, cart, endpoint, ids, selectedIdType]);
+  }, [authKey, cart, endpoint, ids, selectedIdType, features?.apiVersion]);
 
   return {
     cartState,

--- a/src/hooks/usePastTransaction/usePastTransaction.tsx
+++ b/src/hooks/usePastTransaction/usePastTransaction.tsx
@@ -9,6 +9,7 @@ import {
 import { Sentry } from "../../utils/errorTracking";
 import { ERROR_MESSAGE } from "../../context/alert";
 import { IdentificationContext } from "../../context/identification";
+import { CampaignConfigContext } from "../../context/campaignConfig";
 
 export type PastTransactionHook = {
   pastTransactionsResult: PastTransactionsResult["pastTransactions"] | null;
@@ -31,6 +32,7 @@ export const usePastTransaction = (
   const [error, setError] = useState<PastTransactionError | null>(null);
   const prevIds = usePrevious(ids);
   const { selectedIdType } = useContext(IdentificationContext);
+  const { features } = useContext(CampaignConfigContext);
 
   useEffect(() => {
     const fetchPastTransactions = async (): Promise<void> => {
@@ -47,7 +49,8 @@ export const usePastTransaction = (
           authKey,
           endpoint,
           categories,
-          getAllTransactions
+          getAllTransactions,
+          features?.apiVersion
         );
         if (isMounted()) {
           setPastTransactionsResult(pastTransactionsResponse?.pastTransactions);
@@ -78,6 +81,7 @@ export const usePastTransaction = (
     selectedIdType,
     prevIds,
     isMounted,
+    features?.apiVersion,
   ]);
 
   return {

--- a/src/hooks/useQuota/useQuota.tsx
+++ b/src/hooks/useQuota/useQuota.tsx
@@ -6,6 +6,7 @@ import { transform } from "lodash";
 import { Quota, CampaignPolicy, ItemQuota } from "../../types";
 import { usePrevious } from "../usePrevious";
 import { IdentificationContext } from "../../context/identification";
+import { CampaignConfigContext } from "../../context/campaignConfig";
 
 type QuotaState = "DEFAULT" | "FETCHING_QUOTA" | "NO_QUOTA" | "NOT_ELIGIBLE";
 
@@ -110,12 +111,19 @@ export const useQuota = (
   const { products } = useContext(ProductContext);
   const prevIds = usePrevious(ids);
   const prevProducts = usePrevious(products);
+  const { features } = useContext(CampaignConfigContext);
 
   const updateQuota: QuotaHook["updateQuota"] = useCallback(() => {
     const update = async (): Promise<void> => {
       try {
         setQuotaState("FETCHING_QUOTA");
-        const quota = await getQuota(ids, selectedIdType, authKey, endpoint);
+        const quota = await getQuota(
+          ids,
+          selectedIdType,
+          authKey,
+          endpoint,
+          features?.apiVersion
+        );
         const filteredQuotas = filterQuotaWithAvailableProducts(
           quota,
           products
@@ -145,7 +153,15 @@ export const useQuota = (
       }
     };
     update();
-  }, [ids, authKey, endpoint, products, quotaResponse, selectedIdType]);
+  }, [
+    ids,
+    authKey,
+    endpoint,
+    products,
+    quotaResponse,
+    selectedIdType,
+    features?.apiVersion,
+  ]);
 
   /**
    * Update the quota whenever the ids or products change

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -43,6 +43,7 @@ interface PostTransaction {
   transactions: Transaction[];
   key: string;
   endpoint: string;
+  apiVersion?: string;
 }
 
 export const mockGetQuota = async (
@@ -195,14 +196,18 @@ export const liveGetQuota = async (
   ids: string[],
   identificationFlag: IdentificationFlag,
   key: string,
-  endpoint: string
+  endpoint: string,
+  apiVersion?: string
 ): Promise<Quota> => {
   let response;
   if (ids.length === 0) {
     throw new QuotaError("No ID was provided");
   }
+  // format version with forward slash, to be added into endpoint, i.e. /v1, v2
+  const version = apiVersion ? `/${apiVersion}` : "";
+
   try {
-    response = await fetchWithValidator(Quota, `${endpoint}/quota`, {
+    response = await fetchWithValidator(Quota, `${endpoint}${version}/quota`, {
       method: "POST",
       headers: {
         Authorization: key,
@@ -274,14 +279,18 @@ export const livePostTransaction = async ({
   endpoint,
   key,
   transactions,
+  apiVersion,
 }: PostTransaction): Promise<PostTransactionResult> => {
   if (ids.length === 0) {
     throw new PostTransactionError("No ID was provided");
   }
+  // format version with forward slash, to be added into endpoint, i.e. /v1
+  const version = apiVersion ? `/${apiVersion}` : "";
+
   try {
     const response = await fetchWithValidator(
       PostTransactionResult,
-      `${endpoint}/transactions`,
+      `${endpoint}${version}/transactions`,
       {
         method: "POST",
         headers: {
@@ -348,16 +357,20 @@ export const livePastTransactions = async (
   key: string,
   endpoint: string,
   categories?: string[],
-  getAllTransactions = false
+  getAllTransactions = false,
+  apiVersion?: string
 ): Promise<PastTransactionsResult> => {
   let response;
   if (ids.length === 0) {
     throw new PastTransactionError("No ID was provided");
   }
+  // format version with forward slash, to be added into endpoint, i.e. /v1
+  const version = apiVersion ? `/${apiVersion}` : "";
+
   try {
     response = await fetchWithValidator(
       PastTransactionsResult,
-      `${endpoint}/transactions/history`,
+      `${endpoint}${version}/transactions/history`,
       {
         method: "POST",
         headers: {

--- a/src/services/quota/quota.test.tsx
+++ b/src/services/quota/quota.test.tsx
@@ -150,7 +150,7 @@ const mockGetQuotaResponseMultipleId = {
 const postTransactionParams = {
   ids: ["S0000000J"],
   identificationFlag,
-  transactions: [{ category: "product-1", quantity: 1, identifiers: [] }],
+  transactions: [{ category: "product-1", quantity: 2, identifiers: [] }],
   key,
   endpoint,
 };
@@ -219,6 +219,22 @@ describe("quota", () => {
         identificationFlag,
         key,
         endpoint
+      );
+      expect(quota).toEqual(mockGetQuotaResultSingleId);
+    });
+
+    it("should return the quota of an ID if version is passed in", async () => {
+      expect.assertions(1);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockGetQuotaResponseSingleId),
+      });
+      const quota = await getQuota(
+        ["S0000000J"],
+        identificationFlag,
+        key,
+        endpoint,
+        "v2" // version from features
       );
       expect(quota).toEqual(mockGetQuotaResultSingleId);
     });
@@ -314,6 +330,19 @@ describe("quota", () => {
       expect(result).toEqual(mockPostTransactionResult);
     });
 
+    it("should return the correct success result even with additional version param", async () => {
+      expect.assertions(1);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockPostTransactionResponse),
+      });
+      const result = await postTransaction({
+        ...postTransactionParams,
+        apiVersion: "v2",
+      });
+      expect(result).toEqual(mockPostTransactionResult);
+    });
+
     it("should throw error if no ID was provided", async () => {
       expect.assertions(1);
       mockFetch.mockResolvedValueOnce({
@@ -391,6 +420,24 @@ describe("quota", () => {
         identificationFlag,
         key,
         endpoint
+      );
+      expect(pastTransactionsResult).toEqual(mockPastTransactionsResult);
+    });
+
+    it("should return past transactions with additional version param", async () => {
+      expect.assertions(1);
+      mockFetch.mockReturnValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockPastTransactionsResponse),
+      });
+      const pastTransactionsResult = await getPastTransactions(
+        ["S0000000J"],
+        identificationFlag,
+        key,
+        endpoint,
+        [],
+        false,
+        "v2"
       );
       expect(pastTransactionsResult).toEqual(mockPastTransactionsResult);
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,6 +162,7 @@ const CampaignFeatures = t.intersection([
   }),
   t.partial({
     alternateIds: t.array(IdentificationFlag),
+    apiVersion: t.union([t.literal("v1"), t.literal("v2")]),
   }),
 ]);
 


### PR DESCRIPTION
[Notion link](https://www.notion.so/FE-path-toggling-for-mobile-application-502f314239cc4effb72d7134f4bd0975) <!-- Remove this link if no relevant Notion link -->

This PR adds a new feature flag `apiVersion` that is used to perform toggling between different version of endpoints on our app.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
