### PR TITLE
fix: key error for copy changes, translation

### DIFF
--- a/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
+++ b/src/components/CustomerQuota/CheckoutSuccess/CheckoutSuccessCard.tsx
@@ -227,7 +227,7 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
                 accessible={true}
               >
                 {`${c13nt(
-                  "redeemed",
+                  "checkoutSuccessTitle",
                   undefined,
                   i18nt("checkoutSuccessScreen", "redeemed")
                 )}`}
@@ -242,7 +242,7 @@ export const CheckoutSuccessCard: FunctionComponent<CheckoutSuccessCard> = ({
             <View>
               <AppText>
                 {`${c13nt(
-                  "redeemedItems",
+                  "checkoutSuccessDescription",
                   undefined,
                   i18nt("checkoutSuccessScreen", "redeemedItems")
                 )}`}


### PR DESCRIPTION
Made a change to 2 of the translation keys indadvertedly 😢 
- Should be `CheckoutSuccessTitle` instead of `redeemed` 
- Should be `CheckoutSuccessDescription` instead of `redeemedItems`

![image](https://user-images.githubusercontent.com/43963814/148725431-ce2a26f7-42e1-4e95-af03-ff56d1920179.png)

This PR adds... <!-- A brief description of what your PR does -->
- corrected keys for 2 elements 
- also made the change on SSM

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
