### PR TITLE
fix: trim passport num logic

### DIFF
--- a/src/components/CustomerDetails/InputPassportSection.test.tsx
+++ b/src/components/CustomerDetails/InputPassportSection.test.tsx
@@ -40,9 +40,10 @@ describe("InputPassportSection", () => {
     expect(passportCountryInput[1]!.props["children"]).toEqual("Afghanistan");
 
     fireEvent(passportNumberInput!, "onChange", {
-      nativeEvent: { text: "valid-alternate-id" },
+      nativeEvent: { text: "                valid-alternate-id    " },
     });
-    expect(passportNumberInput!.props["value"]).toEqual("valid-alternate-id");
+
+    expect(setIdInput).toHaveBeenCalledWith("AFG-valid-alternate-id");
 
     fireEvent.press(identityDetailsCheckButton!);
     expect(submitId).toHaveBeenCalledTimes(1);

--- a/src/components/CustomerDetails/InputPassportSection.tsx
+++ b/src/components/CustomerDetails/InputPassportSection.tsx
@@ -51,11 +51,13 @@ export const InputPassportSection: FunctionComponent<InputPassportSection> = ({
     setSelectedCountry(item);
   };
 
+  const trimmedPassportNum: string = (passportNum || "").trim();
+
   useEffect(() => {
-    selectedCountry && passportNum
-      ? setIdInput(`${selectedCountry?.value}-${passportNum}`)
+    selectedCountry && trimmedPassportNum
+      ? setIdInput(`${selectedCountry?.value}-${trimmedPassportNum}`)
       : setIdInput("");
-  }, [selectedCountry, passportNum, setIdInput]);
+  }, [selectedCountry, trimmedPassportNum, setIdInput]);
 
   const getScannerComponent = (): JSX.Element | null => {
     return scannerType !== "NONE" ? (

--- a/src/components/CustomerDetails/InputPassportSection.tsx
+++ b/src/components/CustomerDetails/InputPassportSection.tsx
@@ -51,7 +51,9 @@ export const InputPassportSection: FunctionComponent<InputPassportSection> = ({
     setSelectedCountry(item);
   };
 
-  const trimmedPassportNum: string = (passportNum || "").trim();
+  const trimmedPassportNum: string | undefined = passportNum
+    ? passportNum.trim()
+    : passportNum;
 
   useEffect(() => {
     selectedCountry && trimmedPassportNum


### PR DESCRIPTION
[Notion link](https://www.notion.so/Trim-extra-leading-or-trailing-spaces-from-user-input-738d72c9467740d9b5e77b3b4828cf28) 

This PR adds the fix for passport numbers not being validated found during testing of trailing and leading whitespace for non NRIC signup values. 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
