### PR TITLE
fix: save passportNum input and prevent it from submitting empty values

### DIFF
--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -195,7 +195,7 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
         id,
         products: defaultProducts,
       });
-      setIdInput("");
+      setIdInput(id);
     } catch (e) {
       setIsScanningEnabled(false);
       showErrorAlert(e, () => setIsScanningEnabled(true));


### PR DESCRIPTION
[Notion link](https://www.notion.so/Trim-extra-leading-or-trailing-spaces-from-user-input-738d72c9467740d9b5e77b3b4828cf28)

This PR adds saving of input values after successful check and when users backpress to the previous screen, preventing empty values from being submitted and causing an invalid check. 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
