### PR TITLE
chore: addonToggle to only show its own category

### DIFF
--- a/src/components/CustomerQuota/ItemsSelection/AddonsItems.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/AddonsItems.tsx
@@ -22,7 +22,7 @@ const BIG_NUMBER = 99999;
 export const AddonsItems: FunctionComponent<{
   ids: string[];
   isShowAddonItems: boolean;
-  categoryFilter: string[];
+  categoryFilter?: string;
 }> = ({ ids, isShowAddonItems, categoryFilter }) => {
   const [transactionList, setTransactionList] = useState<TransactionsGroup[]>(
     []
@@ -37,7 +37,7 @@ export const AddonsItems: FunctionComponent<{
     ids,
     sessionToken,
     endpoint,
-    categoryFilter.length > 0 ? categoryFilter : undefined,
+    categoryFilter ? [categoryFilter] : undefined,
     true
   );
 

--- a/src/components/CustomerQuota/ItemsSelection/ItemCheckbox.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemCheckbox.tsx
@@ -14,13 +14,9 @@ export const ItemCheckbox: FunctionComponent<{
   const [isShowAddonsItems, setIsShowAddonsItems] = useState(false);
   const { category, quantity, maxQuantity, descriptionAlert } = cartItem;
   const { getProduct } = useContext(ProductContext);
-  const { name = category, description, quantity: productQuantity, alert } =
+  const { name = category, description, quantity: productQuantity } =
     getProduct(category) || {};
 
-  const categoryFilter = [category];
-  if (typeof alert?.threshold === "string") {
-    categoryFilter.push(alert.threshold);
-  }
   return (
     <Checkbox
       label={
@@ -43,7 +39,7 @@ export const ItemCheckbox: FunctionComponent<{
           <AddonsItems
             ids={ids}
             isShowAddonItems={isShowAddonsItems}
-            categoryFilter={categoryFilter}
+            categoryFilter={category}
           />
         ) : undefined
       }


### PR DESCRIPTION
[Notion link](notion-link-here) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- revert categoryFilter in AddonsItems and ItemCheckbox to only show its own category
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [ ] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
