### PR TITLE
chore(deps): update google-libphonenumber

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10144,9 +10144,9 @@
       }
     },
     "google-libphonenumber": {
-      "version": "3.2.19",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.19.tgz",
-      "integrity": "sha512-zevRvpUuc88wIXa+ijlMprAc8SrldUtYY2vQpfymmxyZ2ksct6gFrGxccpo28+zjvjK51VoSUaDUHS24XYp6dA=="
+      "version": "3.2.22",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.22.tgz",
+      "integrity": "sha512-lzEllxWc05n/HEv75SsDrA7zdEVvQzTZimItZm/TZ5XBs7cmx2NJmSlA5I0kZbdKNu8GFETBhSpo+SOhx0JslA=="
     },
     "graceful-fs": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "expo-permissions": "~9.0.1",
     "expo-updates": "^0.2.12",
     "fp-ts": "^2.9.5",
-    "google-libphonenumber": "^3.2.19",
+    "google-libphonenumber": "^3.2.22",
     "io-ts": "^2.2.16",
     "io-ts-reporters": "^1.2.2",
     "io-ts-types": "^0.5.16",

--- a/src/utils/validatePhoneNumbers.test.tsx
+++ b/src/utils/validatePhoneNumbers.test.tsx
@@ -106,10 +106,11 @@ describe("mobileNumberValidator", () => {
   });
 
   it("should return true for valid numbers", () => {
-    expect.assertions(3);
+    expect.assertions(4);
     expect(mobileNumberValidator("+65", "96247612")).toBe(true);
     expect(mobileNumberValidator("+65", "98261749")).toBe(true);
     expect(mobileNumberValidator("+65", "98219374")).toBe(true);
+    expect(mobileNumberValidator("+65", "80230000")).toBe(true);
   });
 });
 
@@ -137,9 +138,10 @@ describe("fullPhoneNumberValidator", () => {
   });
 
   it("should return true for valid phone numbers", () => {
-    expect.assertions(3);
+    expect.assertions(4);
     expect(fullPhoneNumberValidator("+6596247612")).toBe(true);
     expect(fullPhoneNumberValidator("+6598261749")).toBe(true);
     expect(fullPhoneNumberValidator("+6598219374")).toBe(true);
+    expect(fullPhoneNumberValidator("+6580230000")).toBe(true);
   });
 });


### PR DESCRIPTION
[Notion](https://www.notion.so/Phone-number-throwing-invalid-error-although-it-s-valid-5697015c1edd4891bc56a7c0aba53e1e)

A user reported that their number starting with 8023 doesn't pass validations.
Upon further investigation, updating to the latest `google-libphonenumber` allows it to work.

Before:
```
  ● mobileNumberValidator › should return true for valid numbers

    expect(received).toBe(expected) // Object.is equality

    Expected: true
    Received: false

      111 |     expect(mobileNumberValidator("+65", "98261749")).toBe(true);
      112 |     expect(mobileNumberValidator("+65", "98219374")).toBe(true);
    > 113 |     expect(mobileNumberValidator("+65", "80230000")).toBe(true);
          |                                                      ^
      114 |   });
      115 | });
      116 | 

      at Object.<anonymous> (src/utils/validatePhoneNumbers.test.tsx:113:54)
```
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
