### PR TITLE
refactor: use c13n instead of hardcoded copy changes for GW theme

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -29,11 +29,6 @@ export const en: Translations = {
     goToStatistics: "Go to statistics",
     nationalityInputLabel: "Nationality (non-Singaporean)",
     passportInputLabel: "Passport number",
-    /**
-     * GovWallet related copy changes below
-     */
-    recordEligibleMerchantQr: "Record eligible merchant’s payment QR",
-    record: "Record",
   },
   idScanner: {
     enterIdManually: "Enter ID manually",
@@ -97,14 +92,6 @@ export const en: Translations = {
     valid: "Valid",
     complete: "Complete",
     quantity: "qty",
-    /**
-     * GovWallet-related copy changes below
-     */
-    recorded: "Recorded!",
-    recordedItems: "Item(s) recorded:",
-    previouslyRecordedRecent: "Previously recorded %{time} ago%{today}.",
-    previouslyRecordedDate: "Previously recorded on %{dateTime}%{today}.",
-    previouslyRecordedItems: "Item(s) recorded previously:",
   },
   checkoutUnsuccessfulScreen: {
     unsuccessful: "Unsuccessful return!",

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -26,11 +26,6 @@ export type Translations = {
     goToStatistics: string;
     nationalityInputLabel: string;
     passportInputLabel: string;
-    /**
-     * GovWallet-related copy changes below
-     */
-    recordEligibleMerchantQr?: string;
-    record?: string;
   };
   idScanner: {
     enterIdManually: string;
@@ -94,14 +89,6 @@ export type Translations = {
     valid: string;
     complete: string;
     quantity: string;
-    /**
-     * GovWallet-related copy changes below
-     */
-    recorded?: string;
-    recordedItems?: string;
-    previouslyRecordedRecent?: string;
-    previouslyRecordedDate?: string;
-    previouslyRecordedItems?: string;
   };
   checkoutUnsuccessfulScreen: {
     unsuccessful: string;

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -269,7 +269,6 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
   };
 
   const tCampaignName = c13nt(features?.campaignName ?? "");
-  const checkEligibleItemsKey = "checkEligibleItems";
 
   return (
     <>
@@ -304,9 +303,11 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
               </AppText>
             )}
             <AppText>
-              {c13nt(checkEligibleItemsKey) !== checkEligibleItemsKey
-                ? c13nt(checkEligibleItemsKey)
-                : i18nt("collectCustomerDetailsScreen", checkEligibleItemsKey)}
+              {`${c13nt(
+                "checkEligibleItems",
+                undefined,
+                i18nt("collectCustomerDetailsScreen", "checkEligibleItems")
+              )}`}
             </AppText>
             {getInputComponent()}
           </Card>

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -49,7 +49,6 @@ import {
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
 import { extractPassportIdFromEvent } from "../../utils/passportScanning";
 import { useTheme } from "../../context/theme";
-import { GOVWALLET_THEME_NAME } from "../../common/styles/themes";
 
 const styles = StyleSheet.create({
   content: {
@@ -270,6 +269,7 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
   };
 
   const tCampaignName = c13nt(features?.campaignName ?? "");
+  const checkEligibleItemsKey = "checkEligibleItems";
 
   return (
     <>
@@ -304,12 +304,9 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
               </AppText>
             )}
             <AppText>
-              {theme.name === GOVWALLET_THEME_NAME
-                ? i18nt(
-                    "collectCustomerDetailsScreen",
-                    "recordEligibleMerchantQr"
-                  )
-                : i18nt("collectCustomerDetailsScreen", "checkEligibleItems")}
+              {c13nt(checkEligibleItemsKey) !== checkEligibleItemsKey
+                ? c13nt(checkEligibleItemsKey)
+                : i18nt("collectCustomerDetailsScreen", checkEligibleItemsKey)}
             </AppText>
             {getInputComponent()}
           </Card>

--- a/src/components/CustomerDetails/InputIdSection.tsx
+++ b/src/components/CustomerDetails/InputIdSection.tsx
@@ -7,8 +7,6 @@ import { AppText } from "../Layout/AppText";
 import { SecondaryButton } from "../Layout/Buttons/SecondaryButton";
 import { size, color, fontSize } from "../../common/styles";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
-import { useTheme } from "../../context/theme";
-import { GOVWALLET_THEME_NAME } from "../../common/styles/themes";
 
 const styles = StyleSheet.create({
   scanButtonWrapper: {
@@ -57,8 +55,8 @@ export const InputIdSection: FunctionComponent<InputIdSection> = ({
   submitId,
   keyboardType,
 }) => {
-  const { theme } = useTheme();
-  const { i18nt } = useTranslate();
+  const { i18nt, c13nt } = useTranslate();
+  const checkKey = "check";
   return (
     <>
       <View style={styles.scanButtonWrapper}>
@@ -94,9 +92,9 @@ export const InputIdSection: FunctionComponent<InputIdSection> = ({
         </View>
         <SecondaryButton
           text={
-            theme.name === GOVWALLET_THEME_NAME
-              ? i18nt("collectCustomerDetailsScreen", "record")
-              : i18nt("collectCustomerDetailsScreen", "check")
+            c13nt(checkKey) !== checkKey
+              ? c13nt(checkKey)
+              : i18nt("collectCustomerDetailsScreen", checkKey)
           }
           onPress={submitId}
           accessibilityLabel="identity-details-check-button"

--- a/src/components/CustomerDetails/InputIdSection.tsx
+++ b/src/components/CustomerDetails/InputIdSection.tsx
@@ -56,7 +56,6 @@ export const InputIdSection: FunctionComponent<InputIdSection> = ({
   keyboardType,
 }) => {
   const { i18nt, c13nt } = useTranslate();
-  const checkKey = "check";
   return (
     <>
       <View style={styles.scanButtonWrapper}>
@@ -91,11 +90,11 @@ export const InputIdSection: FunctionComponent<InputIdSection> = ({
           />
         </View>
         <SecondaryButton
-          text={
-            c13nt(checkKey) !== checkKey
-              ? c13nt(checkKey)
-              : i18nt("collectCustomerDetailsScreen", checkKey)
-          }
+          text={`${c13nt(
+            "check",
+            undefined,
+            i18nt("collectCustomerDetailsScreen", "check")
+          )}`}
           onPress={submitId}
           accessibilityLabel="identity-details-check-button"
         />

--- a/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
+++ b/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
@@ -30,7 +30,6 @@ import {
   useTranslate,
 } from "../../../hooks/useTranslate/useTranslate";
 import { useTheme } from "../../../context/theme";
-import { GOVWALLET_THEME_NAME } from "../../../common/styles/themes";
 
 const MAX_TRANSACTIONS_TO_DISPLAY = 1;
 
@@ -179,6 +178,8 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
 
   const translationProps = useTranslate();
   const { c13nt, i18nt } = translationProps;
+  const redeemedKey = "redeemed";
+  const redeemedItemsKey = "redeemedItems";
   const transactionsByTimeMap = groupTransactionsByTime(
     sortedTransactions,
     allProducts || [],
@@ -230,9 +231,9 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
                 {`${c13nt(
                   "checkoutSuccessTitle",
                   undefined,
-                  theme.name === GOVWALLET_THEME_NAME
-                    ? i18nt("checkoutSuccessScreen", "recorded")
-                    : i18nt("checkoutSuccessScreen", "redeemed")
+                  c13nt(redeemedKey) !== redeemedKey
+                    ? c13nt(redeemedKey)
+                    : i18nt("checkoutSuccessScreen", redeemedKey)
                 )}`}
               </AppText>
               {showGlobalQuota && firstGlobalQuota!.quotaRefreshTime ? (
@@ -247,9 +248,9 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
                 {`${c13nt(
                   "checkoutSuccessDescription",
                   undefined,
-                  theme.name === GOVWALLET_THEME_NAME
-                    ? i18nt("checkoutSuccessScreen", "recordedItems")
-                    : i18nt("checkoutSuccessScreen", "redeemedItems")
+                  c13nt(redeemedItemsKey) !== redeemedItemsKey
+                    ? c13nt(redeemedItemsKey)
+                    : i18nt("checkoutSuccessScreen", redeemedItemsKey)
                 )}`}
               </AppText>
               <View style={styles.checkoutItemsList}>

--- a/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
+++ b/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
@@ -178,8 +178,6 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
 
   const translationProps = useTranslate();
   const { c13nt, i18nt } = translationProps;
-  const redeemedKey = "redeemed";
-  const redeemedItemsKey = "redeemedItems";
   const transactionsByTimeMap = groupTransactionsByTime(
     sortedTransactions,
     allProducts || [],
@@ -229,11 +227,9 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
                 accessible={true}
               >
                 {`${c13nt(
-                  "checkoutSuccessTitle",
+                  "redeemed",
                   undefined,
-                  c13nt(redeemedKey) !== redeemedKey
-                    ? c13nt(redeemedKey)
-                    : i18nt("checkoutSuccessScreen", redeemedKey)
+                  i18nt("checkoutSuccessScreen", "redeemed")
                 )}`}
               </AppText>
               {showGlobalQuota && firstGlobalQuota!.quotaRefreshTime ? (
@@ -246,11 +242,9 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
             <View>
               <AppText>
                 {`${c13nt(
-                  "checkoutSuccessDescription",
+                  "redeemedItems",
                   undefined,
-                  c13nt(redeemedItemsKey) !== redeemedItemsKey
-                    ? c13nt(redeemedItemsKey)
-                    : i18nt("checkoutSuccessScreen", redeemedItemsKey)
+                  i18nt("checkoutSuccessScreen", "redeemedItems")
                 )}`}
               </AppText>
               <View style={styles.checkoutItemsList}>

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -125,7 +125,6 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
 
   const translationProps = useTranslate();
   const { i18nt, c13nt } = translationProps;
-  const previouslyRedeemedItemsKey = "previouslyRedeemedItems";
   const transactionsByCategoryMap = groupTransactionsByCategory(
     sortedTransactions,
     allProducts || [],
@@ -211,15 +210,9 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
                 <View>
                   <AppText style={styles.wrapper}>
                     {`${c13nt(
-                      "checkoutSuccessPreviousItems",
+                      "previouslyRedeemedItems",
                       undefined,
-                      c13nt(previouslyRedeemedItemsKey) !==
-                        previouslyRedeemedItemsKey
-                        ? c13nt(previouslyRedeemedItemsKey)
-                        : i18nt(
-                            "checkoutSuccessScreen",
-                            previouslyRedeemedItemsKey
-                          )
+                      i18nt("checkoutSuccessScreen", "previouslyRedeemedItems")
                     )}`}
                   </AppText>
                   {transactionsByCategoryList.map(

--- a/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
+++ b/src/components/CustomerQuota/NoQuota/NoQuotaCard.tsx
@@ -34,7 +34,6 @@ import { CampaignConfigContext } from "../../../context/campaignConfig";
 import { AuthContext } from "../../../context/auth";
 import { useTranslate } from "../../../hooks/useTranslate/useTranslate";
 import { useTheme } from "../../../context/theme";
-import { GOVWALLET_THEME_NAME } from "../../../common/styles/themes";
 
 const DURATION_THRESHOLD_SECONDS = 60 * 10; // 10 minutes
 const MAX_TRANSACTIONS_TO_DISPLAY = 5;
@@ -126,6 +125,7 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
 
   const translationProps = useTranslate();
   const { i18nt, c13nt } = translationProps;
+  const previouslyRedeemedItemsKey = "previouslyRedeemedItems";
   const transactionsByCategoryMap = groupTransactionsByCategory(
     sortedTransactions,
     allProducts || [],
@@ -213,14 +213,12 @@ export const NoQuotaCard: FunctionComponent<NoQuotaCard> = ({
                     {`${c13nt(
                       "checkoutSuccessPreviousItems",
                       undefined,
-                      theme.name === GOVWALLET_THEME_NAME
-                        ? i18nt(
-                            "checkoutSuccessScreen",
-                            "previouslyRecordedItems"
-                          )
+                      c13nt(previouslyRedeemedItemsKey) !==
+                        previouslyRedeemedItemsKey
+                        ? c13nt(previouslyRedeemedItemsKey)
                         : i18nt(
                             "checkoutSuccessScreen",
-                            "previouslyRedeemedItems"
+                            previouslyRedeemedItemsKey
                           )
                     )}`}
                   </AppText>

--- a/src/components/CustomerQuota/NoQuota/TransactionTitle.tsx
+++ b/src/components/CustomerQuota/NoQuota/TransactionTitle.tsx
@@ -28,6 +28,7 @@ export const DistantTransactionTitle: FunctionComponent<{
             today,
           })
         )}`
+          // TODO: move this functionality into c13nt
           .replace("%{dateTime}", formatDateTime(transactionTime))
           .replace("%{today}", today)}
       </AppText>
@@ -55,6 +56,7 @@ export const RecentTransactionTitle: FunctionComponent<{
             today,
           })
         )}`
+          // TODO: move this functionality into c13nt
           .replace("%{time}", formatTimeDifference(now, transactionTime))
           .replace("%{today}", today)}
       </AppText>

--- a/src/components/CustomerQuota/NoQuota/TransactionTitle.tsx
+++ b/src/components/CustomerQuota/NoQuota/TransactionTitle.tsx
@@ -13,21 +13,23 @@ export const DistantTransactionTitle: FunctionComponent<{
   toggleTimeSensitiveTitle: boolean;
 }> = ({ transactionTime, toggleTimeSensitiveTitle }) => {
   const { c13nt, i18nt } = useTranslate();
-  const limitReachedDateKey = "limitReachedDate";
+
   const today = toggleTimeSensitiveTitle
     ? `${i18nt("checkoutSuccessScreen", "today")}`
     : "";
   return (
     <>
       <AppText style={sharedStyles.statusTitle}>
-        {c13nt(limitReachedDateKey) !== limitReachedDateKey
-          ? c13nt(limitReachedDateKey)
-              .replace("${dateTime}", formatDateTime(transactionTime))
-              .replace("${today}", today)
-          : i18nt("checkoutSuccessScreen", limitReachedDateKey, undefined, {
-              dateTime: formatDateTime(transactionTime),
-              today,
-            })}
+        {`${c13nt(
+          "limitReachedDate",
+          undefined,
+          i18nt("checkoutSuccessScreen", "limitReachedDate", undefined, {
+            dateTime: formatDateTime(transactionTime),
+            today,
+          })
+        )}`
+          .replace("%{dateTime}", formatDateTime(transactionTime))
+          .replace("%{today}", today)}
       </AppText>
     </>
   );
@@ -39,26 +41,22 @@ export const RecentTransactionTitle: FunctionComponent<{
   toggleTimeSensitiveTitle: boolean;
 }> = ({ now, transactionTime, toggleTimeSensitiveTitle }) => {
   const { c13nt, i18nt } = useTranslate();
-  const limitReachedRecentKey = "limitReachedRecent";
   const today = toggleTimeSensitiveTitle
     ? `${i18nt("checkoutSuccessScreen", "today")}`
     : "";
   return (
     <>
       <AppText style={sharedStyles.statusTitle}>
-        {c13nt(limitReachedRecentKey) !== limitReachedRecentKey
-          ? c13nt(limitReachedRecentKey)
-              .replace("${time}", formatTimeDifference(now, transactionTime))
-              .replace("${today}", today)
-          : `${i18nt(
-              "checkoutSuccessScreen",
-              limitReachedRecentKey,
-              undefined,
-              {
-                time: formatTimeDifference(now, transactionTime),
-                today,
-              }
-            )}`}
+        {`${c13nt(
+          "limitReachedRecent",
+          undefined,
+          i18nt("checkoutSuccessScreen", "limitReachedRecent", undefined, {
+            dateTime: formatDateTime(transactionTime),
+            today,
+          })
+        )}`
+          .replace("%{time}", formatTimeDifference(now, transactionTime))
+          .replace("%{today}", today)}
       </AppText>
     </>
   );

--- a/src/components/CustomerQuota/NoQuota/TransactionTitle.tsx
+++ b/src/components/CustomerQuota/NoQuota/TransactionTitle.tsx
@@ -7,32 +7,24 @@ import {
   formatTimeDifference,
 } from "../../../utils/dateTimeFormatter";
 import { useTranslate } from "../../../hooks/useTranslate/useTranslate";
-import { useTheme } from "../../../context/theme";
-import { GOVWALLET_THEME_NAME } from "../../../common/styles/themes";
 
 export const DistantTransactionTitle: FunctionComponent<{
   transactionTime: Date;
   toggleTimeSensitiveTitle: boolean;
 }> = ({ transactionTime, toggleTimeSensitiveTitle }) => {
-  const { theme } = useTheme();
-  const { i18nt } = useTranslate();
+  const { c13nt, i18nt } = useTranslate();
+  const limitReachedDateKey = "limitReachedDate";
   const today = toggleTimeSensitiveTitle
     ? `${i18nt("checkoutSuccessScreen", "today")}`
     : "";
   return (
     <>
       <AppText style={sharedStyles.statusTitle}>
-        {theme.name === GOVWALLET_THEME_NAME
-          ? i18nt(
-              "checkoutSuccessScreen",
-              "previouslyRecordedDate",
-              undefined,
-              {
-                dateTime: formatDateTime(transactionTime),
-                today,
-              }
-            )
-          : i18nt("checkoutSuccessScreen", "limitReachedDate", undefined, {
+        {c13nt(limitReachedDateKey) !== limitReachedDateKey
+          ? c13nt(limitReachedDateKey)
+              .replace("${dateTime}", formatDateTime(transactionTime))
+              .replace("${today}", today)
+          : i18nt("checkoutSuccessScreen", limitReachedDateKey, undefined, {
               dateTime: formatDateTime(transactionTime),
               today,
             })}
@@ -46,28 +38,27 @@ export const RecentTransactionTitle: FunctionComponent<{
   transactionTime: Date;
   toggleTimeSensitiveTitle: boolean;
 }> = ({ now, transactionTime, toggleTimeSensitiveTitle }) => {
-  const { theme } = useTheme();
-  const { i18nt } = useTranslate();
+  const { c13nt, i18nt } = useTranslate();
+  const limitReachedRecentKey = "limitReachedRecent";
   const today = toggleTimeSensitiveTitle
     ? `${i18nt("checkoutSuccessScreen", "today")}`
     : "";
   return (
     <>
       <AppText style={sharedStyles.statusTitle}>
-        {theme.name === GOVWALLET_THEME_NAME
-          ? `${i18nt(
+        {c13nt(limitReachedRecentKey) !== limitReachedRecentKey
+          ? c13nt(limitReachedRecentKey)
+              .replace("${time}", formatTimeDifference(now, transactionTime))
+              .replace("${today}", today)
+          : `${i18nt(
               "checkoutSuccessScreen",
-              "previouslyRecordedRecent",
+              limitReachedRecentKey,
               undefined,
               {
                 time: formatTimeDifference(now, transactionTime),
                 today,
               }
-            )}`
-          : `${i18nt("checkoutSuccessScreen", "limitReachedRecent", undefined, {
-              time: formatTimeDifference(now, transactionTime),
-              today,
-            })}`}
+            )}`}
       </AppText>
     </>
   );


### PR DESCRIPTION
This PR adds... <!-- A brief description of what your PR does -->
- use of c13n for previously hardcoded app text
- toggle these text based on SSM params `en` and `zh` if they exist

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
