### PR TITLE
feat: add payment_receipt to `tt-token` category

### DIFF
--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -12,6 +12,7 @@ import {
 import { CartHook, CartItem } from "../../../hooks/useCart/useCart";
 import { size } from "../../../common/styles";
 import { ProductContext } from "../../../context/products";
+import { IdentificationContext } from "../../../context/identification";
 
 const styles = StyleSheet.create({
   cartItemComponent: {
@@ -26,6 +27,7 @@ export const Item: FunctionComponent<{
   cartItem: CartItem;
   updateCart: CartHook["updateCart"];
 }> = ({ ids, addonToggleItem, cartItem, updateCart }) => {
+  const { selectedIdType } = useContext(IdentificationContext);
   const { getProduct } = useContext(ProductContext);
   const identifiers = getProduct(cartItem.category)?.identifiers || [];
 
@@ -36,7 +38,7 @@ export const Item: FunctionComponent<{
   // only applied for Pod distribution
   if (isPodCampaign(cartItem.category)) {
     // Pod distribution can only redeem for 1 user at a time
-    if (!isPodChargeable(ids[0], identifiers, cartItem)) {
+    if (!isPodChargeable(selectedIdType.validation, identifiers, cartItem)) {
       ({ newIdentifiers, newCartItem } = removePaymentReceiptField(
         identifiers,
         cartItem

--- a/src/components/CustomerQuota/ItemsSelection/Item.tsx
+++ b/src/components/CustomerQuota/ItemsSelection/Item.tsx
@@ -4,11 +4,14 @@ import { ItemCheckbox } from "./ItemCheckbox";
 import { ItemIdentifiersCard } from "./ItemIdentifiersCard";
 import { ItemNoQuota } from "./ItemNoQuota";
 import { ItemStepper } from "./ItemStepper";
+import {
+  isPodCampaign,
+  isPodChargeable,
+  removePaymentReceiptField,
+} from "../utils";
 import { CartHook, CartItem } from "../../../hooks/useCart/useCart";
 import { size } from "../../../common/styles";
 import { ProductContext } from "../../../context/products";
-import { PolicyIdentifier } from "../../../types";
-import { validate as validatePassport } from "../../../utils/validatePassport";
 
 const styles = StyleSheet.create({
   cartItemComponent: {
@@ -16,72 +19,6 @@ const styles = StyleSheet.create({
     marginHorizontal: -size(2),
   },
 });
-
-/**
- * Check if the campaign contains tt-token
- * to indicate pod campaign
- *
- * @param cartItemCategory category of item
- */
-const isPodCampaign = (cartItemCategory: string): boolean =>
-  cartItemCategory.includes("tt-token");
-
-/**
- * Check if pod is chargeable.
- *
- * Redemption of the first token is chargeable for passport customer.
- *
- * @param id customerId
- * @param identifiers policy identifiers
- * @param cartItem policy cart item
- */
-const isPodChargeable = (
-  id: string,
-  identifiers: PolicyIdentifier[],
-  cartItem: CartItem
-): boolean => {
-  if (identifiers.length > 0) {
-    if (cartItem.category.includes("tt-token-lost")) {
-      if (cartItem.descriptionAlert === "*chargeable") {
-        return true;
-      }
-    } else if (validatePassport(id)) {
-      if (cartItem.category.includes("tt-token")) {
-        if (cartItem.descriptionAlert === "*chargeable") {
-          return true;
-        }
-      }
-    }
-  }
-  return false;
-};
-
-/**
- * Filters out the payment receipt identifier if not required
- * which happens when pod is not chargeable
- * Shape of identifiers and cartItem.identifierInputs are slightly different and
- * hence require to filter separately
- *
- * @param identifiers identifiers that can be modified
- * @param cartItem cartItem containing identifiers that can be modified
- */
-const removePaymentReceiptField = (
-  identifiers: PolicyIdentifier[],
-  cartItem: CartItem
-): {
-  newIdentifiers: PolicyIdentifier[];
-  newCartItem: CartItem;
-} => {
-  identifiers = identifiers.filter(
-    (identifier: { label: string }) =>
-      identifier.label != "Payment receipt number"
-  );
-  cartItem.identifierInputs = cartItem.identifierInputs.filter(
-    (identifier) => identifier.label != "Payment receipt number"
-  );
-
-  return { newIdentifiers: identifiers, newCartItem: cartItem };
-};
 
 export const Item: FunctionComponent<{
   ids: string[];

--- a/src/components/CustomerQuota/utils.test.ts
+++ b/src/components/CustomerQuota/utils.test.ts
@@ -20,7 +20,6 @@ import {
 } from "./utils";
 import "../../common/i18n/i18nMock";
 import { CartItem } from "../../hooks/useCart/useCart";
-import { number } from "fp-ts";
 
 describe("formatQuantityText", () => {
   it("should return only the quantity when no unit is given", () => {

--- a/src/components/CustomerQuota/utils.test.ts
+++ b/src/components/CustomerQuota/utils.test.ts
@@ -362,6 +362,21 @@ describe("pod related utils", () => {
       ).toStrictEqual(true);
     });
 
+    it("should return false for tt-token-lost category if it's not *chargeable", () => {
+      expect.assertions(1);
+      validCartItem["category"] = "tt-token-lost";
+      expect(
+        isPodChargeable(customerId, validIdentifiers, validCartItem)
+      ).toStrictEqual(false);
+    });
+
+    it("should return false for non-pod category", () => {
+      expect.assertions(1);
+      expect(
+        isPodChargeable(customerId, validIdentifiers, validCartItem)
+      ).toStrictEqual(false);
+    });
+
     describe("for passport customer", () => {
       customerId = "AFG-A111111";
 
@@ -371,6 +386,13 @@ describe("pod related utils", () => {
         expect(
           isPodChargeable(customerId, validIdentifiers, validCartItem)
         ).toStrictEqual(true);
+      });
+
+      it("should return false for non-pod category", () => {
+        expect.assertions(1);
+        expect(
+          isPodChargeable(customerId, validIdentifiers, validCartItem)
+        ).toStrictEqual(false);
       });
     });
   });

--- a/src/components/CustomerQuota/utils.test.ts
+++ b/src/components/CustomerQuota/utils.test.ts
@@ -7,6 +7,7 @@ import {
   CampaignPolicy,
   PolicyIdentifier,
   IdentifierInput,
+  ValidationType,
 } from "../../types";
 import {
   formatQuantityText,
@@ -302,7 +303,7 @@ describe("pod related utils", () => {
     },
   ];
 
-  let customerId = "S0000001I";
+  let idType = "NRIC" as ValidationType;
   let validCartItem: CartItem;
   let validIdentifiers: PolicyIdentifier[];
   beforeEach(() => {
@@ -358,7 +359,7 @@ describe("pod related utils", () => {
       validCartItem["category"] = "tt-token-lost";
       validCartItem["descriptionAlert"] = "*chargeable";
       expect(
-        isPodChargeable(customerId, validIdentifiers, validCartItem)
+        isPodChargeable(idType, validIdentifiers, validCartItem)
       ).toStrictEqual(true);
     });
 
@@ -366,39 +367,37 @@ describe("pod related utils", () => {
       expect.assertions(1);
       validCartItem["category"] = "tt-token-lost";
       expect(
-        isPodChargeable(customerId, validIdentifiers, validCartItem)
+        isPodChargeable(idType, validIdentifiers, validCartItem)
       ).toStrictEqual(false);
     });
 
     it("should return false for non-pod category", () => {
       expect.assertions(1);
       expect(
-        isPodChargeable(customerId, validIdentifiers, validCartItem)
+        isPodChargeable(idType, validIdentifiers, validCartItem)
       ).toStrictEqual(false);
     });
 
     it("should return false if there are no identifiers", () => {
       expect.assertions(1);
-      expect(isPodChargeable(customerId, [], validCartItem)).toStrictEqual(
-        false
-      );
+      expect(isPodChargeable(idType, [], validCartItem)).toStrictEqual(false);
     });
 
     describe("for passport customer", () => {
-      customerId = "AFG-A111111";
+      idType = "PASSPORT";
 
       it("should return true for tt-token category", () => {
         expect.assertions(1);
         validCartItem["category"] = "tt-token";
         expect(
-          isPodChargeable(customerId, validIdentifiers, validCartItem)
+          isPodChargeable(idType, validIdentifiers, validCartItem)
         ).toStrictEqual(true);
       });
 
       it("should return false for non-pod category", () => {
         expect.assertions(1);
         expect(
-          isPodChargeable(customerId, validIdentifiers, validCartItem)
+          isPodChargeable(idType, validIdentifiers, validCartItem)
         ).toStrictEqual(false);
       });
     });

--- a/src/components/CustomerQuota/utils.test.ts
+++ b/src/components/CustomerQuota/utils.test.ts
@@ -377,6 +377,13 @@ describe("pod related utils", () => {
       ).toStrictEqual(false);
     });
 
+    it("should return false if there are no identifiers", () => {
+      expect.assertions(1);
+      expect(isPodChargeable(customerId, [], validCartItem)).toStrictEqual(
+        false
+      );
+    });
+
     describe("for passport customer", () => {
       customerId = "AFG-A111111";
 

--- a/src/components/CustomerQuota/utils.ts
+++ b/src/components/CustomerQuota/utils.ts
@@ -4,12 +4,12 @@ import {
   CampaignPolicy,
   PastTransactionsResult,
   PolicyIdentifier,
+  ValidationType,
 } from "../../types";
 import { getIdentifierInputDisplay } from "../../utils/getIdentifierInputDisplay";
 import { formatDateTime } from "../../utils/dateTimeFormatter";
 import { TranslationHook } from "../../hooks/useTranslate/useTranslate";
 import { CartItem } from "../../hooks/useCart/useCart";
-import { validate as validatePassport } from "../../utils/validatePassport";
 
 export const BIG_NUMBER = 99999;
 
@@ -157,7 +157,7 @@ export const isPodCampaign = (cartItemCategory: string): boolean =>
  * @param cartItem policy cart item
  */
 export const isPodChargeable = (
-  id: string,
+  idType: ValidationType,
   identifiers: PolicyIdentifier[],
   cartItem: CartItem
 ): boolean => {
@@ -166,7 +166,7 @@ export const isPodChargeable = (
       if (cartItem.descriptionAlert === "*chargeable") {
         return true;
       }
-    } else if (validatePassport(id)) {
+    } else if (idType === "PASSPORT") {
       if (cartItem.category.includes("tt-token")) {
         return true;
       }

--- a/src/components/CustomerQuota/utils.ts
+++ b/src/components/CustomerQuota/utils.ts
@@ -1,9 +1,15 @@
 import { differenceInSeconds } from "date-fns";
 import { Transaction, TransactionsGroup } from "./TransactionsGroup";
-import { CampaignPolicy, PastTransactionsResult } from "../../types";
+import {
+  CampaignPolicy,
+  PastTransactionsResult,
+  PolicyIdentifier,
+} from "../../types";
 import { getIdentifierInputDisplay } from "../../utils/getIdentifierInputDisplay";
 import { formatDateTime } from "../../utils/dateTimeFormatter";
 import { TranslationHook } from "../../hooks/useTranslate/useTranslate";
+import { CartItem } from "../../hooks/useCart/useCart";
+import { validate as validatePassport } from "../../utils/validatePassport";
 
 export const BIG_NUMBER = 99999;
 
@@ -130,4 +136,68 @@ export const groupTransactionsByCategory = (
   });
 
   return transactionsByCategoryMap;
+};
+
+/**
+ * Check if the campaign contains tt-token
+ * to indicate pod campaign
+ *
+ * @param cartItemCategory category of item
+ */
+export const isPodCampaign = (cartItemCategory: string): boolean =>
+  cartItemCategory.includes("tt-token");
+
+/**
+ * Check if pod is chargeable.
+ *
+ * Redemption of the first token is chargeable for passport customer.
+ *
+ * @param id customerId
+ * @param identifiers policy identifiers
+ * @param cartItem policy cart item
+ */
+export const isPodChargeable = (
+  id: string,
+  identifiers: PolicyIdentifier[],
+  cartItem: CartItem
+): boolean => {
+  if (identifiers.length > 0) {
+    if (cartItem.category.includes("tt-token-lost")) {
+      if (cartItem.descriptionAlert === "*chargeable") {
+        return true;
+      }
+    } else if (validatePassport(id)) {
+      if (cartItem.category.includes("tt-token")) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+/**
+ * Filters out the payment receipt identifier if not required
+ * which happens when pod is not chargeable
+ * Shape of identifiers and cartItem.identifierInputs are slightly different and
+ * hence require to filter separately
+ *
+ * @param identifiers identifiers that can be modified
+ * @param cartItem cartItem containing identifiers that can be modified
+ */
+export const removePaymentReceiptField = (
+  identifiers: PolicyIdentifier[],
+  cartItem: CartItem
+): {
+  newIdentifiers: PolicyIdentifier[];
+  newCartItem: CartItem;
+} => {
+  identifiers = identifiers.filter(
+    (identifier: { label: string }) =>
+      identifier.label != "Payment receipt number"
+  );
+  cartItem.identifierInputs = cartItem.identifierInputs.filter(
+    (identifier) => identifier.label != "Payment receipt number"
+  );
+
+  return { newIdentifiers: identifiers, newCartItem: cartItem };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,14 @@ const ScanButtonType = t.union([
   t.literal("CODE_39"),
 ]);
 
+const ValidationType = t.union([
+  t.literal("NRIC"),
+  t.literal("PASSPORT"),
+  t.literal("REGEX"),
+  t.literal("UIN"),
+  t.literal("EMAIL"),
+]);
+
 const PolicyIdentifier = t.intersection([
   t.type({
     label: t.string,
@@ -157,13 +165,7 @@ const IdentificationFlag = t.intersection([
       t.literal("QR"),
       t.literal("NONE"),
     ]),
-    validation: t.union([
-      t.literal("NRIC"),
-      t.literal("PASSPORT"),
-      t.literal("REGEX"),
-      t.literal("UIN"),
-      t.literal("EMAIL"),
-    ]),
+    validation: ValidationType,
   }),
   t.partial({
     label: t.string,
@@ -196,6 +198,7 @@ export const CampaignConfig = t.type({
 
 export type TextInputType = t.TypeOf<typeof TextInputType>;
 export type ScanButtonType = t.TypeOf<typeof ScanButtonType>;
+export type ValidationType = t.TypeOf<typeof ValidationType>;
 export type CategoryType = t.TypeOf<typeof CategoryType>;
 export type IdentifierInput = t.TypeOf<typeof IdentifierInput>;
 export type IdentificationFlag = t.TypeOf<typeof IdentificationFlag>;

--- a/src/utils/validatePassport.ts
+++ b/src/utils/validatePassport.ts
@@ -1,6 +1,6 @@
 import { ERROR_MESSAGE } from "../context/alert";
 
-const validate = (inputPassport: string): boolean => {
+export const validate = (inputPassport: string): boolean => {
   const passportRegex = "^[A-Za-z]{1,3}-[a-zA-Z0-9]{5,9}$";
   return inputPassport.match(passportRegex) !== null;
 };

--- a/src/utils/validatePassport.ts
+++ b/src/utils/validatePassport.ts
@@ -1,6 +1,6 @@
 import { ERROR_MESSAGE } from "../context/alert";
 
-export const validate = (inputPassport: string): boolean => {
+const validate = (inputPassport: string): boolean => {
   const passportRegex = "^[A-Za-z]{1,3}-[a-zA-Z0-9]{5,9}$";
   return inputPassport.match(passportRegex) !== null;
 };


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Part-1-of-2-Update-policy-and-Sally-screens-for-TT-Token-Passport-collection-collect-money-upon-1s-30f8b583dbf64a7bb8dd5acc90f877b0) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- `isPodChargeable` now checks `tt-token`'s PAYMENT_RECEIPT field

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [x] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
