### PR TITLE
fix: flatlist key to be defaulted to label ?? value

### DIFF
--- a/src/components/DropdownFilterModal/DropdownFilterModal.tsx
+++ b/src/components/DropdownFilterModal/DropdownFilterModal.tsx
@@ -107,9 +107,7 @@ export const ListItem: FunctionComponent<{
   return (
     <View style={styles.listItemView}>
       {item.tag ? (
-        <Text style={styles.listItemTag}>
-          {c13nt(item.value, undefined, item.label)}
-        </Text>
+        <Text style={styles.listItemTag}>{item.label}</Text>
       ) : (
         <TouchableOpacity
           onPress={() => {
@@ -206,7 +204,7 @@ export const DropdownFilterModal: FunctionComponent<DropdownFilterModal> = ({
                 onItemSelection={onItemSelection}
               />
             )}
-            keyExtractor={(item) => item.value}
+            keyExtractor={(item) => item.label ?? item.value}
           />
         </View>
       </View>


### PR DESCRIPTION
[Notion link](notion-link-here) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- modify keyExtractor to be defaulted to `item.label ?? item.value`
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [ ] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
