### PR TITLE
refactor: format the string input before passing to onCheck for manual

### DIFF
--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -250,7 +250,13 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
         scannerType={selectedIdType.scannerType}
         openCamera={() => setShouldShowCamera(true)}
         setIdInput={setIdInput}
-        submitId={() => onCheck(idInput)}
+        /**
+         * When using the manual input, `idInput` is a string, unlike the JSON format
+         * done when scanning the QR.
+         *
+         * Thus, we need to reformat the `idInput` before passing to `onCheck`
+         */
+        submitId={() => onCheck(`{"passportId": "${idInput}"}`)}
       />
     ) : (
       <InputIdSection

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -254,7 +254,8 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
          * When using the manual input, `idInput` is a string, unlike the JSON format
          * done when scanning the QR.
          *
-         * Thus, we need to reformat the `idInput` before passing to `onCheck`
+         * Thus, we need to reformat the manual `idInput`
+         * before passing to `onCheck`
          */
         submitId={() => onCheck(`{"passportId": "${idInput}"}`)}
       />

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -172,35 +172,7 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
     );
   }, [selectionArray, selectedIdType, setSelectedIdType]);
 
-  const setState = useState()[1];
   const onCheck = async (input: string): Promise<void> => {
-    /**
-     * If "Passport" tab is chosen, we want to extract the passport
-     * number from a JSON object containing the `passportId`.
-     */
-    if (selectedIdType.label === "Passport") {
-      let passportId;
-      try {
-        ({ passportId } = JSON.parse(input));
-      } catch (e) {
-        /**
-         * If we encounter any JSON errors, we set `passportId` to empty
-         * in order to allow logic below to handle it as an empty/invalid ID.
-         *
-         * However, any other errors will trigger the ErrorBoundary.
-         */
-        if (e instanceof SyntaxError) {
-          passportId = "";
-        } else {
-          setState(() => {
-            throw e;
-          });
-        }
-      } finally {
-        input = passportId;
-      }
-    }
-
     try {
       setIsScanningEnabled(false);
       if (!features) {
@@ -229,8 +201,35 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
     }
   };
 
+  const setState = useState()[1];
   const onBarCodeScanned: BarCodeScannedCallback = (event) => {
     if (isFocused && isScanningEnabled && event.data) {
+      /**
+       * If "Passport" tab is chosen, we want to extract the passport
+       * number from a JSON object containing the `passportId`.
+       */
+      if (selectedIdType.label === "Passport") {
+        let passportId;
+        try {
+          ({ passportId } = JSON.parse(event.data));
+        } catch (e) {
+          /**
+           * If we encounter any JSON errors, we set `passportId` to empty
+           * in order to allow logic below to handle it as an empty/invalid ID.
+           *
+           * However, any other errors will trigger the ErrorBoundary.
+           */
+          if (e instanceof SyntaxError) {
+            passportId = "";
+          } else {
+            setState(() => {
+              throw e;
+            });
+          }
+        } finally {
+          event.data = passportId;
+        }
+      }
       onCheck(event.data);
     }
   };
@@ -250,14 +249,7 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
         scannerType={selectedIdType.scannerType}
         openCamera={() => setShouldShowCamera(true)}
         setIdInput={setIdInput}
-        /**
-         * When using the manual input, `idInput` is a string, unlike the JSON format
-         * done when scanning the QR.
-         *
-         * Thus, we need to reformat the manual `idInput`
-         * before passing to `onCheck`
-         */
-        submitId={() => onCheck(`{"passportId": "${idInput}"}`)}
+        submitId={() => onCheck(idInput)}
       />
     ) : (
       <InputIdSection


### PR DESCRIPTION
[Notion link](notion-link-here) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- reformat passport manual input

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
