### PR TITLE
fix: interestArea now takes the correct width and height

### DIFF
--- a/src/components/IdScanner/IdScanner.tsx
+++ b/src/components/IdScanner/IdScanner.tsx
@@ -167,12 +167,16 @@ export const IdScanner: FunctionComponent<IdScanner> = ({
       const { x: interestAreaX, y: interestAreaY } = interestArea;
       if (origin && boundsSize && interestAreaX && interestAreaY) {
         const { x: boundsX, y: boundsY } = origin;
-        const { width, height } = boundsSize;
+        const { width: boundsWidth, height: boundsHeight } = boundsSize;
+        const {
+          width: interestAreaWidth,
+          height: interestAreaHeight,
+        } = interestArea;
         if (
           boundsX >= interestAreaX &&
           boundsY >= interestAreaY &&
-          boundsX + width <= interestAreaX + width &&
-          boundsY + height <= interestAreaY + height
+          boundsX + boundsWidth <= interestAreaX + interestAreaWidth &&
+          boundsY + boundsHeight <= interestAreaY + interestAreaHeight
         ) {
           if (onBarCodeScanned) {
             onBarCodeScanned(event);


### PR DESCRIPTION
[Notion link](https://www.notion.so/Cannot-scan-login-QR-code-after-upgrading-Expo-to-SDK-42-d23580a167784ff595c43bbe5541db37) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- fix bounding box logic for physical android devices. InterestArea now takes the correct `width` and `height` addition

(tested with physical android, emulator android, and physical iPhone)
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [x] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
