### PR TITLE
feat: tt token passport part 2

### DIFF
--- a/src/components/CustomerAppeal/CustomerAppealScreen.tsx
+++ b/src/components/CustomerAppeal/CustomerAppealScreen.tsx
@@ -24,6 +24,7 @@ import {
 } from "./ReasonSelection/ReasonSelectionCard";
 import { pushRoute, navigateHome } from "../../common/navigation";
 import { AuthContext } from "../../context/auth";
+import { IdentificationContext } from "../../context/identification";
 import { Sentry } from "../../utils/errorTracking";
 import { CampaignConfigContext } from "../../context/campaignConfig";
 import { useQuota } from "../../hooks/useQuota/useQuota";
@@ -68,6 +69,7 @@ export const CustomerAppealScreen: FunctionComponent<NavigationProps> = ({
 
   const [ids] = useState(navigation.getParam("ids"));
   const { policies: allProducts } = useContext(CampaignConfigContext);
+  const { selectedIdType } = useContext(IdentificationContext);
 
   const onCancel = useCallback((): void => {
     navigateHome(navigation);
@@ -108,25 +110,33 @@ export const CustomerAppealScreen: FunctionComponent<NavigationProps> = ({
               descriptionAlert,
             });
           } else if (typeof policyThreshold === "string") {
-            /**
-             * Policy threshold is string when its visibility is conditional to other policy that is
-             * written on the threshold.
-             *
-             * Some assumptions that are made:
-             * - Policies with dependencies on other policies should be defined after their dependents
-             * - Policies with dependencies show up depending on whether its dependent policy's
-             *   descriptionAlert is shown
-             */
-            const dependentReason = result.find(
-              (reason) =>
-                reason.descriptionAlert && reason.category === policyThreshold
-            );
-            if (dependentReason && policy.alert) {
-              result.push({
-                category: policy.category,
-                description: policy.name,
-                descriptionAlert: policy.alert.label,
-              });
+            if (
+              !(
+                selectedIdType.validation === "PASSPORT" &&
+                policy.category === "tt-token-lost-waive"
+              )
+            ) {
+              /**
+               * Policy threshold is string when its visibility is conditional to other policy that is
+               * written on the threshold.
+               *
+               * Some assumptions that are made:
+               * - Policies with dependencies on other policies should be defined after their dependents
+               * - Policies with dependencies show up depending on whether its dependent policy's
+               *   descriptionAlert is shown
+               */
+              const dependentReason = result.find(
+                (reason) =>
+                  reason.descriptionAlert && reason.category === policyThreshold
+              );
+              console.log(dependentReason);
+              if (dependentReason && policy.alert) {
+                result.push({
+                  category: policy.category,
+                  description: policy.name,
+                  descriptionAlert: policy.alert.label,
+                });
+              }
             }
           } else {
             result.push({

--- a/src/components/CustomerAppeal/CustomerAppealScreen.tsx
+++ b/src/components/CustomerAppeal/CustomerAppealScreen.tsx
@@ -129,7 +129,6 @@ export const CustomerAppealScreen: FunctionComponent<NavigationProps> = ({
                 (reason) =>
                   reason.descriptionAlert && reason.category === policyThreshold
               );
-              console.log(dependentReason);
               if (dependentReason && policy.alert) {
                 result.push({
                   category: policy.category,

--- a/src/components/CustomerQuota/utils.test.ts
+++ b/src/components/CustomerQuota/utils.test.ts
@@ -303,7 +303,7 @@ describe("pod related utils", () => {
     },
   ];
 
-  let idType = "NRIC" as ValidationType;
+  let idType: ValidationType;
   let validCartItem: CartItem;
   let validIdentifiers: PolicyIdentifier[];
   beforeEach(() => {
@@ -354,37 +354,45 @@ describe("pod related utils", () => {
   });
 
   describe("isPodChargeable", () => {
-    it("should return true for tt-token-lost category", () => {
-      expect.assertions(1);
-      validCartItem["category"] = "tt-token-lost";
-      validCartItem["descriptionAlert"] = "*chargeable";
-      expect(
-        isPodChargeable(idType, validIdentifiers, validCartItem)
-      ).toStrictEqual(true);
+    beforeEach(() => {
+      idType = "NRIC";
     });
 
-    it("should return false for tt-token-lost category if it's not *chargeable", () => {
-      expect.assertions(1);
-      validCartItem["category"] = "tt-token-lost";
-      expect(
-        isPodChargeable(idType, validIdentifiers, validCartItem)
-      ).toStrictEqual(false);
-    });
+    describe("for non-passport customer", () => {
+      it("should return true for tt-token-lost category", () => {
+        expect.assertions(1);
+        validCartItem["category"] = "tt-token-lost";
+        validCartItem["descriptionAlert"] = "*chargeable";
+        expect(
+          isPodChargeable(idType, validIdentifiers, validCartItem)
+        ).toStrictEqual(true);
+      });
 
-    it("should return false for non-pod category", () => {
-      expect.assertions(1);
-      expect(
-        isPodChargeable(idType, validIdentifiers, validCartItem)
-      ).toStrictEqual(false);
-    });
+      it("should return false for tt-token-lost category if it's not *chargeable", () => {
+        expect.assertions(1);
+        validCartItem["category"] = "tt-token-lost";
+        expect(
+          isPodChargeable(idType, validIdentifiers, validCartItem)
+        ).toStrictEqual(false);
+      });
 
-    it("should return false if there are no identifiers", () => {
-      expect.assertions(1);
-      expect(isPodChargeable(idType, [], validCartItem)).toStrictEqual(false);
+      it("should return false for non-pod category", () => {
+        expect.assertions(1);
+        expect(
+          isPodChargeable(idType, validIdentifiers, validCartItem)
+        ).toStrictEqual(false);
+      });
+
+      it("should return false if there are no identifiers", () => {
+        expect.assertions(1);
+        expect(isPodChargeable(idType, [], validCartItem)).toStrictEqual(false);
+      });
     });
 
     describe("for passport customer", () => {
-      idType = "PASSPORT";
+      beforeEach(() => {
+        idType = "PASSPORT";
+      });
 
       it("should return true for tt-token category", () => {
         expect.assertions(1);
@@ -394,11 +402,11 @@ describe("pod related utils", () => {
         ).toStrictEqual(true);
       });
 
-      it("should return false for non-pod category", () => {
+      it("should return true for any category", () => {
         expect.assertions(1);
         expect(
           isPodChargeable(idType, validIdentifiers, validCartItem)
-        ).toStrictEqual(false);
+        ).toStrictEqual(true);
       });
     });
   });

--- a/src/components/CustomerQuota/utils.test.ts
+++ b/src/components/CustomerQuota/utils.test.ts
@@ -354,7 +354,7 @@ describe("pod related utils", () => {
   });
 
   describe("isPodChargeable", () => {
-    beforeEach(() => {
+    beforeAll(() => {
       idType = "NRIC";
     });
 
@@ -390,7 +390,7 @@ describe("pod related utils", () => {
     });
 
     describe("for passport customer", () => {
-      beforeEach(() => {
+      beforeAll(() => {
         idType = "PASSPORT";
       });
 

--- a/src/components/CustomerQuota/utils.ts
+++ b/src/components/CustomerQuota/utils.ts
@@ -167,9 +167,7 @@ export const isPodChargeable = (
         return true;
       }
     } else if (idType === "PASSPORT") {
-      if (cartItem.category.includes("tt-token")) {
-        return true;
-      }
+      return true;
     }
   }
   return false;


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Part-2-of-2-Update-policy-and-Sally-screens-for-TT-Token-Passport-collection-collect-money-upon-1s-ded1eb59d6f74dc6be172fd69fef73ea) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- `PAYMENT_RECEIPT` field to all `PASSPORT` input
- remove `tt-token-lost-waive` appeal block from `PASSPORT` entry
<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [x] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
