### PR TITLE
build: ensure PR title follows conventional commits specs

### DIFF
--- a/.github/workflows/deploy_branch_preview.yml
+++ b/.github/workflows/deploy_branch_preview.yml
@@ -9,6 +9,16 @@ concurrency:
   group: ${{ github.ref }} # The branch or tag ref that triggered the workflow run.
 
 jobs:
+  lint:
+    runs-on: ubuntu-18.04
+    continue-on-error: false
+    timeout-minutes: 5
+
+    steps:
+      - name: check if PR title follows conventional commits specs
+        uses: amannn/action-semantic-pull-request@v3.4.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   test:
     name: Lint & Test
     runs-on: ubuntu-18.04


### PR DESCRIPTION
This PR adds a lint check to ensure that PR title will follow conventional commits specs

Sample error thrown if PR title is wrong
```
Error: No release type found in pull request title "wrong/ lint PR titles and minor github workflow updates". Add a prefix to indicate what kind of release this pull request corresponds to. For reference, see https://www.conventionalcommits.org/

Available types:
 - feat: A new feature
 - fix: A bug fix
 - docs: Documentation only changes
 - style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
 - refactor: A code change that neither fixes a bug nor adds a feature
 - perf: A code change that improves performance
 - test: Adding missing tests or correcting existing tests
 - build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
 - ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
 - chore: Other changes that don't modify src or test files
 - revert: Reverts a previous commit
 ```

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
