### PR TITLE
feat: more generic error message for validity period errors

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -211,8 +211,8 @@ export const en: Translations = {
       primaryActionText: "OK",
     },
     expiredQR: {
-      title: "Expired",
-      body: "Get a new QR code from your in-charge.",
+      title: "Cannot use",
+      body: "Only use your QR code during the validity period.",
       primaryActionText: "OK",
     },
     expiredOTP: {

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -203,8 +203,8 @@ export const zh: Translations = {
       primaryActionText: "确定",
     },
     expiredQR: {
-      title: "过期",
-      body: "请向您的负责人索取新QR码。",
+      title: "不能使用",
+      body: "仅限于在有效期内使用您的QR码。",
       primaryActionText: "确定",
     },
     expiredOTP: {


### PR DESCRIPTION
The "Expired" error message is shared between to error instances, `AuthExpiredError`, `AuthNotFoundError`, `SessionError`. Below are the methods to evoke the dialog messages through different error instances.

### Self-Testing 🛠️

**AuthExpiredError (`AUTH_FAILURE_EXPIRED_TOKEN`)**

- Generate a campaign with not yet valid validity period ⇒ try to login
- Generate a campaign with already expired validity period ⇒ try to login

**AuthNotFoundError (`AUTH_NOT_FOUND`/`AUTH_ROLE_UNAUTHORIZED`)**

- Generate a campaign with invalid `uuid` ⇒ try to login
- Generate a campaign ⇒ modify its user `role` in dynamodb to not be `OPERATOR` ⇒ call any `authenticatedRequestHandler()` API

**SessionError**

- Login to a campaign ⇒ change its sessionToken ⇒ Login to a campaign

more details in the [Notion link](https://www.notion.so/Error-message-to-prompt-to-only-use-Login-QR-code-during-validity-period-63e8a7e3ce984786acdffa91612700d8)

### Test for Acceptance Criteria

- Go to Change Campaign page ⇒ change `validFrom` ⇒ select campaign

This PR adds... <!-- A brief description of what your PR does -->
- Replaces the error message translation for `en` and `zh`
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [x] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [x] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
