### PR TITLE
build: fix deploy prod url

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Parse Asset URL
         id: androidUrl
         run: |
-          ASSET_URL=$(cat buildLogAndroid.txt | tail | egrep -o 'https?://expo\.io/artifacts/[^ ]+')
+          ASSET_URL=$(cat buildLogAndroid.txt | tail | egrep -o 'https?://expo\.dev/artifacts/[^ ]+')
           echo The android url is $ASSET_URL
           echo "::set-output name=assetUrl::$ASSET_URL"
       - name: Download APK Asset
@@ -183,7 +183,7 @@ jobs:
       - name: Parse Asset URL
         id: iosUrl
         run: |
-          ASSET_URL=$(cat buildLogIOS.txt | tail | egrep -o 'https?://expo\.io/artifacts/[^ ]+')
+          ASSET_URL=$(cat buildLogIOS.txt | tail | egrep -o 'https?://expo\.dev/artifacts/[^ ]+')
           echo The IOS url is $ASSET_URL
           echo "::set-output name=assetUrl::$ASSET_URL"
       - name: Download IPA Asset


### PR DESCRIPTION
Expo changed their domain TLD to .dev

Found out by looking at the difference between the last 2 deploys:
(success)
`[03:07:30] Successfully built standalone app: https://expo.io/artifacts/8aa9a7b7-2197-49cc-9350-0c963205ebd6`
vs
(failure)
`[03:08:51] Successfully built standalone app: https://expo.dev/artifacts/9eb33980-0605-4086-a82e-743f849e6876`

Turns out expo changed domain: https://github.com/expo/expo-cli/pull/3771

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
