### PR TITLE
feat: identifierSelectionInput placeholder to use c13nt

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -124,6 +124,9 @@ export const en: Translations = {
     "*chargeable": "Chargeable",
     "*waive charges": "waive charges",
   },
+  identifierSelectionInput: {
+    placeholder: "Select reason",
+  },
   errorMessages: {
     alreadyUsedDifferentIDNumber: {
       title: "Already used",

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -115,6 +115,9 @@ export type Translations = {
     appleStore: string;
     androidStore: string;
   };
+  identifierSelectionInput: {
+    placeholder: string;
+  };
   addonsToggleComponent: { "*chargeable": string; "*waive charges": string };
   errorMessages: {
     alreadyUsedDifferentIDNumber: {

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -121,6 +121,9 @@ export const zh: Translations = {
     "*chargeable": "应收费",
     "*waive charges": "免收费",
   },
+  identifierSelectionInput: {
+    placeholder: "请选择原因",
+  },
   errorMessages: {
     alreadyUsedDifferentIDNumber: {
       title: "已使用",

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierSelectionInput.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierSelectionInput.tsx
@@ -30,12 +30,8 @@ export const IdentifierSelectionInput: FunctionComponent<{
     >
       <DropdownFilterInput
         label={label}
-        placeholder={`${c13nt(
-          "selectionPlaceholder",
-          undefined,
-          i18nt("identifierSelectionInput", "placeholder")
-        )}`}
-        value={`${c13nt(selectedChoice)}`}
+        placeholder={i18nt("identifierSelectionInput", "placeholder")}
+        value={c13nt(selectedChoice)}
         dropdownItems={dropdownItems}
         onItemSelection={onItemSelection}
       />

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierSelectionInput.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierSelectionInput.tsx
@@ -1,4 +1,3 @@
-import { placeholder } from "i18n-js";
 import React, { FunctionComponent, useState } from "react";
 import { View } from "react-native";
 

--- a/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierSelectionInput.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/IdentifierLayout/IdentifierSelectionInput.tsx
@@ -1,3 +1,4 @@
+import { placeholder } from "i18n-js";
 import React, { FunctionComponent, useState } from "react";
 import { View } from "react-native";
 
@@ -13,7 +14,7 @@ export const IdentifierSelectionInput: FunctionComponent<{
   onSelectDropdown: (choice: string) => void;
   dropdownItems?: PolicyChoices[];
 }> = ({ addMarginRight, label, onSelectDropdown, dropdownItems = [] }) => {
-  const { c13nt } = useTranslate();
+  const { c13nt, i18nt } = useTranslate();
   const [selectedChoice, setSelectedChoice] = useState<string>("");
 
   const onItemSelection = (item: PolicyChoices): void => {
@@ -30,7 +31,11 @@ export const IdentifierSelectionInput: FunctionComponent<{
     >
       <DropdownFilterInput
         label={label}
-        placeholder="Select reason"
+        placeholder={`${c13nt(
+          "selectionPlaceholder",
+          undefined,
+          i18nt("identifierSelectionInput", "placeholder")
+        )}`}
         value={`${c13nt(selectedChoice)}`}
         dropdownItems={dropdownItems}
         onItemSelection={onItemSelection}


### PR DESCRIPTION
[Notion link](notion-link-here) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- IdentifierSelectionInput placeholder to use c13nt and to have default i18nt
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [ ] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
