### PR TITLE
build: replace musket-dev with supplyally-bot

### DIFF
--- a/.github/workflows/deploy_branch_preview.yml
+++ b/.github/workflows/deploy_branch_preview.yml
@@ -18,7 +18,7 @@ jobs:
       - name: check if PR title follows conventional commits specs
         uses: amannn/action-semantic-pull-request@v3.4.2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_SUPPLYALLY_BOT }}
   test:
     name: Lint & Test
     runs-on: ubuntu-18.04
@@ -118,7 +118,7 @@ jobs:
       - name: Add Comment To PR
         uses: mshick/add-pr-comment@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_SUPPLYALLY_BOT }}
           EXPO_PROJECT: "@supplyallytest/rationally"
         with:
           message: |

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -101,7 +101,7 @@ jobs:
         id: changelog
         uses: metcalfc/changelog-generator@v1.0.0
         with:
-          myToken: ${{ secrets.GITHUB_TOKEN }}
+          myToken: ${{ secrets.GH_TOKEN_SUPPLYALLY_BOT }}
           head-ref: ${{ steps.setTags.outputs.latestTag }}
           base-ref: ${{ steps.setTags.outputs.previousTag }}
       - name: Creating Release
@@ -110,7 +110,7 @@ jobs:
           body: |
             Changes in this Release: 
             ${{ steps.changelog.outputs.changelog }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN_SUPPLYALLY_BOT }}
           name: Release ${{ env.GITHUB_REF_SLUG }}
           allowUpdates: true
   build_android:
@@ -150,7 +150,7 @@ jobs:
       - name: Upload Release Asset
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GH_TOKEN_SUPPLYALLY_BOT }}
           file: ./supplyally-${{ env.GITHUB_REF_SLUG }}.apk
           asset_name: supplyally-${{ env.GITHUB_REF_SLUG }}.apk
           tag: ${{ github.ref }}
@@ -191,7 +191,7 @@ jobs:
       - name: Upload Release Asset
         uses: svenstaro/upload-release-action@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GH_TOKEN_SUPPLYALLY_BOT }}
           file: ./supplyally-${{ env.GITHUB_REF_SLUG }}.ipa
           asset_name: supplyally-${{ env.GITHUB_REF_SLUG }}.ipa
           tag: ${{ github.ref }}

--- a/.github/workflows/test_e2e.yml
+++ b/.github/workflows/test_e2e.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: "rationally-app/mobile-e2e"
-          token: ${{ secrets.MUSKET_DEV_GITHUB_ACCESS_TOKEN }}
+          token: ${{ secrets.GH_TOKEN_SUPPLYALLY_BOT }}
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you're releasing this for the first time, you need to create a tag to specify
 ```
 uses: metcalfc/changelog-generator@v0.4.0
 with:
-   myToken: ${{ secrets.GITHUB_TOKEN }}
+   myToken: ${{ secrets.GH_TOKEN_SUPPLYALLY_BOT }}
    base-ref: <base-tag> # e.g. prod-0
 ```
 


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Deprecate-musket-dev-e0334798edd94330b58b176b76cd82c7) <!-- Remove this link if no relevant Notion link -->

This PR replaces usage of `musket-dev` bot user with `supplyally-bot` in our build workflows.

Also replaced use of default `GITHUB_TOKEN` to be consistent.


<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
