### PR TITLE
feat: PAYMENT_RECEIPT to have optional value.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -96,7 +96,10 @@ const PolicyIdentifier = t.intersection([
       }),
     ]),
   }),
-  t.partial({ validationRegex: t.string }),
+  t.partial({
+    validationRegex: t.string,
+    isOptional: t.boolean,
+  }),
 ]);
 
 const IdentifierInput = t.intersection([

--- a/src/utils/validateIdentifierInputs.test.ts
+++ b/src/utils/validateIdentifierInputs.test.ts
@@ -38,9 +38,20 @@ describe("validateIdentifierInputs", () => {
           textInputType: "PHONE_NUMBER",
         },
         {
-          label: "some payment receipt",
+          label: "payment receipt with regex",
           value: "1234acbd5678qwer1234",
-          validationRegex: "^[a-zA-Z0-9]{1,20}$",
+          validationRegex: "(\\0*|^([A-Za-z0-9])*)$",
+          textInputType: "PAYMENT_RECEIPT",
+        },
+        {
+          label: "payment receipt with regex and empty value",
+          value: "",
+          validationRegex: "(\\0*|^([A-Za-z0-9])*)$",
+          textInputType: "PAYMENT_RECEIPT",
+        },
+        {
+          label: "payment receipt without regex",
+          value: "within20characters",
           textInputType: "PAYMENT_RECEIPT",
         },
       ])

--- a/src/utils/validateIdentifierInputs.ts
+++ b/src/utils/validateIdentifierInputs.ts
@@ -58,6 +58,5 @@ export const validateIdentifierInputs = (
   ) {
     throw new Error(ERROR_MESSAGE.DUPLICATE_IDENTIFIER_INPUT);
   }
-  console.log("asdfasdf");
   return true;
 };

--- a/src/utils/validateIdentifierInputs.ts
+++ b/src/utils/validateIdentifierInputs.ts
@@ -19,24 +19,20 @@ export const validateIdentifierInputs = (
   identifierInputs: IdentifierInput[]
 ): boolean => {
   for (const { value, validationRegex, textInputType } of identifierInputs) {
-    if (
-      textInputType === "PAYMENT_RECEIPT" &&
-      (!value ||
-        !isMatchRegex(
-          value,
-          validationRegex
-            ? validationRegex
-            : defaultPaymentReceiptValidationRegex
-        ))
-    ) {
-      throw new Error(ERROR_MESSAGE.INVALID_PAYMENT_RECEIPT_NUMBER);
-    }
-    if (!value) {
+    if (textInputType !== "PAYMENT_RECEIPT" && !value) {
       throw new Error(ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT);
     }
-
     if (textInputType === "NUMBER" && isNaN(Number(value))) {
       throw new Error(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
+    }
+    if (
+      textInputType === "PAYMENT_RECEIPT" &&
+      !isMatchRegex(
+        value,
+        validationRegex ? validationRegex : defaultPaymentReceiptValidationRegex
+      )
+    ) {
+      throw new Error(ERROR_MESSAGE.INVALID_PAYMENT_RECEIPT_NUMBER);
     }
     if (
       textInputType === "PHONE_NUMBER" &&
@@ -62,6 +58,6 @@ export const validateIdentifierInputs = (
   ) {
     throw new Error(ERROR_MESSAGE.DUPLICATE_IDENTIFIER_INPUT);
   }
-
+  console.log("asdfasdf");
   return true;
 };


### PR DESCRIPTION
[Notion link](notion-link-here) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- remove mandatory `value` for `PAYMENT_RECEIPT`
- update `PolicyIdentifier` type

I think 
``` typescript
    if (textInputType !== "PAYMENT_RECEIPT" && !value) {
      throw new Error(ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT);
    }
```
can be removed instead. Empty `value` will still be checked in the `regex` matching as well as BE validation
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [x] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
