### PR TITLE
feat(pp): handle `null` type case

### DIFF
--- a/src/utils/passportScanning.test.ts
+++ b/src/utils/passportScanning.test.ts
@@ -31,7 +31,7 @@ describe("passportScanning", () => {
           expect(extractPassportIdFromEvent(event)).toStrictEqual("");
         });
 
-        it("should return empty string if passportId is boolean", () => {
+        it("should return empty string if passportId is a boolean", () => {
           expect.assertions(1);
           event = {
             data: JSON.stringify({
@@ -42,7 +42,7 @@ describe("passportScanning", () => {
           expect(extractPassportIdFromEvent(event)).toStrictEqual("");
         });
 
-        it("should return empty string if passportId is number", () => {
+        it("should return empty string if passportId is a number", () => {
           expect.assertions(1);
           event = {
             data: JSON.stringify({
@@ -53,7 +53,7 @@ describe("passportScanning", () => {
           expect(extractPassportIdFromEvent(event)).toStrictEqual("");
         });
 
-        it("should return empty string if passportId is array", () => {
+        it("should return empty string if passportId is an array", () => {
           expect.assertions(1);
           event = {
             data: JSON.stringify({
@@ -64,11 +64,24 @@ describe("passportScanning", () => {
           expect(extractPassportIdFromEvent(event)).toStrictEqual("");
         });
 
-        it("should return empty string if passportId is object", () => {
+        it("should return empty string if passportId is an empty object", () => {
           expect.assertions(1);
           event = {
             data: JSON.stringify({
               passportId: {},
+            }),
+          };
+
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
+
+        it("should return empty string if passportId is a non-empty object", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify({
+              passportId: {
+                value: "ABC-12345",
+              },
             }),
           };
 
@@ -97,7 +110,7 @@ describe("passportScanning", () => {
           expect(extractPassportIdFromEvent(event)).toStrictEqual("");
         });
 
-        it("should return empty string if data does not contain passportId", () => {
+        it("should return empty string if data is an empty object", () => {
           expect.assertions(1);
           event = {
             data: JSON.stringify({}),
@@ -106,7 +119,27 @@ describe("passportScanning", () => {
           expect(extractPassportIdFromEvent(event)).toStrictEqual("");
         });
 
-        it("should return empty string if data is boolean", () => {
+        it("should return empty string if data is an object without 'passportId' property", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify({
+              property: "value",
+            }),
+          };
+
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
+
+        it("should return empty string if data is a string", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify("123"),
+          };
+
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
+
+        it("should return empty string if data is a boolean", () => {
           expect.assertions(1);
           event = {
             data: JSON.stringify(true),

--- a/src/utils/passportScanning.test.ts
+++ b/src/utils/passportScanning.test.ts
@@ -88,7 +88,16 @@ describe("passportScanning", () => {
       });
 
       describe("cases without passportId", () => {
-        it("should return empty string if it does not contain passportId", () => {
+        it("should return empty string if data is null", () => {
+          expect.assertions(1);
+          event = {
+            data: JSON.stringify(null),
+          };
+
+          expect(extractPassportIdFromEvent(event)).toStrictEqual("");
+        });
+
+        it("should return empty string if data does not contain passportId", () => {
           expect.assertions(1);
           event = {
             data: JSON.stringify({}),
@@ -96,6 +105,7 @@ describe("passportScanning", () => {
 
           expect(extractPassportIdFromEvent(event)).toStrictEqual("");
         });
+
         it("should return empty string if data is boolean", () => {
           expect.assertions(1);
           event = {

--- a/src/utils/passportScanning.ts
+++ b/src/utils/passportScanning.ts
@@ -11,7 +11,7 @@ export const extractPassportIdFromEvent = (event: BarCodeEvent): string => {
      *
      * However, any other errors will trigger the ErrorBoundary.
      */
-    if (e instanceof SyntaxError) {
+    if (e instanceof SyntaxError || e instanceof TypeError) {
       return "";
     } else {
       throw e;


### PR DESCRIPTION
[Notion link](https://www.notion.so/Passport-Scanner-Edge-Cases-null-8057773fada0480f90661edfa53fa6ac) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->

- handling of `null` type case when scanning passport

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
