### PR TITLE
fix: De-sync between passport number field and what is submitted

### DIFF
--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -239,6 +239,7 @@ const CollectCustomerDetailsScreen: FunctionComponent<NavigationFocusInjectedPro
       <InputPassportSection
         scannerType={selectedIdType.scannerType}
         openCamera={() => setShouldShowCamera(true)}
+        idInput={idInput}
         setIdInput={setIdInput}
         submitId={() => onCheck(idInput)}
       />

--- a/src/components/CustomerDetails/InputPassportSection.test.tsx
+++ b/src/components/CustomerDetails/InputPassportSection.test.tsx
@@ -19,6 +19,7 @@ describe("InputPassportSection", () => {
       <InputPassportSection
         scannerType={"NONE"}
         openCamera={openCamera}
+        idInput=""
         setIdInput={setIdInput}
         submitId={submitId}
       />

--- a/src/components/CustomerDetails/InputPassportSection.tsx
+++ b/src/components/CustomerDetails/InputPassportSection.tsx
@@ -64,6 +64,8 @@ export const InputPassportSection: FunctionComponent<InputPassportSection> = ({
   }, [selectedCountry, trimmedPassportNum, setIdInput]);
 
   useEffect(() => {
+    // Change both states to default value to sync the submitted
+    // input field state (idInput) with the local states.
     if (idInput === "") {
       setPassportNum(undefined);
       setSelectedCountry(undefined);

--- a/src/components/CustomerDetails/InputPassportSection.tsx
+++ b/src/components/CustomerDetails/InputPassportSection.tsx
@@ -32,6 +32,7 @@ const styles = StyleSheet.create({
 interface InputPassportSection {
   scannerType: "CODE_39" | "QR" | "NONE";
   openCamera: () => void;
+  idInput: string;
   setIdInput: (id: string) => void;
   submitId: () => void;
 }
@@ -39,6 +40,7 @@ interface InputPassportSection {
 export const InputPassportSection: FunctionComponent<InputPassportSection> = ({
   scannerType,
   openCamera,
+  idInput,
   setIdInput,
   submitId,
 }) => {
@@ -60,6 +62,13 @@ export const InputPassportSection: FunctionComponent<InputPassportSection> = ({
       ? setIdInput(`${selectedCountry?.value}-${trimmedPassportNum}`)
       : setIdInput("");
   }, [selectedCountry, trimmedPassportNum, setIdInput]);
+
+  useEffect(() => {
+    if (idInput === "") {
+      setPassportNum(undefined);
+      setSelectedCountry(undefined);
+    }
+  }, [idInput]);
 
   const getScannerComponent = (): JSX.Element | null => {
     return scannerType !== "NONE" ? (

--- a/storybook/stories/CustomerDetails/InputsElements.tsx
+++ b/storybook/stories/CustomerDetails/InputsElements.tsx
@@ -77,6 +77,7 @@ const InputPassportSectionItem = (): ReactElement => {
       <InputPassportSection
         scannerType={"NONE"}
         openCamera={() => null}
+        idInput=""
         setIdInput={() => null}
         submitId={() => alert("Submitted")}
       />


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/De-sync-between-passport-number-field-and-what-is-submitted-4277f5c27bae45879369ad3ea99e813a)

This PR fix de-sync between passport number field and what is submitted.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [X] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [X] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
