### PR TITLE
fix: refactor code to centralize text and prevent overflow behind che…

### DIFF
--- a/src/components/Layout/Checkbox.tsx
+++ b/src/components/Layout/Checkbox.tsx
@@ -38,12 +38,12 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   toggleWrapper: {
-    flex: 1,
+    flex: 0.5,
     alignItems: "flex-end",
   },
   addonsWrapper: {
     marginRight: size(1),
-    flex: 1,
+    flex: 0.5,
   },
   toggle: {
     borderWidth: 1,
@@ -114,9 +114,9 @@ export const Checkbox: FunctionComponent<Checkbox> = ({
       >
         <View style={styles.categoryWrapper}>
           <View style={styles.labelWrapper}>{label}</View>
-          <View>
+          {addonsLabel && (
             <View style={styles.labelWrapper}>{addonsLabel}</View>
-          </View>
+          )}
           <View style={styles.toggleWrapper}>
             <Toggle isChecked={isChecked} />
           </View>

--- a/src/components/Layout/Checkbox.tsx
+++ b/src/components/Layout/Checkbox.tsx
@@ -113,8 +113,8 @@ export const Checkbox: FunctionComponent<Checkbox> = ({
         ]}
       >
         <View style={styles.categoryWrapper}>
+          <View style={styles.labelWrapper}>{label}</View>
           <View>
-            <View style={styles.labelWrapper}>{label}</View>
             <View style={styles.labelWrapper}>{addonsLabel}</View>
           </View>
           <View style={styles.toggleWrapper}>


### PR DESCRIPTION
[Notion link](https://www.notion.so/Long-text-overflows-on-certain-screen-sizes-on-redemption-of-items-26c193e774634eeeb7947ffd9a2998f5) 

This PR prevents the overflow of text on certain screen sizes that causes it to be hidden behind the checkbox. It also centralizes all texts that do not belong to their own cards and live in `customerCard`. 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)