### PR TITLE
chore(deps): update react native webview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19870,9 +19870,9 @@
       "dev": true
     },
     "react-native-webview": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-10.9.0.tgz",
-      "integrity": "sha512-zYZfmdJca/xRbwvvOfPhzL59SQC4L0W9rPWVF4zMi7BMDdCVHXVp0wKZ9KzmqxZNwadZNTxl5s0pvd6p3S34Fg==",
+      "version": "11.4.3",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-11.4.3.tgz",
+      "integrity": "sha512-bC6r7vbukC1QYbG2vTmif8/gt6jzlGA7WK7zeVLt8ysZJvBNtoHtT2k7EoMgJIW6/6DTy1rrn6uZS4v2Fa4exQ==",
       "requires": {
         "escape-string-regexp": "2.0.0",
         "invariant": "2.2.4"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-native-reanimated": "~1.9.0",
     "react-native-screens": "~2.9.0",
     "react-native-svg": "12.1.0",
-    "react-native-webview": "^10.9.0",
+    "react-native-webview": "^11.4.3",
     "react-navigation": "^4.1.0",
     "react-navigation-drawer": "^2.5.0",
     "react-navigation-stack": "^1.10.3",


### PR DESCRIPTION
The Snyk PR has issues with our CI. This PR also updates `react-native-webview` to the very latest.

Have tested the HelpModal, works fine!

| | |
|--|--|
|![image](https://user-images.githubusercontent.com/577802/116640704-c1b8b780-a99d-11eb-853a-2f9977122c26.png)|![image](https://user-images.githubusercontent.com/577802/116640711-c4b3a800-a99d-11eb-8abf-3875a23c71b6.png)|
