### PR TITLE
fix: TransactionsGroup overflow of text for payment QR identifier input

### DIFF
--- a/src/components/CustomerQuota/TransactionsGroup.tsx
+++ b/src/components/CustomerQuota/TransactionsGroup.tsx
@@ -33,6 +33,7 @@ export const styles = StyleSheet.create({
   },
   itemDetail: {
     fontSize: fontSize(-1),
+    marginRight: size(3),
   },
   appealLabel: {
     fontSize: fontSize(-1),

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -333,6 +333,12 @@ export const mockPastTransactions = async (
         category: "toilet-paper",
         quantity: 1,
         transactionTime,
+        identifierInputs: [
+          {
+            label: "toilet-paper label",
+            value: `${"loremipsum".repeat(15)}`,
+          },
+        ],
       },
       {
         category: "instant-noodles",
@@ -348,6 +354,17 @@ export const mockPastTransactions = async (
         category: "vouchers",
         quantity: 5,
         transactionTime,
+      },
+      {
+        category: "store",
+        quantity: 1,
+        transactionTime,
+        identifierInputs: [
+          {
+            label: "store label",
+            value: `${"loremipsum".repeat(15)}`,
+          },
+        ],
       },
     ],
   };

--- a/storybook/stories/CustomerQuota/CheckoutSuccessCard.tsx
+++ b/storybook/stories/CustomerQuota/CheckoutSuccessCard.tsx
@@ -7,7 +7,9 @@ import { RedeemedItem } from "../../../src/components/CustomerQuota/CheckoutSucc
 import { PurchasedItem } from "../../../src/components/CustomerQuota/CheckoutSuccess/PurchasedItem";
 import { Quota, CampaignPolicy } from "../../../src/types";
 import { CampaignConfigContext } from "../../../src/context/campaignConfig";
+import { ThemeContext } from "../../../src/context/theme";
 import { ItemQuantities } from "../../../src/components/CustomerQuota/types";
+import { govWalletTheme } from "../../../src/common/styles/themes";
 
 const products: CampaignPolicy[] = [
   {
@@ -41,6 +43,24 @@ const products: CampaignPolicy[] = [
   },
 ];
 
+const records: CampaignPolicy[] = [
+  {
+    category: "store",
+    name: "🏢 Store",
+    description: "",
+    order: 1,
+    quantity: {
+      period: 1,
+      limit: 1,
+      default: 1,
+      unit: {
+        type: "POSTFIX",
+        label: " qty",
+      },
+    },
+  },
+];
+
 const quotaResponse: Quota = {
   remainingQuota: [
     { category: "toilet-paper", quantity: 1 },
@@ -54,6 +74,12 @@ const quotaResponse: Quota = {
     { category: "toilet-paper", quantity: Number.MAX_SAFE_INTEGER },
     { category: "chocolate", quantity: Number.MAX_SAFE_INTEGER },
   ],
+};
+
+const recordQuotaResponse: Quota = {
+  remainingQuota: [{ category: "store", quantity: 1 }],
+  globalQuota: [{ category: "store", quantity: 1 }],
+  localQuota: [{ category: "store", quantity: Number.MAX_SAFE_INTEGER }],
 };
 
 const itemQuantities: ItemQuantities = {
@@ -99,4 +125,25 @@ storiesOf("CustomerQuota", module)
     >
       <PurchasedItem itemQuantities={itemQuantities} />
     </View>
+  ))
+  .add("PurchaseSuccessCard (GovWallet)", () => (
+    <ThemeContext.Provider
+      value={{ theme: govWalletTheme, setTheme: () => {} }}
+    >
+      <CampaignConfigContext.Provider
+        value={{
+          policies: records,
+          features: null,
+          c13n: {},
+        }}
+      >
+        <View key="3" style={{ margin: size(3) }}>
+          <CheckoutSuccessCard
+            ids={["S01115A000"]}
+            onCancel={() => null}
+            quotaResponse={recordQuotaResponse}
+          />
+        </View>
+      </CampaignConfigContext.Provider>
+    </ThemeContext.Provider>
   ));


### PR DESCRIPTION
[Notion Link](https://www.notion.so/sally-wallet/Overflow-of-text-for-Payment-QR-identifier-input-field-2abc70886f504cbe87c38713d7401de6)

This PR fix overflow of text for payment QR identifier input.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [ ] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
