### PR TITLE
revert: Revert "feat: use securestore for config" [deployment]

### DIFF
--- a/src/context/authStore.tsx
+++ b/src/context/authStore.tsx
@@ -137,7 +137,7 @@ export const AuthStoreContextProvider: FunctionComponent<{
      * old storage locations.
      * @param newStorageHasData whether most recent data has been found. If this is true, does not
      * attempt any migration and just clears old storage locations
-     * @returns the updated value of {@link newStorageHasData}, i.e. true if any updated data was found
+     * @returns the updated value of {@link hasUpdatedData}, i.e. true if any updated data was found
      * in the older storage (if {@link newStorageHasData} was passed in as true, it will always return true)
      */
     const migrateOldAuthFromStore = async (

--- a/src/context/campaignConfigsStore.test.tsx
+++ b/src/context/campaignConfigsStore.test.tsx
@@ -8,29 +8,9 @@ import { Text, Button } from "react-native";
 import { Sentry } from "../utils/errorTracking";
 import { ErrorBoundary } from "../components/ErrorBoundary/ErrorBoundary";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import {
-  readFromStoreInBuckets,
-  saveToStoreInBuckets,
-} from "../utils/bucketStorageHelper";
 
-jest.mock("../utils/bucketStorageHelper");
-
-const mockGetItem = AsyncStorage.getItem as jest.MockedFunction<
-  typeof AsyncStorage.getItem
->;
-const mockSetItem = AsyncStorage.setItem as jest.MockedFunction<
-  typeof AsyncStorage.setItem
->;
-const mockRemoveItem = AsyncStorage.removeItem as jest.MockedFunction<
-  typeof AsyncStorage.removeItem
->;
-
-const mockReadBucket = readFromStoreInBuckets as jest.MockedFunction<
-  typeof readFromStoreInBuckets
->;
-const mockWriteBucket = saveToStoreInBuckets as jest.MockedFunction<
-  typeof saveToStoreInBuckets
->;
+const mockGetItem = AsyncStorage.getItem as jest.Mock;
+const mockSetItem = AsyncStorage.setItem as jest.Mock;
 
 jest.mock("../utils/errorTracking");
 const mockCaptureException = jest.fn();
@@ -40,25 +20,19 @@ const testCampaignKey = "test-campaign";
 
 describe("CampaignConfigsStoreContextProvider", () => {
   beforeEach(() => {
-    mockGetItem.mockReset().mockName("asyncGetItem");
-    mockSetItem.mockReset().mockName("asyncSetItem");
-    mockRemoveItem.mockReset().mockName("asyncRemoveItem");
-    mockReadBucket.mockReset().mockName("bucketReadItem");
-    mockWriteBucket
-      .mockReset()
-      .mockName("bucketWriteItem")
-      .mockResolvedValue(undefined);
+    mockGetItem.mockReset();
+    mockSetItem.mockReset();
     mockCaptureException.mockReset();
   });
 
   it("should load the campaign configs from the store if it exists", async () => {
     expect.assertions(7);
-    mockReadBucket.mockResolvedValueOnce(
+    mockGetItem.mockImplementationOnce(() =>
       JSON.stringify({
         [testCampaignKey]: {
-          features: { validFeature: "validFeature" },
-          policies: [{ validPolicy: "validPolicy" }],
-          c13n: { validTranslation: "validTranslation" },
+          features: { asd: "asd" },
+          policies: [{ sdf: "sdf" }],
+          c13n: { asdi: "asdi" },
         },
       })
     );
@@ -86,27 +60,19 @@ describe("CampaignConfigsStoreContextProvider", () => {
       </CampaignConfigsStoreContextProvider>
     );
 
-    expect(mockReadBucket).toHaveBeenCalledTimes(1);
-    expect(mockReadBucket).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
+    expect(mockGetItem).toHaveBeenCalledTimes(1);
+    expect(mockGetItem).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
     expect(queryByTestId("loaded")).toBeNull();
     await waitFor(() => {
-      expect(queryByTestId("features")).toHaveTextContent(
-        `{"validFeature":"validFeature"}`
-      );
-      expect(queryByTestId("policies")).toHaveTextContent(
-        `[{"validPolicy":"validPolicy"}]`
-      );
-      expect(queryByTestId("c13n")).toHaveTextContent(
-        `{"validTranslation":"validTranslation"}`
-      );
+      expect(queryByTestId("features")).toHaveTextContent(`{"asd":"asd"}`);
+      expect(queryByTestId("policies")).toHaveTextContent(`[{"sdf":"sdf"}]`);
+      expect(queryByTestId("c13n")).toHaveTextContent(`{"asdi":"asdi"}`);
       expect(queryByTestId("loaded")).toHaveTextContent("true");
     });
   });
 
   it("should not set configs if it doesn't exist in the store", async () => {
     expect.assertions(5);
-
-    mockReadBucket.mockResolvedValueOnce("{}");
 
     const { queryByTestId } = render(
       <CampaignConfigsStoreContextProvider>
@@ -128,8 +94,8 @@ describe("CampaignConfigsStoreContextProvider", () => {
       </CampaignConfigsStoreContextProvider>
     );
 
-    expect(mockReadBucket).toHaveBeenCalledTimes(1);
-    expect(mockReadBucket).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
+    expect(mockGetItem).toHaveBeenCalledTimes(1);
+    expect(mockGetItem).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
 
     await waitFor(() => {
       expect(queryByTestId("features")).toHaveTextContent("");
@@ -140,7 +106,7 @@ describe("CampaignConfigsStoreContextProvider", () => {
 
   it("should call Sentry when the campaign config from the store is malformed", async () => {
     expect.assertions(3);
-    mockReadBucket.mockResolvedValueOnce("malformed object");
+    mockGetItem.mockImplementationOnce(() => "malformed object");
 
     render(
       <ErrorBoundary>
@@ -156,8 +122,8 @@ describe("CampaignConfigsStoreContextProvider", () => {
       </ErrorBoundary>
     );
 
-    expect(mockReadBucket).toHaveBeenCalledTimes(1);
-    expect(mockReadBucket).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
+    expect(mockGetItem).toHaveBeenCalledTimes(1);
+    expect(mockGetItem).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
 
     await waitFor(() => {
       expect(mockCaptureException).toHaveBeenCalledTimes(1);
@@ -166,12 +132,12 @@ describe("CampaignConfigsStoreContextProvider", () => {
 
   it("should clear the campaign configs and from asyncstorage when clear function is called", async () => {
     expect.assertions(10);
-    mockReadBucket.mockResolvedValueOnce(
+    mockGetItem.mockImplementationOnce(() =>
       JSON.stringify({
         [testCampaignKey]: {
-          features: { validFeature: "validFeature" },
-          policies: [{ validPolicy: "validPolicy" }],
-          c13n: { validTranslation: "validTranslation" },
+          features: { asd: "asd" },
+          policies: [{ sdf: "sdf" }],
+          c13n: { asdi: "asdi" },
         },
       })
     );
@@ -200,36 +166,20 @@ describe("CampaignConfigsStoreContextProvider", () => {
       </CampaignConfigsStoreContextProvider>
     );
 
-    expect(mockReadBucket).toHaveBeenCalledTimes(1);
-    expect(mockReadBucket).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
+    expect(mockGetItem).toHaveBeenCalledTimes(1);
+    expect(mockGetItem).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
 
     await waitFor(() => {
-      expect(queryByTestId("features")).toHaveTextContent(
-        `{"validFeature":"validFeature"}`
-      );
-      expect(queryByTestId("policies")).toHaveTextContent(
-        `[{"validPolicy":"validPolicy"}]`
-      );
-      expect(queryByTestId("c13n")).toHaveTextContent(
-        `{"validTranslation":"validTranslation"}`
-      );
+      expect(queryByTestId("features")).toHaveTextContent(`{"asd":"asd"}`);
+      expect(queryByTestId("policies")).toHaveTextContent(`[{"sdf":"sdf"}]`);
+      expect(queryByTestId("c13n")).toHaveTextContent(`{"asdi":"asdi"}`);
     });
 
     const button = getByText("test button");
     fireEvent.press(button);
     await waitFor(() => {
-      expect(mockWriteBucket).toHaveBeenCalledTimes(1);
-      expect(mockWriteBucket).toHaveBeenCalledWith(
-        "CAMPAIGN_CONFIGS_STORE",
-        "{}",
-        JSON.stringify({
-          [testCampaignKey]: {
-            features: { validFeature: "validFeature" },
-            policies: [{ validPolicy: "validPolicy" }],
-            c13n: { validTranslation: "validTranslation" },
-          },
-        })
-      );
+      expect(mockSetItem).toHaveBeenCalledTimes(1);
+      expect(mockSetItem).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE", "{}");
       expect(queryByTestId("features")).toHaveTextContent("");
       expect(queryByTestId("policies")).toHaveTextContent("");
       expect(queryByTestId("c13n")).toHaveTextContent("");
@@ -238,12 +188,12 @@ describe("CampaignConfigsStoreContextProvider", () => {
 
   it("should add a campaign config properly", async () => {
     expect.assertions(10);
-    mockReadBucket.mockResolvedValueOnce(
+    mockGetItem.mockImplementationOnce(() =>
       JSON.stringify({
         [testCampaignKey]: {
-          features: { validFeature: "validFeature" },
-          policies: [{ validPolicy: "validPolicy" }],
-          c13n: { validTranslation: "validTranslation" },
+          features: { asd: "asd" },
+          policies: [{ sdf: "sdf" }],
+          c13n: { asdi: "asdi" },
         },
       })
     );
@@ -265,9 +215,9 @@ describe("CampaignConfigsStoreContextProvider", () => {
               <Button
                 onPress={() =>
                   setCampaignConfig(testCampaignKey, {
-                    features: { newFeature: "newFeature" },
-                    policies: [{ newPolicy: "newPolicy" }],
-                    c13n: { newTranslation: "newTranslation" },
+                    features: { new: "new" },
+                    policies: [{ new: "new" }],
+                    c13n: { new: "new" },
                   } as any)
                 }
                 title="test button"
@@ -278,67 +228,48 @@ describe("CampaignConfigsStoreContextProvider", () => {
       </CampaignConfigsStoreContextProvider>
     );
 
-    expect(mockReadBucket).toHaveBeenCalledTimes(1);
-    expect(mockReadBucket).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
+    expect(mockGetItem).toHaveBeenCalledTimes(1);
+    expect(mockGetItem).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
 
     await waitFor(() => {
-      expect(queryByTestId("features")).toHaveTextContent(
-        `{"validFeature":"validFeature"}`
-      );
-      expect(queryByTestId("policies")).toHaveTextContent(
-        `[{"validPolicy":"validPolicy"}]`
-      );
-      expect(queryByTestId("c13n")).toHaveTextContent(
-        `{"validTranslation":"validTranslation"}`
-      );
+      expect(queryByTestId("features")).toHaveTextContent(`{"asd":"asd"}`);
+      expect(queryByTestId("policies")).toHaveTextContent(`[{"sdf":"sdf"}]`);
+      expect(queryByTestId("c13n")).toHaveTextContent(`{"asdi":"asdi"}`);
     });
 
     const button = getByText("test button");
     fireEvent.press(button);
     await waitFor(() => {
-      expect(mockWriteBucket).toHaveBeenCalledTimes(1);
-      expect(mockWriteBucket).toHaveBeenCalledWith(
+      expect(mockSetItem).toHaveBeenCalledTimes(1);
+      expect(mockSetItem).toHaveBeenCalledWith(
         "CAMPAIGN_CONFIGS_STORE",
         JSON.stringify({
           [testCampaignKey]: {
-            features: { newFeature: "newFeature" },
-            policies: [{ newPolicy: "newPolicy" }],
-            c13n: { newTranslation: "newTranslation" },
-          },
-        }),
-        JSON.stringify({
-          [testCampaignKey]: {
-            features: { validFeature: "validFeature" },
-            policies: [{ validPolicy: "validPolicy" }],
-            c13n: { validTranslation: "validTranslation" },
+            features: { new: "new" },
+            policies: [{ new: "new" }],
+            c13n: { new: "new" },
           },
         })
       );
-      expect(queryByTestId("features")).toHaveTextContent(
-        `{"newFeature":"newFeature"}`
-      );
-      expect(queryByTestId("policies")).toHaveTextContent(
-        `[{"newPolicy":"newPolicy"}]`
-      );
-      expect(queryByTestId("c13n")).toHaveTextContent(
-        `{"newTranslation":"newTranslation"}`
-      );
+      expect(queryByTestId("features")).toHaveTextContent(`{"new":"new"}`);
+      expect(queryByTestId("policies")).toHaveTextContent(`[{"new":"new"}]`);
+      expect(queryByTestId("c13n")).toHaveTextContent(`{"new":"new"}`);
     });
   });
 
   it("should add a campaign config properly when there are existing configs for other campaigns", async () => {
     expect.assertions(6);
-    mockReadBucket.mockResolvedValueOnce(
+    mockGetItem.mockImplementationOnce(() =>
       JSON.stringify({
         [testCampaignKey]: {
-          features: { validFeature: "validFeature" },
-          policies: [{ validPolicy: "validPolicy" }],
-          c13n: { validTranslation: "validTranslation" },
+          features: { asd: "asd" },
+          policies: [{ sdf: "sdf" }],
+          c13n: { asdi: "asdi" },
         },
         "another-test-campaign": {
-          features: { validFeature: "anotherFeature" },
-          policies: [{ validPolicy: "anotherPolicy" }],
-          c13n: { validTranslation: "anotherTranslation" },
+          features: { dfg: "dfg" },
+          policies: [{ sdf: "sdf" }],
+          c13n: { asdi: "asdi" },
         },
       })
     );
@@ -352,9 +283,9 @@ describe("CampaignConfigsStoreContextProvider", () => {
               <Button
                 onPress={() =>
                   setCampaignConfig(testCampaignKey, {
-                    features: { newFeature: "newFeature" },
-                    policies: [{ newPolicy: "newPolicy" }],
-                    c13n: { newTranslation: "newTranslation" },
+                    features: { new: "new" },
+                    policies: [{ new: "new" }],
+                    c13n: { new: "new" },
                   } as any)
                 }
                 title="test button"
@@ -365,60 +296,48 @@ describe("CampaignConfigsStoreContextProvider", () => {
       </CampaignConfigsStoreContextProvider>
     );
 
-    expect(mockReadBucket).toHaveBeenCalledTimes(1);
-    expect(mockReadBucket).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
+    expect(mockGetItem).toHaveBeenCalledTimes(1);
+    expect(mockGetItem).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
 
     await waitFor(() => {
       expect(queryByTestId("configs")).toHaveTextContent(
-        `{"test-campaign":{"features":{"validFeature":"validFeature"},"policies":[{"validPolicy":"validPolicy"}],"c13n":{"validTranslation":"validTranslation"}},"another-test-campaign":{"features":{"validFeature":"anotherFeature"},"policies":[{"validPolicy":"anotherPolicy"}],"c13n":{"validTranslation":"anotherTranslation"}}}`
+        `{"test-campaign":{"features":{"asd":"asd"},"policies":[{"sdf":"sdf"}],"c13n":{"asdi":"asdi"}},"another-test-campaign":{"features":{"dfg":"dfg"},"policies":[{"sdf":"sdf"}],"c13n":{"asdi":"asdi"}}}`
       );
     });
 
     const button = getByText("test button");
     fireEvent.press(button);
     await waitFor(() => {
-      expect(mockWriteBucket).toHaveBeenCalledTimes(1);
-      expect(mockWriteBucket).toHaveBeenCalledWith(
+      expect(mockSetItem).toHaveBeenCalledTimes(1);
+      expect(mockSetItem).toHaveBeenCalledWith(
         "CAMPAIGN_CONFIGS_STORE",
         JSON.stringify({
           [testCampaignKey]: {
-            features: { newFeature: "newFeature" },
-            policies: [{ newPolicy: "newPolicy" }],
-            c13n: { newTranslation: "newTranslation" },
+            features: { new: "new" },
+            policies: [{ new: "new" }],
+            c13n: { new: "new" },
           },
           "another-test-campaign": {
-            features: { validFeature: "anotherFeature" },
-            policies: [{ validPolicy: "anotherPolicy" }],
-            c13n: { validTranslation: "anotherTranslation" },
-          },
-        }),
-        JSON.stringify({
-          [testCampaignKey]: {
-            features: { validFeature: "validFeature" },
-            policies: [{ validPolicy: "validPolicy" }],
-            c13n: { validTranslation: "validTranslation" },
-          },
-          "another-test-campaign": {
-            features: { validFeature: "anotherFeature" },
-            policies: [{ validPolicy: "anotherPolicy" }],
-            c13n: { validTranslation: "anotherTranslation" },
+            features: { dfg: "dfg" },
+            policies: [{ sdf: "sdf" }],
+            c13n: { asdi: "asdi" },
           },
         })
       );
       expect(queryByTestId("configs")).toHaveTextContent(
-        `{"test-campaign":{"features":{"newFeature":"newFeature"},"policies":[{"newPolicy":"newPolicy"}],"c13n":{"newTranslation":"newTranslation"}},"another-test-campaign":{"features":{"validFeature":"anotherFeature"},"policies":[{"validPolicy":"anotherPolicy"}],"c13n":{"validTranslation":"anotherTranslation"}}}`
+        `{"test-campaign":{"features":{"new":"new"},"policies":[{"new":"new"}],"c13n":{"new":"new"}},"another-test-campaign":{"features":{"dfg":"dfg"},"policies":[{"sdf":"sdf"}],"c13n":{"asdi":"asdi"}}}`
       );
     });
   });
 
   it("should add the campaign config properly when some null keys are input", async () => {
     expect.assertions(10);
-    mockReadBucket.mockResolvedValueOnce(
+    mockGetItem.mockImplementationOnce(() =>
       JSON.stringify({
         [testCampaignKey]: {
-          features: { validFeature: "validFeature" },
-          policies: [{ validPolicy: "validPolicy" }],
-          c13n: { validTranslation: "validTranslation" },
+          features: { asd: "asd" },
+          policies: [{ sdf: "sdf" }],
+          c13n: { asdi: "asdi" },
         },
       })
     );
@@ -441,8 +360,8 @@ describe("CampaignConfigsStoreContextProvider", () => {
                 onPress={() =>
                   setCampaignConfig(testCampaignKey, {
                     features: null,
-                    policies: [{ newPolicy: "newPolicy" }],
-                    c13n: { validTranslation: "validTranslation" },
+                    policies: [{ new: "new" }],
+                    c13n: { asdi: "asdi" },
                   } as any)
                 }
                 title="test button"
@@ -453,62 +372,43 @@ describe("CampaignConfigsStoreContextProvider", () => {
       </CampaignConfigsStoreContextProvider>
     );
 
-    expect(mockReadBucket).toHaveBeenCalledTimes(1);
-    expect(mockReadBucket).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
+    expect(mockGetItem).toHaveBeenCalledTimes(1);
+    expect(mockGetItem).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
 
     await waitFor(() => {
-      expect(queryByTestId("features")).toHaveTextContent(
-        `{"validFeature":"validFeature"}`
-      );
-      expect(queryByTestId("policies")).toHaveTextContent(
-        `[{"validPolicy":"validPolicy"}]`
-      );
-      expect(queryByTestId("c13n")).toHaveTextContent(
-        `{"validTranslation":"validTranslation"}`
-      );
+      expect(queryByTestId("features")).toHaveTextContent(`{"asd":"asd"}`);
+      expect(queryByTestId("policies")).toHaveTextContent(`[{"sdf":"sdf"}]`);
+      expect(queryByTestId("c13n")).toHaveTextContent(`{"asdi":"asdi"}`);
     });
 
     const button = getByText("test button");
     fireEvent.press(button);
     await waitFor(() => {
-      expect(mockWriteBucket).toHaveBeenCalledTimes(1);
-      expect(mockWriteBucket).toHaveBeenCalledWith(
+      expect(mockSetItem).toHaveBeenCalledTimes(1);
+      expect(mockSetItem).toHaveBeenCalledWith(
         "CAMPAIGN_CONFIGS_STORE",
         JSON.stringify({
           [testCampaignKey]: {
-            features: { validFeature: "validFeature" },
-            policies: [{ newPolicy: "newPolicy" }],
-            c13n: { validTranslation: "validTranslation" },
-          },
-        }),
-        JSON.stringify({
-          [testCampaignKey]: {
-            features: { validFeature: "validFeature" },
-            policies: [{ validPolicy: "validPolicy" }],
-            c13n: { validTranslation: "validTranslation" },
+            features: { asd: "asd" },
+            policies: [{ new: "new" }],
+            c13n: { asdi: "asdi" },
           },
         })
       );
-      expect(queryByTestId("features")).toHaveTextContent(
-        `{"validFeature":"validFeature"}`
-      );
-      expect(queryByTestId("policies")).toHaveTextContent(
-        `[{"newPolicy":"newPolicy"}]`
-      );
-      expect(queryByTestId("c13n")).toHaveTextContent(
-        `{"validTranslation":"validTranslation"}`
-      );
+      expect(queryByTestId("features")).toHaveTextContent(`{"asd":"asd"}`);
+      expect(queryByTestId("policies")).toHaveTextContent(`[{"new":"new"}]`);
+      expect(queryByTestId("c13n")).toHaveTextContent(`{"asdi":"asdi"}`);
     });
   });
 
   it("should remove a campaign config properly", async () => {
     expect.assertions(10);
-    mockReadBucket.mockResolvedValueOnce(
+    mockGetItem.mockImplementationOnce(() =>
       JSON.stringify({
         [testCampaignKey]: {
-          features: { validFeature: "validFeature" },
-          policies: [{ validPolicy: "validPolicy" }],
-          c13n: { validTranslation: "validTranslation" },
+          features: { asd: "asd" },
+          policies: [{ sdf: "sdf" }],
+          c13n: { asdi: "asdi" },
         },
       })
     );
@@ -538,160 +438,23 @@ describe("CampaignConfigsStoreContextProvider", () => {
       </CampaignConfigsStoreContextProvider>
     );
 
-    expect(mockReadBucket).toHaveBeenCalledTimes(1);
-    expect(mockReadBucket).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
+    expect(mockGetItem).toHaveBeenCalledTimes(1);
+    expect(mockGetItem).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
 
     await waitFor(() => {
-      expect(queryByTestId("features")).toHaveTextContent(
-        `{"validFeature":"validFeature"}`
-      );
-      expect(queryByTestId("policies")).toHaveTextContent(
-        `[{"validPolicy":"validPolicy"}]`
-      );
-      expect(queryByTestId("c13n")).toHaveTextContent(
-        `{"validTranslation":"validTranslation"}`
-      );
+      expect(queryByTestId("features")).toHaveTextContent(`{"asd":"asd"}`);
+      expect(queryByTestId("policies")).toHaveTextContent(`[{"sdf":"sdf"}]`);
+      expect(queryByTestId("c13n")).toHaveTextContent(`{"asdi":"asdi"}`);
     });
 
     const button = getByText("test button");
     fireEvent.press(button);
     await waitFor(() => {
-      expect(mockWriteBucket).toHaveBeenCalledTimes(1);
-      expect(mockWriteBucket).toHaveBeenCalledWith(
-        "CAMPAIGN_CONFIGS_STORE",
-        "{}",
-        JSON.stringify({
-          [testCampaignKey]: {
-            features: { validFeature: "validFeature" },
-            policies: [{ validPolicy: "validPolicy" }],
-            c13n: { validTranslation: "validTranslation" },
-          },
-        })
-      );
+      expect(mockSetItem).toHaveBeenCalledTimes(1);
+      expect(mockSetItem).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE", "{}");
       expect(queryByTestId("features")).toHaveTextContent("");
       expect(queryByTestId("policies")).toHaveTextContent("");
       expect(queryByTestId("c13n")).toHaveTextContent("");
-    });
-  });
-
-  describe("migration from v1 to v2 storage", () => {
-    it("should clear v1 storage if there is data in later storage without querying v1 for data", async () => {
-      expect.assertions(7);
-      mockReadBucket.mockResolvedValueOnce(
-        JSON.stringify({
-          [testCampaignKey]: {
-            features: { validFeature: "validFeature" },
-            policies: [{ validPolicy: "validPolicy" }],
-            c13n: { validTranslation: "validTranslation" },
-          },
-        })
-      );
-
-      const { queryByTestId, getByTestId } = render(
-        <CampaignConfigsStoreContextProvider>
-          <CampaignConfigsStoreContext.Consumer>
-            {({ hasLoadedFromStore, allCampaignConfigs }) => (
-              <>
-                {hasLoadedFromStore && (
-                  <Text testID="loaded">{`${hasLoadedFromStore}`}</Text>
-                )}
-                <Text testID="features">
-                  {JSON.stringify(
-                    allCampaignConfigs[testCampaignKey]?.features
-                  )}
-                </Text>
-                <Text testID="policies">
-                  {JSON.stringify(
-                    allCampaignConfigs[testCampaignKey]?.policies
-                  )}
-                </Text>
-                <Text testID="c13n">
-                  {JSON.stringify(allCampaignConfigs[testCampaignKey]?.c13n)}
-                </Text>
-              </>
-            )}
-          </CampaignConfigsStoreContext.Consumer>
-        </CampaignConfigsStoreContextProvider>
-      );
-
-      expect(mockReadBucket).toHaveBeenCalledTimes(1);
-      expect(mockReadBucket).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
-      expect(queryByTestId("loaded")).toBeNull();
-
-      expect(await waitFor(() => getByTestId("loaded"))).toHaveTextContent(
-        "true"
-      );
-
-      expect(mockGetItem).not.toHaveBeenCalled();
-      expect(mockRemoveItem).toHaveBeenCalledTimes(1);
-      expect(mockRemoveItem).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
-    });
-
-    it("should use v1 storage credentials and migrate to latest store if all later versions are empty", async () => {
-      expect.assertions(10);
-      mockReadBucket.mockResolvedValueOnce(null);
-      mockGetItem.mockResolvedValueOnce(
-        JSON.stringify({
-          [testCampaignKey]: {
-            features: { validFeature: "validFeature" },
-            policies: [{ validPolicy: "validPolicy" }],
-            c13n: { validTranslation: "validTranslation" },
-          },
-        })
-      );
-
-      const { queryByTestId, getByTestId } = render(
-        <CampaignConfigsStoreContextProvider>
-          <CampaignConfigsStoreContext.Consumer>
-            {({ hasLoadedFromStore, allCampaignConfigs }) => (
-              <>
-                {hasLoadedFromStore && (
-                  <Text testID="loaded">{`${hasLoadedFromStore}`}</Text>
-                )}
-                <Text testID="features">
-                  {JSON.stringify(
-                    allCampaignConfigs[testCampaignKey]?.features
-                  )}
-                </Text>
-                <Text testID="policies">
-                  {JSON.stringify(
-                    allCampaignConfigs[testCampaignKey]?.policies
-                  )}
-                </Text>
-                <Text testID="c13n">
-                  {JSON.stringify(allCampaignConfigs[testCampaignKey]?.c13n)}
-                </Text>
-              </>
-            )}
-          </CampaignConfigsStoreContext.Consumer>
-        </CampaignConfigsStoreContextProvider>
-      );
-
-      expect(mockReadBucket).toHaveBeenCalledTimes(1);
-      expect(mockReadBucket).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
-      expect(queryByTestId("loaded")).toBeNull();
-
-      expect(await waitFor(() => getByTestId("loaded"))).toHaveTextContent(
-        "true"
-      );
-
-      expect(mockGetItem).toHaveBeenCalledTimes(1);
-      expect(mockGetItem).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
-      expect(mockRemoveItem).toHaveBeenCalledTimes(1);
-      expect(mockRemoveItem).toHaveBeenCalledWith("CAMPAIGN_CONFIGS_STORE");
-
-      expect(mockWriteBucket).toHaveBeenCalledTimes(1);
-      expect(mockWriteBucket).toHaveBeenCalledWith(
-        "CAMPAIGN_CONFIGS_STORE",
-        JSON.stringify({
-          [testCampaignKey]: {
-            features: { validFeature: "validFeature" },
-            policies: [{ validPolicy: "validPolicy" }],
-            c13n: { validTranslation: "validTranslation" },
-          },
-        }),
-        "{}"
-      );
     });
   });
 });

--- a/src/hooks/useTranslate/useTranslate.test.tsx
+++ b/src/hooks/useTranslate/useTranslate.test.tsx
@@ -9,12 +9,9 @@ import {
 import { defaultFeatures, defaultProducts } from "../../test/helpers/defaults";
 import { TranslationHook, useTranslate } from "./useTranslate";
 import "../../common/i18n/i18nMock";
-import { readFromStoreInBuckets } from "../../utils/bucketStorageHelper";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
-jest.mock("../../utils/bucketStorageHelper");
-const mockReadBucket = readFromStoreInBuckets as jest.MockedFunction<
-  typeof readFromStoreInBuckets
->;
+const mockGetItem = AsyncStorage.getItem as jest.Mock;
 
 describe("useTranslate", () => {
   let allCampaignConfigs: CampaignConfigsMap;
@@ -45,7 +42,7 @@ describe("useTranslate", () => {
         },
       },
     };
-    mockReadBucket.mockResolvedValue(JSON.stringify(allCampaignConfigs));
+    mockGetItem.mockImplementation(() => JSON.stringify(allCampaignConfigs));
   });
 
   describe("c13nt", () => {


### PR DESCRIPTION
Reverts rationally-app/mobile-application#419