### PR TITLE
feat: chinese translation stats

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -106,7 +106,7 @@ export const en: Translations = {
     distributedAmount: "You have distributed",
     lastDistributedTiming: "Last distributed at %{dateTime}",
     viaAppeal: "via appeal",
-    itemsScanned: "No items scanned",
+    noItemsScanned: "No items scanned",
     title: "Statistics",
     back: "Back",
   },

--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -103,9 +103,12 @@ export const en: Translations = {
     indicateReason: "Indicate reason for appeal",
   },
   statisticsScreen: {
-    distributedAmount: "You have distributed %{quantity}",
+    distributedAmount: "You have distributed",
     lastDistributedTiming: "Last distributed at %{dateTime}",
     viaAppeal: "via appeal",
+    itemsScanned: "No items scanned",
+    title: "Statistics",
+    back: "Back",
   },
   notEligibleScreen: {
     notEligible: "Not eligible",

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -102,6 +102,9 @@ export type Translations = {
     distributedAmount: string;
     lastDistributedTiming: string;
     viaAppeal: string;
+    itemsScanned: string;
+    title: string;
+    back: string;
   };
   notEligibleScreen: {
     notEligible: string;

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -102,7 +102,7 @@ export type Translations = {
     distributedAmount: string;
     lastDistributedTiming: string;
     viaAppeal: string;
-    itemsScanned: string;
+    noItemsScanned: string;
     title: string;
     back: string;
   };

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -104,7 +104,7 @@ export const zh: Translations = {
     distributedAmount: "您已分发",
     lastDistributedTiming: "最后在 %{dateTime} 分发",
     viaAppeal: "通过上诉",
-    itemsScanned: "没有分发记录",
+    noItemsScanned: "没有分发记录",
     title: "统计",
     back: "返回",
   },

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -101,9 +101,12 @@ export const zh: Translations = {
     indicateReason: "说明上诉理由",
   },
   statisticsScreen: {
-    distributedAmount: "您已分发%{quantity}",
+    distributedAmount: "您已分发",
     lastDistributedTiming: "最后在 %{dateTime} 分发",
     viaAppeal: "通过上诉",
+    itemsScanned: "没有分发记录",
+    title: "统计",
+    back: "返回",
   },
   notEligibleScreen: {
     notEligible: "不符合资格",

--- a/src/components/DailyStatistics/StatisticsHeader.tsx
+++ b/src/components/DailyStatistics/StatisticsHeader.tsx
@@ -6,6 +6,7 @@ import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { withNavigation } from "react-navigation";
 import { NavigationProps } from "../../types";
 import { AppText } from "../Layout/AppText";
+import { useTranslate } from "../../hooks/useTranslate/useTranslate";
 
 interface StatisticsHeader extends NavigationProps {
   mode?: AppMode;
@@ -57,6 +58,8 @@ export const StatisticsHeaderComponent: FunctionComponent<StatisticsHeader> = ({
     navigation.navigate("CollectCustomerDetailsScreen");
   };
 
+  const { i18nt } = useTranslate();
+
   return (
     <View style={styles.appHeaderWrapper}>
       <TouchableOpacity style={styles.backButton} onPress={onPressBack}>
@@ -72,7 +75,7 @@ export const StatisticsHeaderComponent: FunctionComponent<StatisticsHeader> = ({
           testID="statistics-header-back-button"
           accessible={true}
         >
-          Back
+          {i18nt("statisticsScreen", "back")}
         </AppText>
       </TouchableOpacity>
       <AppText
@@ -81,7 +84,7 @@ export const StatisticsHeaderComponent: FunctionComponent<StatisticsHeader> = ({
         testID="statistics-header-title"
         accessible={true}
       >
-        Statistics
+        {i18nt("statisticsScreen", "title")}
       </AppText>
       <TouchableOpacity onPress={onPressOpenDrawer}>
         <MaterialCommunityIcons

--- a/src/components/DailyStatistics/TitleStatistic.tsx
+++ b/src/components/DailyStatistics/TitleStatistic.tsx
@@ -4,6 +4,7 @@ import { View, StyleSheet, TouchableOpacity } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { AppText } from "../Layout/AppText";
 import { format, isSameDay } from "date-fns";
+import { useTranslate } from "../../hooks/useTranslate/useTranslate";
 
 interface TitleStatisticComponent {
   totalCount: number | null;
@@ -61,15 +62,20 @@ export const TitleStatisticComponent: FunctionComponent<TitleStatisticComponent>
   onPressPrevDay,
   onPressNextDay,
 }) => {
+  const { i18nt } = useTranslate();
   return (
     <View style={styles.appHeaderWrapper}>
-      <AppText style={styles.smallText}>You distributed</AppText>
+      <AppText style={styles.smallText}>
+        {i18nt("statisticsScreen", "distributedAmount")}
+      </AppText>
       <AppText style={styles.statText}>{totalCount?.toLocaleString()}</AppText>
       <AppText style={styles.smallText}>
-        Last distributed at{" "}
-        {lastTransactionTime !== null
-          ? format(lastTransactionTime, "h:mma")
-          : "-"}
+        {`${i18nt("statisticsScreen", "lastDistributedTiming", undefined, {
+          dateTime:
+            lastTransactionTime !== null
+              ? format(lastTransactionTime, "h:mma")
+              : "-",
+        })}`}
       </AppText>
       <View style={styles.dateToggle}>
         <TouchableOpacity onPress={onPressPrevDay}>

--- a/src/components/DailyStatistics/TransactionHistoryCard.tsx
+++ b/src/components/DailyStatistics/TransactionHistoryCard.tsx
@@ -3,6 +3,7 @@ import { size, fontSize, color } from "../../common/styles";
 import { StyleSheet, View, ActivityIndicator } from "react-native";
 import { AppText } from "../Layout/AppText";
 import { Card } from "../Layout/Card";
+import { useTranslate } from "../../hooks/useTranslate/useTranslate";
 
 interface TransactionHistoryCardComponent {
   transactionHistory: {
@@ -58,6 +59,8 @@ export const TransactionHistoryCardComponent: FunctionComponent<TransactionHisto
   transactionHistory,
   loading,
 }) => {
+  const { i18nt } = useTranslate();
+
   return (
     <Card style={styles.stats}>
       {!loading ? (
@@ -87,7 +90,7 @@ export const TransactionHistoryCardComponent: FunctionComponent<TransactionHisto
               testID="transaction-history-no-items-scanned"
               accessible={true}
             >
-              No items scanned
+              {i18nt("statisticsScreen", "itemsScanned")}
             </AppText>
           </>
         )

--- a/src/components/DailyStatistics/TransactionHistoryCard.tsx
+++ b/src/components/DailyStatistics/TransactionHistoryCard.tsx
@@ -90,7 +90,7 @@ export const TransactionHistoryCardComponent: FunctionComponent<TransactionHisto
               testID="transaction-history-no-items-scanned"
               accessible={true}
             >
-              {i18nt("statisticsScreen", "itemsScanned")}
+              {i18nt("statisticsScreen", "noItemsScanned")}
             </AppText>
           </>
         )

--- a/src/components/DailyStatistics/TransactionHistoryCard.tsx
+++ b/src/components/DailyStatistics/TransactionHistoryCard.tsx
@@ -59,7 +59,7 @@ export const TransactionHistoryCardComponent: FunctionComponent<TransactionHisto
   transactionHistory,
   loading,
 }) => {
-  const { i18nt } = useTranslate();
+  const { c13nt, i18nt } = useTranslate();
 
   return (
     <Card style={styles.stats}>
@@ -68,7 +68,9 @@ export const TransactionHistoryCardComponent: FunctionComponent<TransactionHisto
           transactionHistory.map((item) => (
             <View key={item.category}>
               <View style={styles.transactionText}>
-                <AppText style={styles.categoryName}>{item.name}</AppText>
+                <AppText style={styles.categoryName}>
+                  {c13nt(item.name)}
+                </AppText>
                 <View style={styles.transactionText}>
                   <AppText style={styles.quantityText}>
                     {item.quantityText}

--- a/src/hooks/useDailyStatistics/useDailyStatistics.tsx
+++ b/src/hooks/useDailyStatistics/useDailyStatistics.tsx
@@ -4,6 +4,7 @@ import { CampaignConfigContext } from "../../context/campaignConfig";
 import { getDailyStatistics } from "../../services/statistics";
 import { countTotalTransactionsAndByCategory } from "./utils";
 import { sortTransactionsByOrder } from "../../components/CustomerQuota/utils";
+import { useTranslate } from "../useTranslate/useTranslate";
 
 export type StatisticsHook = {
   totalCount: number | null;
@@ -38,6 +39,7 @@ export const useDailyStatistics = (
 
   const { policies } = useContext(CampaignConfigContext);
   const prevTimestamp = usePrevious(currentTimestamp);
+  const translationProps = useTranslate();
 
   useEffect(() => {
     const fetchDailyStatistics = async (): Promise<void> => {
@@ -54,7 +56,8 @@ export const useDailyStatistics = (
           summarisedTotalCount,
         } = countTotalTransactionsAndByCategory(
           response.pastTransactions,
-          policies
+          policies,
+          translationProps
         );
         setTransactionHistory(
           summarisedTransactionHistory.sort(sortTransactionsByOrder)
@@ -83,6 +86,7 @@ export const useDailyStatistics = (
     sessionToken,
     currentTimestamp,
     prevTimestamp,
+    translationProps,
   ]);
 
   return {

--- a/src/hooks/useDailyStatistics/utils.ts
+++ b/src/hooks/useDailyStatistics/utils.ts
@@ -2,6 +2,7 @@ import { chain, sumBy } from "lodash";
 import { DailyStatistics, CampaignPolicy } from "../../types";
 import { formatQuantityText } from "../../components/CustomerQuota/utils";
 import { Sentry } from "../../utils/errorTracking";
+import { useTranslate } from "../useTranslate/useTranslate";
 
 type SummarisedTransactions = {
   summarisedTransactionHistory: {
@@ -22,6 +23,7 @@ export const countTotalTransactionsAndByCategory = (
     .groupBy("category")
     .reduce<SummarisedTransactions>(
       (prev, transactionsByCategory, key) => {
+        const { i18nt, c13ntForUnit } = useTranslate();
         const findItemByCategory = policies?.find(
           (item) => item.category === key
         );
@@ -41,10 +43,12 @@ export const countTotalTransactionsAndByCategory = (
           category: key,
           quantityText: formatQuantityText(
             totalQuantityInCategory,
-            findItemByCategory?.quantity.unit || {
-              type: "POSTFIX",
-              label: " qty",
-            }
+            findItemByCategory?.quantity.unit
+              ? c13ntForUnit(findItemByCategory?.quantity.unit)
+              : {
+                  type: "POSTFIX",
+                  label: ` ${i18nt("checkoutSuccessScreen", "quantity")}`,
+                }
           ),
           descriptionAlert:
             findItemByCategory?.categoryType === "APPEAL"

--- a/src/hooks/useDailyStatistics/utils.ts
+++ b/src/hooks/useDailyStatistics/utils.ts
@@ -2,7 +2,7 @@ import { chain, sumBy } from "lodash";
 import { DailyStatistics, CampaignPolicy } from "../../types";
 import { formatQuantityText } from "../../components/CustomerQuota/utils";
 import { Sentry } from "../../utils/errorTracking";
-import { useTranslate } from "../useTranslate/useTranslate";
+import { TranslationHook } from "../useTranslate/useTranslate";
 
 type SummarisedTransactions = {
   summarisedTransactionHistory: {
@@ -17,13 +17,15 @@ type SummarisedTransactions = {
 
 export const countTotalTransactionsAndByCategory = (
   transactions: DailyStatistics[],
-  policies: CampaignPolicy[] | null
+  policies: CampaignPolicy[] | null,
+  translationProps: TranslationHook
 ): SummarisedTransactions => {
+  const { i18nt, c13ntForUnit } = translationProps;
+
   return chain(transactions)
     .groupBy("category")
     .reduce<SummarisedTransactions>(
       (prev, transactionsByCategory, key) => {
-        const { i18nt, c13ntForUnit } = useTranslate();
         const findItemByCategory = policies?.find(
           (item) => item.category === key
         );


### PR DESCRIPTION
This PR adds Chinese translation to the stats page

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
