### PR TITLE
feat: extract passport id from event

### DIFF
--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -47,6 +47,7 @@ import {
   defaultSelectedIdType,
 } from "../../context/identification";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
+import { extractPassportIdFromEvent } from "../../utils/passportScanning";
 
 const styles = StyleSheet.create({
   content: {
@@ -209,25 +210,12 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
        * number from a JSON object containing the `passportId`.
        */
       if (selectedIdType.label === "Passport") {
-        let passportId;
         try {
-          ({ passportId } = JSON.parse(event.data));
+          event.data = extractPassportIdFromEvent(event);
         } catch (e) {
-          /**
-           * If we encounter any JSON errors, we set `passportId` to empty
-           * in order to allow logic below to handle it as an empty/invalid ID.
-           *
-           * However, any other errors will trigger the ErrorBoundary.
-           */
-          if (e instanceof SyntaxError) {
-            passportId = "";
-          } else {
-            setState(() => {
-              throw e;
-            });
-          }
-        } finally {
-          event.data = passportId ?? "";
+          setState(() => {
+            throw e;
+          });
         }
       }
       onCheck(event.data);

--- a/src/utils/passportScanning.test.ts
+++ b/src/utils/passportScanning.test.ts
@@ -1,0 +1,111 @@
+import { extractPassportIdFromEvent } from "./passportScanning";
+
+describe("passportScanning", () => {
+  let event: any;
+
+  describe("extractPassportIdFromEvent", () => {
+    it("should return passportID if data is a valid JSON, and contains passportId", () => {
+      event = {
+        data: JSON.stringify({
+          passportId: "ABC-12345",
+        }),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("ABC-12345");
+    });
+
+    it("should return empty string if data is a valid JSON, but does not contain passportId", () => {
+      event = {
+        data: JSON.stringify({}),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+
+      event = {
+        data: JSON.stringify({
+          passportId: null,
+        }),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+
+      event = {
+        data: JSON.stringify({
+          passportId: true,
+        }),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+
+      event = {
+        data: JSON.stringify({
+          passportId: 123456,
+        }),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+
+      event = {
+        data: JSON.stringify({
+          passportId: [],
+        }),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+
+      event = {
+        data: JSON.stringify({
+          passportId: {},
+        }),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+
+      event = {
+        data: JSON.stringify({
+          passportId: undefined,
+        }),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+    });
+
+    it("should return empty string if data is an invalid JSON string", () => {
+      event = {
+        data: JSON.stringify(null),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+
+      event = {
+        data: JSON.stringify(true),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+
+      event = {
+        data: JSON.stringify(123456),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+
+      event = {
+        data: JSON.stringify("123456"),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+
+      event = {
+        data: JSON.stringify([]),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+
+      event = {
+        data: JSON.stringify(undefined),
+      };
+
+      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+    });
+  });
+});

--- a/src/utils/passportScanning.test.ts
+++ b/src/utils/passportScanning.test.ts
@@ -123,15 +123,6 @@ describe("passportScanning", () => {
           expect(extractPassportIdFromEvent(event)).toStrictEqual("");
         });
 
-        it("should return empty string if data is object", () => {
-          expect.assertions(1);
-          event = {
-            data: JSON.stringify({}),
-          };
-
-          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
-        });
-
         it("should return empty string if data is undefined", () => {
           expect.assertions(1);
           event = {

--- a/src/utils/passportScanning.test.ts
+++ b/src/utils/passportScanning.test.ts
@@ -4,108 +4,143 @@ describe("passportScanning", () => {
   let event: any;
 
   describe("extractPassportIdFromEvent", () => {
-    it("should return passportID if data is a valid JSON, and contains passportId", () => {
-      event = {
-        data: JSON.stringify({
-          passportId: "ABC-12345",
-        }),
-      };
+    describe("cases with valid event data", () => {
+      it("should return passportID", () => {
+        expect.assertions(1);
 
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("ABC-12345");
+        event = {
+          data: JSON.stringify({
+            passportId: "ABC-12345",
+          }),
+        };
+
+        expect(extractPassportIdFromEvent(event)).toStrictEqual("ABC-12345");
+      });
     });
 
-    it("should return empty string if data is a valid JSON, but does not contain passportId", () => {
-      event = {
-        data: JSON.stringify({}),
-      };
+    describe("cases with invalid event data", () => {
+      describe("cases with passportId of invalid types", () => {
+        it("should return empty string if passportId is null", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify({
+              passportId: null,
+            }),
+          };
 
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
 
-      event = {
-        data: JSON.stringify({
-          passportId: null,
-        }),
-      };
+        it("should return empty string if passportId is boolean", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify({
+              passportId: true,
+            }),
+          };
 
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
 
-      event = {
-        data: JSON.stringify({
-          passportId: true,
-        }),
-      };
+        it("should return empty string if passportId is number", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify({
+              passportId: 123456789,
+            }),
+          };
 
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
 
-      event = {
-        data: JSON.stringify({
-          passportId: 123456,
-        }),
-      };
+        it("should return empty string if passportId is array", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify({
+              passportId: [],
+            }),
+          };
 
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
 
-      event = {
-        data: JSON.stringify({
-          passportId: [],
-        }),
-      };
+        it("should return empty string if passportId is object", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify({
+              passportId: {},
+            }),
+          };
 
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
 
-      event = {
-        data: JSON.stringify({
-          passportId: {},
-        }),
-      };
+        it("should return empty string if passportId is undefined", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify({
+              passportId: undefined,
+            }),
+          };
 
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
+      });
 
-      event = {
-        data: JSON.stringify({
-          passportId: undefined,
-        }),
-      };
+      describe("cases without passportId", () => {
+        it("should return empty string if it does not contain passportId", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify({}),
+          };
 
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
-    });
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
+        it("should return empty string if data is boolean", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify(true),
+          };
 
-    it("should return empty string if data is an invalid JSON string", () => {
-      event = {
-        data: JSON.stringify(null),
-      };
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
 
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        it("should return empty string if data is number", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify(123456789),
+          };
 
-      event = {
-        data: JSON.stringify(true),
-      };
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
 
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        it("should return empty string if data is array", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify([]),
+          };
 
-      event = {
-        data: JSON.stringify(123456),
-      };
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
 
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        it("should return empty string if data is object", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify({}),
+          };
 
-      event = {
-        data: JSON.stringify("123456"),
-      };
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
 
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        it("should return empty string if data is undefined", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify(undefined),
+          };
 
-      event = {
-        data: JSON.stringify([]),
-      };
-
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
-
-      event = {
-        data: JSON.stringify(undefined),
-      };
-
-      expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
+      });
     });
   });
 });

--- a/src/utils/passportScanning.ts
+++ b/src/utils/passportScanning.ts
@@ -1,0 +1,23 @@
+import { BarCodeEvent } from "expo-barcode-scanner";
+
+export const extractPassportIdFromEvent = (event: BarCodeEvent) => {
+  let passportId;
+  try {
+    ({ passportId } = JSON.parse(event.data));
+  } catch (e) {
+    /**
+     * If we encounter any JSON errors, we set `passportId` to empty
+     * in order to allow logic below to handle it as an empty/invalid ID.
+     *
+     * However, any other errors will trigger the ErrorBoundary.
+     */
+    if (e instanceof SyntaxError) {
+      return "";
+    } else {
+      throw e;
+    }
+  } finally {
+    // TODO: Replace this with `io-ts`
+    return typeof passportId !== "string" ? "" : passportId;
+  }
+};

--- a/src/utils/passportScanning.ts
+++ b/src/utils/passportScanning.ts
@@ -1,6 +1,6 @@
 import { BarCodeEvent } from "expo-barcode-scanner";
 
-export const extractPassportIdFromEvent = (event: BarCodeEvent) => {
+export const extractPassportIdFromEvent = (event: BarCodeEvent): string => {
   let passportId;
   try {
     ({ passportId } = JSON.parse(event.data));
@@ -16,8 +16,7 @@ export const extractPassportIdFromEvent = (event: BarCodeEvent) => {
     } else {
       throw e;
     }
-  } finally {
-    // TODO: Replace this with `io-ts`
-    return typeof passportId !== "string" ? "" : passportId;
   }
+  // TODO: Enforce passportId type with io-ts
+  return typeof passportId !== "string" ? "" : passportId;
 };


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->

- add function to extract passport id from event
- add tests for different JSON strings
- add tests for different strings


<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
