### PR TITLE
chore: allowBackup should be false

### DIFF
--- a/app.json
+++ b/app.json
@@ -41,7 +41,8 @@
     },
     "android": {
       "package": "sg.gov.tech.musket",
-      "permissions": ["CAMERA", "VIBRATE"]
+      "permissions": ["CAMERA", "VIBRATE"],
+      "allowBackup": false
     },
     "packagerOpts": {
       "config": "metro.config.js",


### PR DESCRIPTION
[Notion link](https://www.notion.so/Toggle-backup-to-be-false-in-android-manifest-xml-L002-6f48c5b3cf0f4de2be77d9212ba8dfcf)

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
