### PR TITLE
feat: add payment for passport first lost

### DIFF
--- a/src/components/CustomerAppeal/CustomerAppealScreen.tsx
+++ b/src/components/CustomerAppeal/CustomerAppealScreen.tsx
@@ -103,6 +103,18 @@ export const CustomerAppealScreen: FunctionComponent<NavigationProps> = ({
               policyLimit - quotaResponse.quantity >= policyThreshold
             ) {
               descriptionAlert = policy.alert.label;
+              /**
+               * Passport user is always charged for token and lost token redemption.
+               *
+               * This special if condition is used to prevent further change to the main policy scheme
+               * since this is a special case
+               */
+            } else if (
+              policy.alert &&
+              selectedIdType.validation === "PASSPORT" &&
+              policy.category === "tt-token-lost"
+            ) {
+              descriptionAlert = policy.alert.label;
             }
             result.push({
               category: policy.category,

--- a/src/components/CustomerAppeal/CustomerAppealScreen.tsx
+++ b/src/components/CustomerAppeal/CustomerAppealScreen.tsx
@@ -98,21 +98,17 @@ export const CustomerAppealScreen: FunctionComponent<NavigationProps> = ({
           let descriptionAlert: string | undefined = undefined;
           if (typeof policyThreshold === "number") {
             if (
-              quotaResponse &&
               policy.alert &&
-              policyLimit - quotaResponse.quantity >= policyThreshold
-            ) {
-              descriptionAlert = policy.alert.label;
-              /**
-               * Passport user is always charged for token and lost token redemption.
-               *
-               * This special if condition is used to prevent further change to the main policy scheme
-               * since this is a special case
-               */
-            } else if (
-              policy.alert &&
-              selectedIdType.validation === "PASSPORT" &&
-              policy.category === "tt-token-lost"
+              ((quotaResponse &&
+                policyLimit - quotaResponse.quantity >= policyThreshold) ||
+                /**
+                 * Passport user is always charged for token and lost token redemption.
+                 *
+                 * This special if condition is used to prevent further change to the main policy scheme
+                 * since this is a special case
+                 */
+                (selectedIdType.validation === "PASSPORT" &&
+                  policy.category === "tt-token-lost"))
             ) {
               descriptionAlert = policy.alert.label;
             }


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Part-2-of-2-Update-policy-and-Sally-screens-for-TT-Token-Passport-collection-collect-money-upon-1s-ded1eb59d6f74dc6be172fd69fef73ea) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- require payment for passport user redeeming first lost token

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [ ] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
