### PR TITLE
chore(deps): bump y18n from 4.0.0 to 4.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22540,9 +22540,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "yallist": {
       "version": "2.1.2",


### PR DESCRIPTION
This PR bumps the version of y18n from 4.0.0 to 4.0.3. For more info: https://npmjs.com/advisories/1654

After bump:
```
$ npm ls y18n
├─┬ jest@26.6.3
│ ├─┬ @jest/core@26.6.3
│ │ └─┬ jest-runtime@26.6.3
│ │   └─┬ yargs@15.4.1
│ │     └── y18n@4.0.3  deduped
│ └─┬ jest-cli@26.6.3
│   └─┬ yargs@15.4.1
│     └── y18n@4.0.3 
├─┬ jest-expo@40.0.2
│ └─┬ jest@25.5.4
│   └─┬ jest-cli@25.5.4
│     └─┬ yargs@15.4.1
│       └── y18n@4.0.3  deduped
├─┬ react-native@0.62.2
│ ├─┬ @react-native-community/cli@4.10.1
│ │ └─┬ metro@0.58.0
│ │   ├─┬ metro-inspector-proxy@0.58.0
│ │   │ └─┬ yargs@14.2.3
│ │   │   └── y18n@4.0.3  deduped
│ │   └─┬ yargs@14.2.3
│ │     └── y18n@4.0.3  deduped
│ └─┬ @react-native-community/cli-platform-android@4.7.0
│   └─┬ logkitty@0.6.1
│     └─┬ yargs@12.0.5
│       └── y18n@4.0.3  deduped
└─┬ react-native-qrcode-svg@6.0.6
  └─┬ qrcode@1.4.4
    └─┬ yargs@13.3.2
      └── y18n@4.0.3  deduped
```

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [ ] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
