### PR TITLE
fix: add testId for e2e

### DIFF
--- a/src/components/Layout/Checkbox.tsx
+++ b/src/components/Layout/Checkbox.tsx
@@ -115,6 +115,7 @@ export const Checkbox: FunctionComponent<Checkbox> = ({
           }}
           underlayColor="transparent"
           activeOpacity={1}
+          testID="item-checkbox"
         >
           <Toggle isChecked={isChecked} />
         </TouchableHighlight>


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Fix-TT-Token-s-Related-history-accordion-misalignment-d6fbaa2b403e4eeca1a51cdf308bf255) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- after the touchable area constrain for checkbox in [PR500](https://github.com/rationally-app/mobile-application/pull/500). the e2e test case is [failed](https://gahmen.slack.com/archives/C01AEVAN3LK/p1639653793008900?thread_ts=1639648722.008600&cid=C01AEVAN3LK) because there is no `testId` for checkbox layout. here this PR adding the testId for Checbox's Touchable area .

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
