### PR TITLE
fix: remove extra period after 最多

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -56,7 +56,7 @@ export const en: Translations = {
     campaignValidTo: "Valid till %{dateTime}",
     idNumber: "Identification number",
     idNumbers: "Identification numbers",
-    quotaLimitMax: "Max",
+    quotaLimitMax: "Max.",
     quotaAppealCancel: "Cancel",
     quotaButtonCheckout: "Checkout",
     quotaButtonAdd: "Add",

--- a/src/components/CustomerQuota/ItemsSelection/ItemMaxUnitLabel.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemMaxUnitLabel.tsx
@@ -11,8 +11,7 @@ export const ItemMaxUnitLabel: FunctionComponent<{
   const tUnit = c13ntForUnit(unit);
   return (
     <>
-      {i18nt("customerQuotaScreen", "quotaLimitMax")}
-      {". "}
+      {i18nt("customerQuotaScreen", "quotaLimitMax")}{" "}
       {formatQuantityText(maxQuantity, tUnit)}
     </>
   );


### PR DESCRIPTION
[Notion link](https://www.notion.so/Remove-extra-after-a5e6eadca9154af1982892c508137266) <!-- Remove this link if no relevant Notion link -->

This PR adds removes the extra period after 最多 (chinese for max) in items selection page.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
