### PR TITLE
fix: customer identification number background colour

### DIFF
--- a/src/components/CustomerAppeal/ReasonSelection/ReasonSelectionCard.tsx
+++ b/src/components/CustomerAppeal/ReasonSelection/ReasonSelectionCard.tsx
@@ -8,6 +8,7 @@ import { ReasonItem } from "./ReasonItem";
 import { SecondaryButton } from "../../Layout/Buttons/SecondaryButton";
 import { AlertModalContext, WARNING_MESSAGE } from "../../../context/alert";
 import { useTranslate } from "../../../hooks/useTranslate/useTranslate";
+import { useTheme } from "../../../context/theme";
 
 const styles = StyleSheet.create({
   titlePadding: {
@@ -43,11 +44,15 @@ export const ReasonSelectionCard: FunctionComponent<ReasonSelectionCard> = ({
   onCancel,
   onReasonSelection,
 }) => {
+  const { theme } = useTheme();
   const { showWarnAlert } = useContext(AlertModalContext);
   const { i18nt } = useTranslate();
   return (
     <View>
-      <CustomerCard ids={ids}>
+      <CustomerCard
+        ids={ids}
+        headerBackgroundColor={theme.customerCard.successfulHeaderColor}
+      >
         <Card>
           <View style={styles.titlePadding}>
             <ReasonSelectionHeader title={reasonSelectionHeader} />

--- a/src/components/CustomerQuota/CustomerCard.tsx
+++ b/src/components/CustomerQuota/CustomerCard.tsx
@@ -96,7 +96,7 @@ export const CustomerCard: FunctionComponent<{
           styles.header,
           headerBackgroundColor
             ? { backgroundColor: headerBackgroundColor }
-            : {},
+            : { backgroundColor: theme.customerCard.successfulHeaderColor },
         ]}
       >
         <Feather


### PR DESCRIPTION
The CustomerCard ID background colour was defined in the styles with a default colour previously, which should be superseded by each type of CustomerCard (successful/unsuccessful). This was missed out in the theme.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
