### PR TITLE
refactor: addons toggle to only show when transactionList exists

### DIFF
--- a/src/components/CustomerQuota/ItemsSelection/AddonsItems.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/AddonsItems.tsx
@@ -10,12 +10,15 @@ export const AddonsItems: FunctionComponent<{
   return isShowAddonItems && transactionList && transactionList.length > 0 ? (
     <>
       {transactionList.map(
-        (transactionsByCategory: TransactionsGroup, index: number) => (
+        (
+          { transactions, order }: Omit<TransactionsGroup, "header">,
+          index: number
+        ) => (
           <TransactionsGroup
             key={index}
             maxTransactionsToDisplay={BIG_NUMBER}
-            {...transactionsByCategory}
-            header={undefined}
+            transactions={transactions}
+            order={order}
           />
         )
       )}

--- a/src/components/CustomerQuota/ItemsSelection/AddonsItems.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/AddonsItems.tsx
@@ -1,91 +1,24 @@
-import React, {
-  FunctionComponent,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
-import { ActivityIndicator } from "react-native";
-import { color } from "../../../common/styles";
-import { AlertModalContext } from "../../../context/alert";
-import { AuthContext } from "../../../context/auth";
-import { CampaignConfigContext } from "../../../context/campaignConfig";
-import { usePastTransaction } from "../../../hooks/usePastTransaction/usePastTransaction";
-import { useTranslate } from "../../../hooks/useTranslate/useTranslate";
+import React, { FunctionComponent } from "react";
 import { TransactionsGroup } from "../TransactionsGroup";
-import {
-  groupTransactionsByCategory,
-  sortTransactionsByCategory,
-} from "../utils";
 
 const BIG_NUMBER = 99999;
 
 export const AddonsItems: FunctionComponent<{
-  ids: string[];
+  transactionList: TransactionsGroup[];
   isShowAddonItems: boolean;
-  categoryFilter?: string;
-}> = ({ ids, isShowAddonItems, categoryFilter }) => {
-  const [transactionList, setTransactionList] = useState<TransactionsGroup[]>(
-    []
-  );
-  const { sessionToken, endpoint } = useContext(AuthContext);
-  const { policies: allProducts } = useContext(CampaignConfigContext);
-  const {
-    pastTransactionsResult: sortedTransactions,
-    loading,
-    error,
-  } = usePastTransaction(
-    ids,
-    sessionToken,
-    endpoint,
-    categoryFilter ? [categoryFilter] : undefined,
-    true
-  );
-
-  const { showErrorAlert } = useContext(AlertModalContext);
-  useEffect(() => {
-    if (error) {
-      showErrorAlert(error);
-    }
-  }, [error, showErrorAlert]);
-  const translationProps = useTranslate();
-  useEffect(() => {
-    const latestTransactionTime: Date | undefined =
-      sortedTransactions && sortedTransactions.length > 0
-        ? sortedTransactions[0].transactionTime
-        : undefined;
-
-    const transactionsByCategoryMap = groupTransactionsByCategory(
-      sortedTransactions,
-      allProducts || [],
-      latestTransactionTime,
-      translationProps
-    );
-
-    const transactionsByCategoryList = sortTransactionsByCategory(
-      transactionsByCategoryMap
-    );
-    setTransactionList(transactionsByCategoryList);
-  }, [sortedTransactions, allProducts, translationProps]);
-  return isShowAddonItems ? (
-    loading ? (
-      <ActivityIndicator
-        style={{ alignSelf: "flex-start" }}
-        size="large"
-        color={color("grey", 40)}
-      />
-    ) : (
-      <>
-        {transactionList.map(
-          (transactionsByCategory: TransactionsGroup, index: number) => (
-            <TransactionsGroup
-              key={index}
-              maxTransactionsToDisplay={BIG_NUMBER}
-              {...transactionsByCategory}
-              header={undefined}
-            />
-          )
-        )}
-      </>
-    )
+}> = ({ transactionList, isShowAddonItems }) => {
+  return isShowAddonItems && transactionList && transactionList.length > 0 ? (
+    <>
+      {transactionList.map(
+        (transactionsByCategory: TransactionsGroup, index: number) => (
+          <TransactionsGroup
+            key={index}
+            maxTransactionsToDisplay={BIG_NUMBER}
+            {...transactionsByCategory}
+            header={undefined}
+          />
+        )
+      )}
+    </>
   ) : null;
 };

--- a/src/components/CustomerQuota/ItemsSelection/AddonsItems.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/AddonsItems.tsx
@@ -10,15 +10,11 @@ export const AddonsItems: FunctionComponent<{
   return isShowAddonItems && transactionList && transactionList.length > 0 ? (
     <>
       {transactionList.map(
-        (
-          { transactions, order }: Omit<TransactionsGroup, "header">,
-          index: number
-        ) => (
+        ({ header, ...rest }: TransactionsGroup, index: number) => (
           <TransactionsGroup
             key={index}
             maxTransactionsToDisplay={BIG_NUMBER}
-            transactions={transactions}
-            order={order}
+            {...rest}
           />
         )
       )}

--- a/src/components/CustomerQuota/ItemsSelection/AddonsItems.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/AddonsItems.tsx
@@ -10,11 +10,14 @@ export const AddonsItems: FunctionComponent<{
   return isShowAddonItems && transactionList && transactionList.length > 0 ? (
     <>
       {transactionList.map(
-        ({ header, ...rest }: TransactionsGroup, index: number) => (
+        (
+          { header, ...transactionsGroupWithoutHeader }: TransactionsGroup,
+          index: number
+        ) => (
           <TransactionsGroup
             key={index}
             maxTransactionsToDisplay={BIG_NUMBER}
-            {...rest}
+            {...transactionsGroupWithoutHeader}
           />
         )
       )}

--- a/src/components/CustomerQuota/ItemsSelection/ItemCheckbox.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemCheckbox.tsx
@@ -4,6 +4,8 @@ import { ItemContent } from "./ItemContent";
 import { CartItem, CartHook } from "../../../hooks/useCart/useCart";
 import { ProductContext } from "../../../context/products";
 import { AddonsItems } from "./AddonsItems";
+import { TransactionsGroup } from "../TransactionsGroup";
+import { ShowAddonsToggle } from "./ShowAddonsToggle";
 
 export const ItemCheckbox: FunctionComponent<{
   ids: string[];
@@ -12,6 +14,9 @@ export const ItemCheckbox: FunctionComponent<{
   updateCart: CartHook["updateCart"];
 }> = ({ ids, addonToggleItem, cartItem, updateCart }) => {
   const [isShowAddonsItems, setIsShowAddonsItems] = useState(false);
+  const [addonsTransactionList, setAddonsTransactionList] = useState<
+    TransactionsGroup[]
+  >([]);
   const { category, quantity, maxQuantity, descriptionAlert } = cartItem;
   const { getProduct } = useContext(ProductContext);
   const { name = category, description, quantity: productQuantity } =
@@ -23,23 +28,32 @@ export const ItemCheckbox: FunctionComponent<{
         <ItemContent
           name={name}
           description={description}
-          descriptionAlert={descriptionAlert}
           unit={productQuantity?.unit}
           maxQuantity={maxQuantity}
           accessibilityLabel="item-checkbox"
-          showAddonsToggle={(e) => {
-            e.stopPropagation();
-            setIsShowAddonsItems(!isShowAddonsItems);
-          }}
-          showAddons={isShowAddonsItems}
         />
+      }
+      addonsLabel={
+        descriptionAlert && descriptionAlert.length > 0 ? (
+          <ShowAddonsToggle
+            descriptionAlert={descriptionAlert}
+            toggleIsShowAddons={(e) => {
+              e.stopPropagation();
+              setIsShowAddonsItems(!isShowAddonsItems);
+            }}
+            isShowAddons={isShowAddonsItems}
+            addonsTransactionList={addonsTransactionList}
+            setAddonsTransactionList={setAddonsTransactionList}
+            ids={ids}
+            categoryFilter={category}
+          />
+        ) : undefined
       }
       addons={
         addonToggleItem ? (
           <AddonsItems
-            ids={ids}
+            transactionList={addonsTransactionList}
             isShowAddonItems={isShowAddonsItems}
-            categoryFilter={category}
           />
         ) : undefined
       }

--- a/src/components/CustomerQuota/ItemsSelection/ItemContent.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ItemContent.tsx
@@ -1,12 +1,11 @@
 import React, { FunctionComponent } from "react";
-import { View, StyleSheet, GestureResponderEvent } from "react-native";
+import { View, StyleSheet } from "react-native";
 import { AppText } from "../../Layout/AppText";
 import { CampaignPolicy } from "../../../types";
 import { ItemMaxUnitLabel } from "./ItemMaxUnitLabel";
 import { fontSize, color } from "../../../common/styles";
 import { sharedStyles } from "./sharedStyles";
 import { useTranslate } from "../../../hooks/useTranslate/useTranslate";
-import { ShowAddonsToggle, DescriptionAlertTypes } from "./ShowAddonsToggle";
 
 const styles = StyleSheet.create({
   name: {
@@ -25,21 +24,15 @@ const styles = StyleSheet.create({
 export const ItemContent: FunctionComponent<{
   name: CampaignPolicy["name"];
   description: CampaignPolicy["description"];
-  descriptionAlert?: DescriptionAlertTypes;
   unit: CampaignPolicy["quantity"]["unit"];
   maxQuantity: number;
   accessibilityLabel?: string;
-  showAddonsToggle?: (e: GestureResponderEvent) => void;
-  showAddons?: boolean;
 }> = ({
   name,
   description,
-  descriptionAlert,
   unit,
   maxQuantity,
   accessibilityLabel = "item-content",
-  showAddonsToggle,
-  showAddons,
 }) => {
   const { c13nt } = useTranslate();
   const tDescription = c13nt(description ?? "");
@@ -61,13 +54,6 @@ export const ItemContent: FunctionComponent<{
         <AppText style={sharedStyles.maxQuantityLabel}>
           <ItemMaxUnitLabel unit={unit} maxQuantity={maxQuantity} />
         </AppText>
-      )}
-      {descriptionAlert && descriptionAlert.length > 0 && (
-        <ShowAddonsToggle
-          descriptionAlert={descriptionAlert}
-          toggleIsShowAddons={showAddonsToggle}
-          isShowAddons={showAddons}
-        />
       )}
     </View>
   );

--- a/src/components/CustomerQuota/ItemsSelection/ShowAddonsToggle.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/ShowAddonsToggle.tsx
@@ -1,14 +1,24 @@
-import React, { FunctionComponent } from "react";
+import React, { FunctionComponent, useContext, useEffect } from "react";
 import {
   TouchableOpacity,
   StyleSheet,
   GestureResponderEvent,
+  ActivityIndicator,
 } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { color, size } from "../../../common/styles";
 import { AppText } from "../../Layout/AppText";
 import { useTranslate } from "../../../hooks/useTranslate/useTranslate";
 import { Translations } from "../../../common/i18n/translations/type";
+import { AuthContext } from "../../../context/auth";
+import { CampaignConfigContext } from "../../../context/campaignConfig";
+import { usePastTransaction } from "../../../hooks/usePastTransaction/usePastTransaction";
+import { AlertModalContext } from "../../../context/alert";
+import {
+  groupTransactionsByCategory,
+  sortTransactionsByCategory,
+} from "../utils";
+import { TransactionsGroup } from "../TransactionsGroup";
 
 const styles = StyleSheet.create({
   descriptionAlert: {
@@ -24,18 +34,82 @@ export const ShowAddonsToggle: FunctionComponent<{
   descriptionAlert: DescriptionAlertTypes;
   toggleIsShowAddons?: (e: GestureResponderEvent) => void;
   isShowAddons?: boolean;
-}> = ({ descriptionAlert, toggleIsShowAddons, isShowAddons }) => {
-  const { i18nt } = useTranslate();
-
-  return (
-    <TouchableOpacity onPress={toggleIsShowAddons}>
-      <AppText style={styles.descriptionAlert}>
-        {`${i18nt("addonsToggleComponent", descriptionAlert)} `}
-        <MaterialCommunityIcons
-          name={isShowAddons ? "chevron-up" : "chevron-down"}
-          size={size(2)}
-        />
-      </AppText>
-    </TouchableOpacity>
+  addonsTransactionList: TransactionsGroup[];
+  setAddonsTransactionList: (transactions: TransactionsGroup[]) => void;
+  ids: string[];
+  categoryFilter?: string;
+}> = ({
+  descriptionAlert,
+  toggleIsShowAddons,
+  isShowAddons,
+  addonsTransactionList,
+  setAddonsTransactionList,
+  ids,
+  categoryFilter,
+}) => {
+  const { sessionToken, endpoint } = useContext(AuthContext);
+  const { policies: allProducts } = useContext(CampaignConfigContext);
+  const {
+    pastTransactionsResult: sortedTransactions,
+    loading,
+    error,
+  } = usePastTransaction(
+    ids,
+    sessionToken,
+    endpoint,
+    categoryFilter ? [categoryFilter] : undefined,
+    true
   );
+
+  const { showErrorAlert } = useContext(AlertModalContext);
+  useEffect(() => {
+    if (error) {
+      showErrorAlert(error);
+    }
+  }, [error, showErrorAlert]);
+  const translationProps = useTranslate();
+  useEffect(() => {
+    const latestTransactionTime: Date | undefined =
+      sortedTransactions && sortedTransactions.length > 0
+        ? sortedTransactions[0].transactionTime
+        : undefined;
+
+    const transactionsByCategoryMap = groupTransactionsByCategory(
+      sortedTransactions,
+      allProducts || [],
+      latestTransactionTime,
+      translationProps
+    );
+    const transactionsByCategoryList = sortTransactionsByCategory(
+      transactionsByCategoryMap
+    );
+    setAddonsTransactionList(transactionsByCategoryList);
+  }, [
+    sortedTransactions,
+    allProducts,
+    translationProps,
+    setAddonsTransactionList,
+  ]);
+  return addonsTransactionList && addonsTransactionList.length > 0 ? (
+    loading ? (
+      <ActivityIndicator
+        style={{ alignSelf: "flex-start" }}
+        size="large"
+        color={color("grey", 40)}
+      />
+    ) : (
+      <TouchableOpacity onPress={toggleIsShowAddons}>
+        <AppText style={styles.descriptionAlert}>
+          {`${translationProps.i18nt(
+            "addonsToggleComponent",
+            descriptionAlert
+          )} `}
+          <MaterialCommunityIcons
+            name={isShowAddons ? "chevron-up" : "chevron-down"}
+            size={size(2)}
+          />
+        </AppText>
+      </TouchableOpacity>
+    )
+  ) : null;
 };

--- a/src/components/CustomerQuota/TransactionsGroup.tsx
+++ b/src/components/CustomerQuota/TransactionsGroup.tsx
@@ -50,7 +50,7 @@ export interface Transaction {
 }
 
 export interface TransactionsGroup {
-  header: string | undefined;
+  header?: string;
   transactions: Transaction[];
   order: number;
 }

--- a/src/components/Layout/Checkbox.tsx
+++ b/src/components/Layout/Checkbox.tsx
@@ -84,12 +84,14 @@ const Toggle: FunctionComponent<Toggle> = ({ isChecked }) => {
 interface Checkbox extends Toggle {
   label: ReactElement;
   addons?: ReactElement;
+  addonsLabel?: ReactElement;
   onToggle: (isChecked: boolean) => void;
 }
 
 export const Checkbox: FunctionComponent<Checkbox> = ({
   label,
   addons,
+  addonsLabel,
   isChecked,
   onToggle,
 }) => {
@@ -111,7 +113,10 @@ export const Checkbox: FunctionComponent<Checkbox> = ({
         ]}
       >
         <View style={styles.categoryWrapper}>
-          <View style={styles.labelWrapper}>{label}</View>
+          <View>
+            <View style={styles.labelWrapper}>{label}</View>
+            <View style={styles.labelWrapper}>{addonsLabel}</View>
+          </View>
           <View style={styles.toggleWrapper}>
             <Toggle isChecked={isChecked} />
           </View>


### PR DESCRIPTION
[Notion link](https://www.notion.so/Related-history-accordion-should-not-appear-if-there-isn-t-any-past-transaction-185aebbb017a4bfabfa4e421cc538e8c) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- addons Toggle now shows only when transactionList exists
- refactor ItemContent to not have ShowAddonsToggle
- separate ShowAddonsToggle to its own component under Checkbox
(if this component is to be used in more identifier inputs, will try to put in more generic location)
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [x] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
