### PR TITLE
fix: overflow on statistics page

### DIFF
--- a/src/components/DailyStatistics/TransactionHistoryCard.tsx
+++ b/src/components/DailyStatistics/TransactionHistoryCard.tsx
@@ -26,6 +26,7 @@ const styles = StyleSheet.create({
     fontSize: fontSize(0),
     marginBottom: size(3),
     flexShrink: 1,
+    maxWidth: "60%",
   },
   quantityText: {
     fontFamily: "brand-bold",

--- a/src/components/DailyStatistics/TransactionHistoryCard.tsx
+++ b/src/components/DailyStatistics/TransactionHistoryCard.tsx
@@ -25,6 +25,7 @@ const styles = StyleSheet.create({
     fontFamily: "brand-bold",
     fontSize: fontSize(0),
     marginBottom: size(3),
+    flexShrink: 1,
   },
   quantityText: {
     fontFamily: "brand-bold",


### PR DESCRIPTION
[Notion link](https://www.notion.so/Statistics-page-quantity-alignment-issue-7049a3eb107a4989bac484c6099bac21)

This PR adds the fix to the overflow issue on the statistics page when 3 digits or above quantity is issued to an item on phone screens with display zoom set above a certain limit (max zoom). 

2 environments were used to test this out:

1: Mocking `transactionHistory` data to have `Dead Battery (1 to 1 exchange)` set to 1500 quantity on `npm run storybook` on the statistics screen. 

2: Using [PR-791](https://github.com/rationally-app/backend-api/pull/791) backend environment on Expo with editted policies from parameter store to increase limit redemption to 9999 when raising appeal. 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [x] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
