### PR TITLE
revert: Revert "fix: do not send empty identifier input array to transactions endpoint" [deployment]

### DIFF
--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -1491,60 +1491,6 @@ describe("useCart", () => {
       ]);
     });
 
-    it("should not have identifierInputs property in the transaction request if there are no identifierInputs", async () => {
-      expect.assertions(3);
-      const ids = ["ID1"];
-      const productWithoutIdentifiers = defaultProducts.map((product) => ({
-        ...product,
-        identifiers: undefined,
-      }));
-      const { result } = renderHook(
-        () => useCart(ids, key, endpoint, mockQuotaResSingleId.remainingQuota),
-        {
-          wrapper: ({ children }) =>
-            wrapper({ children, products: productWithoutIdentifiers }),
-        }
-      );
-
-      await waitFor(() => {
-        result.current.updateCart("toilet-paper", 1);
-      });
-
-      mockPostTransaction.mockReturnValueOnce(mockPostTransactionResult);
-
-      result.current.checkoutCart();
-      await waitFor(() => {
-        expect(result.current.cartState).toBe("PURCHASED");
-      });
-
-      expect(result.current.cart).toStrictEqual([
-        {
-          category: "toilet-paper",
-          descriptionAlert: undefined,
-          lastTransactionTime: transactionTime,
-          identifierInputs: [], // present in the cart but removed before sending the transaction
-          maxQuantity: 2,
-          quantity: 1,
-        },
-        {
-          category: "chocolate",
-          descriptionAlert: undefined,
-          lastTransactionTime: transactionTime,
-          identifierInputs: [],
-          maxQuantity: 15,
-          quantity: 0,
-        },
-      ]);
-
-      expect(mockPostTransaction.mock.calls[0][0].transactions).toStrictEqual([
-        {
-          category: "toilet-paper",
-          quantity: 1,
-          identifierInputs: undefined,
-        },
-      ]);
-    });
-
     it("should not be able to complete a transaction without going through checkoutCart", async () => {
       expect.assertions(3);
       const ids = ["ID1"];

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -311,10 +311,7 @@ export const useCart = (
           return {
             category,
             quantity,
-            identifierInputs:
-              cleanedIdentifierInputs.length === 0
-                ? undefined
-                : cleanedIdentifierInputs,
+            identifierInputs: cleanedIdentifierInputs,
           };
         });
       try {
@@ -381,23 +378,26 @@ export const useCart = (
     const checkout = async (): Promise<void> => {
       setCartState("CHECKING_OUT");
       const allCleanedIdentifierInputs: IdentifierInput[] = [];
-      const transactions = Object.values(cart).filter(
-        ({ quantity }) => quantity
-      );
+      const transactions = Object.values(cart)
+        .filter(({ quantity }) => quantity)
+        .map(({ category, quantity, identifierInputs }) => {
+          const cleanedIdentifierInputs = identifierInputs.map((identifier) => {
+            cleanIdentifierInput(identifier);
+            tagOptionalIdentifierInput(
+              identifier,
+              category,
+              optionalIdentifierLabels
+            );
+            return identifier;
+          });
 
-      transactions.forEach(({ category, identifierInputs }) => {
-        const cleanedIdentifierInputs = identifierInputs.map((identifier) => {
-          cleanIdentifierInput(identifier);
-          tagOptionalIdentifierInput(
-            identifier,
+          allCleanedIdentifierInputs.push(...cleanedIdentifierInputs);
+          return {
             category,
-            optionalIdentifierLabels
-          );
-          return identifier;
+            quantity,
+            identifierInputs: cleanedIdentifierInputs,
+          };
         });
-
-        allCleanedIdentifierInputs.push(...cleanedIdentifierInputs);
-      });
 
       if (transactions.length === 0) {
         setCartState("DEFAULT");


### PR DESCRIPTION
Reverts rationally-app/mobile-application#429