### PR TITLE
feat: handle missing disbursements resulting in empty quota

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -354,6 +354,12 @@ export const en: Translations = {
       body: "Invalid quantity",
       primaryActionText: "OK",
     },
+    missingDisbursements: {
+      title: "System error",
+      body:
+        "Eligible identity does not have quota. Contact your in-charge to resolve this issue.",
+      primaryActionText: "OK",
+    },
     categoryDoesNotExist: {
       title: "Error",
       body: "Category does not exist",

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -381,6 +381,12 @@ export type Translations = {
       primaryActionText: string;
       secondaryActionText?: string;
     };
+    missingDisbursements: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+      secondaryActionText?: string;
+    };
     categoryDoesNotExist: {
       title: string;
       body?: string;

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -347,6 +347,11 @@ export const zh: Translations = {
       body: "数量无效",
       primaryActionText: "确定",
     },
+    missingDisbursements: {
+      title: "系统错误",
+      body: "符合资格的身份没有配额。请与您的负责人联系以解决此问题。",
+      primaryActionText: "确定",
+    },
     categoryDoesNotExist: {
       title: "错误",
       body: "找不到物品类别",

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -220,6 +220,7 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
             break;
           case ERROR_MESSAGE.INVALID_QUANTITY:
           case ERROR_MESSAGE.MISSING_SELECTION:
+          case ERROR_MESSAGE.MISSING_DISBURSEMENTS:
             showErrorAlert(cartError, () => clearCartError());
             break;
           default:

--- a/src/components/CustomerQuota/NotEligibleCard.tsx
+++ b/src/components/CustomerQuota/NotEligibleCard.tsx
@@ -36,7 +36,7 @@ interface NotEligibleCard {
 }
 
 /**
- * Shows when the user cannot is not eligible for redemption/purchase
+ * This card is shown when the user is not eligible for redemption/purchase
  */
 export const NotEligibleCard: FunctionComponent<NotEligibleCard> = ({
   ids,

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -58,6 +58,7 @@ export enum ERROR_MESSAGE {
   VALIDATE_INPUT_REGEX_ERROR = "Please check that the ID is in the correct format",
   INVALID_MERCHANT_CODE = "Invalid merchant code",
   INVALID_EMAIL_ADDRESS = "Enter valid email address",
+  MISSING_DISBURSEMENTS = "Eligible identity does not have quota. Contact your in-charge to resolve this issue.",
 }
 
 const errorNameToTranslationKeyMappings: Record<string, string> = {
@@ -123,6 +124,7 @@ const messageToTranslationKeyMappings: Record<string, string> = {
   [ERROR_MESSAGE.VALIDATE_INPUT_REGEX_ERROR]: "checkIdFormat",
   [ERROR_MESSAGE.INVALID_MERCHANT_CODE]: "invalidMerchantCode",
   [ERROR_MESSAGE.INVALID_EMAIL_ADDRESS]: "wrongFormatEmailAddress",
+  [ERROR_MESSAGE.MISSING_DISBURSEMENTS]: "missingDisbursements",
   [CONFIRMATION_MESSAGE.PAYMENT_COLLECTION]:
     CONFIRMATION_MESSAGE.PAYMENT_COLLECTION,
   [CONFIRMATION_MESSAGE.CONFIRM_LOGOUT]: CONFIRMATION_MESSAGE.CONFIRM_LOGOUT,

--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -5,10 +5,13 @@ import { waitFor } from "@testing-library/react-native";
 import { Quota, PostTransactionResult, CampaignPolicy } from "../../types";
 import { postTransaction } from "../../services/quota";
 import {
+  defaultFeatures,
   defaultProducts,
   defaultIdentifier,
 } from "../../test/helpers/defaults";
 import { ProductContextProvider } from "../../context/products";
+import { CampaignConfigContextProvider } from "../../context/campaignConfig";
+import { CampaignConfigsStoreContextProvider } from "../../context/campaignConfigsStore";
 import { ERROR_MESSAGE } from "../../context/alert";
 
 jest.mock("../../services/quota");
@@ -315,6 +318,43 @@ describe("useCart", () => {
       );
       expect(result.current.cartError?.message).toBe(
         ERROR_MESSAGE.INVALID_QUANTITY
+      );
+    });
+
+    it("should throw cartError (missingDisbursements) when quota response has empty quantities", () => {
+      expect.assertions(1);
+      const MissingDisbursementsWrapper: FunctionComponent = ({ children }) => (
+        <CampaignConfigsStoreContextProvider>
+          <CampaignConfigContextProvider
+            campaignConfig={{
+              features: {
+                ...defaultFeatures,
+                apiVersion: "v2",
+                campaignName: "Some Campaign Name",
+              },
+              policies: [defaultProducts[0]],
+              c13n: {},
+            }}
+          >
+            <ProductContextProvider products={defaultProducts}>
+              {children}
+            </ProductContextProvider>
+          </CampaignConfigContextProvider>
+        </CampaignConfigsStoreContextProvider>
+      );
+
+      const ids = ["ID1"];
+
+      const { result } = renderHook(
+        () =>
+          useCart(ids, key, endpoint, mockQuotaResEmptyQuota.remainingQuota),
+        {
+          wrapper: MissingDisbursementsWrapper,
+        }
+      );
+
+      expect(result.current.cartError?.message).toBe(
+        ERROR_MESSAGE.MISSING_DISBURSEMENTS
       );
     });
 

--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -210,6 +210,12 @@ const defaultProductsIdentifierInputsForCart = [
   },
 ];
 
+const mockQuotaResEmptyQuota: Quota = {
+  remainingQuota: [],
+  globalQuota: [],
+  localQuota: [],
+};
+
 const wrapper: FunctionComponent<{ products?: CampaignPolicy[] }> = ({
   children,
   products = defaultProducts,
@@ -288,6 +294,21 @@ describe("useCart", () => {
             endpoint,
             mockQuotaResSingleIdInvalidQuota.remainingQuota
           ),
+        {
+          wrapper,
+        }
+      );
+      expect(result.current.cartError?.message).toBe(
+        ERROR_MESSAGE.INVALID_QUANTITY
+      );
+    });
+
+    it("should throw cartError (invalidQuantity) when quota response has empty quantities", () => {
+      expect.assertions(1);
+      const ids = ["ID1"];
+      const { result } = renderHook(
+        () =>
+          useCart(ids, key, endpoint, mockQuotaResEmptyQuota.remainingQuota),
         {
           wrapper,
         }

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -149,6 +149,15 @@ export const useCart = (
          * having `cart` as a dependency, preventing an infinite loop.
          */
         setCart((cart) => mergeWithCart(cart, cartQuota, getProduct));
+      } else if (features?.apiVersion === "v2") {
+        /**
+         * This is a special case for disbursements, where a beneficiary might be
+         * whitelisted, but not disbursed with any items, resulting in an empty quota.
+         * In this case, we will proceed to the NoQuotaCard, and an error dialog
+         * will be shown subsequently. For non-v2 distributions, an empty quota
+         * will still throw the invalid quantity error, seen below.
+         */
+        setCartError(new Error(ERROR_MESSAGE.MISSING_DISBURSEMENTS));
       } else {
         setCartError(new Error(ERROR_MESSAGE.INVALID_QUANTITY));
       }
@@ -161,6 +170,7 @@ export const useCart = (
     prevIds,
     products,
     prevProducts,
+    features?.apiVersion,
   ]);
 
   const emptyCart: CartHook["emptyCart"] = useCallback(() => {

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -170,7 +170,7 @@ export const useCart = (
     prevIds,
     products,
     prevProducts,
-    features?.apiVersion,
+    features,
   ]);
 
   const emptyCart: CartHook["emptyCart"] = useCallback(() => {


### PR DESCRIPTION
[Notion link](https://www.notion.so/FE-Error-handling-of-whitelisted-beneficiaries-that-do-not-have-any-disbursements-45e33974693e43e6aff9945fa10129b7) <!-- Remove this link if no relevant Notion link -->

This PR handles the possibility where quota returned is empty for `v2/quota` endpoint, i.e. :
```
{
  "remainingQuota": Array [],
  "globalQuota": Array [],
  "localQuota": Array [],
}
```
which could happen when a beneficiary is whitelisted, but not disbursed any credits.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [x] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
