### PR TITLE
feat: parse and store `PAYMENT_QR`

### DIFF
--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -11,7 +11,7 @@ import {
   Transaction,
 } from "../../types";
 import { validateIdentifierInputs } from "../../utils/validateIdentifierInputs";
-import { updateTransactionsPaymentQRIdentifiers } from "../../utils/paymentQRHelper";
+import { getUpdatedTransactionsPaymentQRIdentifiers } from "../../utils/paymentQRHelper";
 import {
   cleanIdentifierInput,
   tagOptionalIdentifierInput,
@@ -312,7 +312,7 @@ export const useCart = (
    */
   const _completeCheckout = useCallback(() => {
     const complete = async (): Promise<void> => {
-      const transactions: Array<Transaction> = Object.values(cart)
+      let transactions: Array<Transaction> = Object.values(cart)
         .filter(({ quantity }) => quantity)
         .map(({ category, quantity, identifierInputs }) => {
           const cleanedIdentifierInputs = identifierInputs.map((identifier) => {
@@ -335,7 +335,7 @@ export const useCart = (
           };
         });
 
-      updateTransactionsPaymentQRIdentifiers(transactions);
+      transactions = getUpdatedTransactionsPaymentQRIdentifiers(transactions);
 
       try {
         const transactionResponse = await postTransaction({

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -8,6 +8,7 @@ import {
   PolicyIdentifier,
   CampaignPolicy,
   ValidationType,
+  Transaction,
 } from "../../types";
 import { validateIdentifierInputs } from "../../utils/validateIdentifierInputs";
 import {
@@ -310,7 +311,7 @@ export const useCart = (
    */
   const _completeCheckout = useCallback(() => {
     const complete = async (): Promise<void> => {
-      const transactions = Object.values(cart)
+      const transactions: Array<Transaction> = Object.values(cart)
         .filter(({ quantity }) => quantity)
         .map(({ category, quantity, identifierInputs }) => {
           const cleanedIdentifierInputs = identifierInputs.map((identifier) => {

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -11,6 +11,7 @@ import {
   Transaction,
 } from "../../types";
 import { validateIdentifierInputs } from "../../utils/validateIdentifierInputs";
+import { updateTransactionsPaymentQRIdentifiers } from "../../utils/paymentQRHelper";
 import {
   cleanIdentifierInput,
   tagOptionalIdentifierInput,
@@ -333,6 +334,9 @@ export const useCart = (
                 : cleanedIdentifierInputs,
           };
         });
+
+      updateTransactionsPaymentQRIdentifiers(transactions);
+
       try {
         const transactionResponse = await postTransaction({
           ids,

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,7 +127,7 @@ const PolicyIdentifier = t.intersection([
   }),
 ]);
 
-const IdentifierInput = t.intersection([
+export const IdentifierInput = t.intersection([
   t.type({
     label: t.string,
     value: t.string,

--- a/src/utils/paymentQRHelper.test.ts
+++ b/src/utils/paymentQRHelper.test.ts
@@ -1,0 +1,38 @@
+import { findValueByKey } from "./paymentQRHelper";
+
+describe("tests for paymentQRHelper", () => {
+  describe("tests for findValueByKey", () => {
+    let records: Record<string, unknown>;
+
+    beforeEach(() => {
+      records = {
+        transactionAmount: 10,
+        merchantAccountInformation: {
+          nets: {
+            terminalId: "1234567890",
+            merchantId: "0987654321",
+          },
+        },
+        merchantName: "Merchant name",
+      };
+    });
+
+    it("should find value by key properly", () => {
+      expect.assertions(1);
+      expect(findValueByKey("merchantName", records)).toStrictEqual(
+        "Merchant name"
+      );
+    });
+
+    it("should find nested value by key properly", () => {
+      expect.assertions(1);
+      expect(findValueByKey("terminalId", records)).toStrictEqual("1234567890");
+    });
+
+    it("should return `undefined` if key does not exist", () => {
+      expect.assertions(1);
+      expect(findValueByKey("nonExistentKey", records)).toBeUndefined();
+    });
+  });
+  });
+});

--- a/src/utils/paymentQRHelper.test.ts
+++ b/src/utils/paymentQRHelper.test.ts
@@ -1,4 +1,8 @@
-import { findValueByKey } from "./paymentQRHelper";
+import { Transaction } from "../types";
+import {
+  findValueByKey,
+  updateTransactionsPaymentQRIdentifiers,
+} from "./paymentQRHelper";
 
 describe("tests for paymentQRHelper", () => {
   describe("tests for findValueByKey", () => {
@@ -34,5 +38,62 @@ describe("tests for paymentQRHelper", () => {
       expect(findValueByKey("nonExistentKey", records)).toBeUndefined();
     });
   });
+
+  describe("tests for updateTransactionsPaymentQRIdentifiers", () => {
+    let transactions: Array<Transaction>;
+
+    beforeEach(() => {
+      transactions = [
+        {
+          category: "category-a",
+          quantity: 1,
+          identifierInputs: [
+            {
+              label: "Payment QR",
+              scanButtonType: "QR",
+              validationRegex: "[\\s\\S]*",
+              value:
+                "00020101021126520008com.grab0136c99990dc-ab89-442f-accb-1fd96dd4eff627330015sg.com.dash.www0110000000901628460010com.myfave0128https://myfave.com/qr/6ntdz329360009SG.AIRPAY0119936009180000000468751810007SG.SGQR01121809112DE3C7020701.000703065743700402010503105060400000708202012105204581253037025802SG5920UDDERS UPPER THOMSON6009Singapore63047AEC",
+              textInputType: "PAYMENT_QR",
+            },
+            {
+              label: "merchantName",
+              isOptional: true,
+              value: "",
+              validationRegex: "^[a-zA-Z0-9 ]*$",
+              textInputType: "STRING",
+            },
+          ],
+        },
+      ];
+    });
+
+    it("should update identifiers properly", () => {
+      expect.assertions(1);
+      updateTransactionsPaymentQRIdentifiers(transactions);
+      expect(transactions).toStrictEqual([
+        {
+          category: "category-a",
+          quantity: 1,
+          identifierInputs: [
+            {
+              label: "Payment QR",
+              scanButtonType: "QR",
+              validationRegex: "[\\s\\S]*",
+              value:
+                "00020101021126520008com.grab0136c99990dc-ab89-442f-accb-1fd96dd4eff627330015sg.com.dash.www0110000000901628460010com.myfave0128https://myfave.com/qr/6ntdz329360009SG.AIRPAY0119936009180000000468751810007SG.SGQR01121809112DE3C7020701.000703065743700402010503105060400000708202012105204581253037025802SG5920UDDERS UPPER THOMSON6009Singapore63047AEC",
+              textInputType: "PAYMENT_QR",
+            },
+            {
+              label: "merchantName",
+              isOptional: true,
+              value: "UDDERS UPPER THOMSON",
+              validationRegex: "^[a-zA-Z0-9 ]*$",
+              textInputType: "STRING",
+            },
+          ],
+        },
+      ]);
+    });
   });
 });

--- a/src/utils/paymentQRHelper.test.ts
+++ b/src/utils/paymentQRHelper.test.ts
@@ -39,10 +39,10 @@ describe("tests for findValueByKey", () => {
 });
 
 describe("tests for updateTransactionsPaymentQRIdentifiers", () => {
-  let transactions: Array<Transaction>;
+  let transactionsBeforeUpdate: Array<Transaction>;
 
   beforeEach(() => {
-    transactions = [
+    transactionsBeforeUpdate = [
       {
         category: "category-a",
         quantity: 1,
@@ -69,8 +69,8 @@ describe("tests for updateTransactionsPaymentQRIdentifiers", () => {
 
   it("should update identifiers properly", () => {
     expect.assertions(1);
-    updateTransactionsPaymentQRIdentifiers(transactions);
-    expect(transactions).toStrictEqual([
+    updateTransactionsPaymentQRIdentifiers(transactionsBeforeUpdate);
+    expect(transactionsBeforeUpdate).toStrictEqual([
       {
         category: "category-a",
         quantity: 1,

--- a/src/utils/paymentQRHelper.test.ts
+++ b/src/utils/paymentQRHelper.test.ts
@@ -1,7 +1,7 @@
 import { Transaction } from "../types";
 import {
   findValueByKey,
-  updateTransactionsPaymentQRIdentifiers,
+  getUpdatedTransactionsPaymentQRIdentifiers,
 } from "./paymentQRHelper";
 
 describe("tests for findValueByKey", () => {
@@ -48,7 +48,7 @@ describe("tests for findValueByKey", () => {
   });
 });
 
-describe("tests for updateTransactionsPaymentQRIdentifiers", () => {
+describe("tests for getUpdatedTransactionsPaymentQRIdentifiers", () => {
   let transactionsBeforeUpdate: Array<Transaction>;
 
   beforeEach(() => {
@@ -72,15 +72,22 @@ describe("tests for updateTransactionsPaymentQRIdentifiers", () => {
             validationRegex: "^[a-zA-Z0-9 ]*$",
             textInputType: "STRING",
           },
+          {
+            label: "propertyThatDoesNotExist",
+            isOptional: true,
+            value: "",
+            textInputType: "STRING",
+          },
         ],
       },
     ];
   });
 
-  it("should update identifiers properly", () => {
+  it("should return updated transactions with identifiers properly", () => {
     expect.assertions(1);
-    updateTransactionsPaymentQRIdentifiers(transactionsBeforeUpdate);
-    expect(transactionsBeforeUpdate).toStrictEqual([
+    expect(
+      getUpdatedTransactionsPaymentQRIdentifiers(transactionsBeforeUpdate)
+    ).toStrictEqual([
       {
         category: "category-a",
         quantity: 1,
@@ -98,6 +105,12 @@ describe("tests for updateTransactionsPaymentQRIdentifiers", () => {
             isOptional: true,
             value: "UDDERS UPPER THOMSON",
             validationRegex: "^[a-zA-Z0-9 ]*$",
+            textInputType: "STRING",
+          },
+          {
+            label: "propertyThatDoesNotExist",
+            isOptional: true,
+            value: "",
             textInputType: "STRING",
           },
         ],

--- a/src/utils/paymentQRHelper.test.ts
+++ b/src/utils/paymentQRHelper.test.ts
@@ -14,6 +14,9 @@ describe("tests for findValueByKey", () => {
         nets: {
           terminalId: "1234567890",
           merchantId: "0987654321",
+          nestedObject: {
+            nestedProperty: "This is nested",
+          },
         },
       },
       merchantName: "Merchant name",
@@ -27,9 +30,16 @@ describe("tests for findValueByKey", () => {
     );
   });
 
-  it("should find nested value by key properly", () => {
+  it("should find two-layer nested value by key properly", () => {
     expect.assertions(1);
     expect(findValueByKey("terminalId", records)).toStrictEqual("1234567890");
+  });
+
+  it("should find three-layer nested value by key properly", () => {
+    expect.assertions(1);
+    expect(findValueByKey("nestedProperty", records)).toStrictEqual(
+      "This is nested"
+    );
   });
 
   it("should return `undefined` if key does not exist", () => {

--- a/src/utils/paymentQRHelper.test.ts
+++ b/src/utils/paymentQRHelper.test.ts
@@ -4,96 +4,94 @@ import {
   updateTransactionsPaymentQRIdentifiers,
 } from "./paymentQRHelper";
 
-describe("tests for paymentQRHelper", () => {
-  describe("tests for findValueByKey", () => {
-    let records: Record<string, unknown>;
+describe("tests for findValueByKey", () => {
+  let records: Record<string, unknown>;
 
-    beforeEach(() => {
-      records = {
-        transactionAmount: 10,
-        merchantAccountInformation: {
-          nets: {
-            terminalId: "1234567890",
-            merchantId: "0987654321",
-          },
+  beforeEach(() => {
+    records = {
+      transactionAmount: 10,
+      merchantAccountInformation: {
+        nets: {
+          terminalId: "1234567890",
+          merchantId: "0987654321",
         },
-        merchantName: "Merchant name",
-      };
-    });
-
-    it("should find value by key properly", () => {
-      expect.assertions(1);
-      expect(findValueByKey("merchantName", records)).toStrictEqual(
-        "Merchant name"
-      );
-    });
-
-    it("should find nested value by key properly", () => {
-      expect.assertions(1);
-      expect(findValueByKey("terminalId", records)).toStrictEqual("1234567890");
-    });
-
-    it("should return `undefined` if key does not exist", () => {
-      expect.assertions(1);
-      expect(findValueByKey("nonExistentKey", records)).toBeUndefined();
-    });
+      },
+      merchantName: "Merchant name",
+    };
   });
 
-  describe("tests for updateTransactionsPaymentQRIdentifiers", () => {
-    let transactions: Array<Transaction>;
+  it("should find value by key properly", () => {
+    expect.assertions(1);
+    expect(findValueByKey("merchantName", records)).toStrictEqual(
+      "Merchant name"
+    );
+  });
 
-    beforeEach(() => {
-      transactions = [
-        {
-          category: "category-a",
-          quantity: 1,
-          identifierInputs: [
-            {
-              label: "Payment QR",
-              scanButtonType: "QR",
-              validationRegex: "[\\s\\S]*",
-              value:
-                "00020101021126520008com.grab0136c99990dc-ab89-442f-accb-1fd96dd4eff627330015sg.com.dash.www0110000000901628460010com.myfave0128https://myfave.com/qr/6ntdz329360009SG.AIRPAY0119936009180000000468751810007SG.SGQR01121809112DE3C7020701.000703065743700402010503105060400000708202012105204581253037025802SG5920UDDERS UPPER THOMSON6009Singapore63047AEC",
-              textInputType: "PAYMENT_QR",
-            },
-            {
-              label: "merchantName",
-              isOptional: true,
-              value: "",
-              validationRegex: "^[a-zA-Z0-9 ]*$",
-              textInputType: "STRING",
-            },
-          ],
-        },
-      ];
-    });
+  it("should find nested value by key properly", () => {
+    expect.assertions(1);
+    expect(findValueByKey("terminalId", records)).toStrictEqual("1234567890");
+  });
 
-    it("should update identifiers properly", () => {
-      expect.assertions(1);
-      updateTransactionsPaymentQRIdentifiers(transactions);
-      expect(transactions).toStrictEqual([
-        {
-          category: "category-a",
-          quantity: 1,
-          identifierInputs: [
-            {
-              label: "Payment QR",
-              scanButtonType: "QR",
-              validationRegex: "[\\s\\S]*",
-              value:
-                "00020101021126520008com.grab0136c99990dc-ab89-442f-accb-1fd96dd4eff627330015sg.com.dash.www0110000000901628460010com.myfave0128https://myfave.com/qr/6ntdz329360009SG.AIRPAY0119936009180000000468751810007SG.SGQR01121809112DE3C7020701.000703065743700402010503105060400000708202012105204581253037025802SG5920UDDERS UPPER THOMSON6009Singapore63047AEC",
-              textInputType: "PAYMENT_QR",
-            },
-            {
-              label: "merchantName",
-              isOptional: true,
-              value: "UDDERS UPPER THOMSON",
-              validationRegex: "^[a-zA-Z0-9 ]*$",
-              textInputType: "STRING",
-            },
-          ],
-        },
-      ]);
-    });
+  it("should return `undefined` if key does not exist", () => {
+    expect.assertions(1);
+    expect(findValueByKey("nonExistentKey", records)).toBeUndefined();
+  });
+});
+
+describe("tests for updateTransactionsPaymentQRIdentifiers", () => {
+  let transactions: Array<Transaction>;
+
+  beforeEach(() => {
+    transactions = [
+      {
+        category: "category-a",
+        quantity: 1,
+        identifierInputs: [
+          {
+            label: "Payment QR",
+            scanButtonType: "QR",
+            validationRegex: "[\\s\\S]*",
+            value:
+              "00020101021126520008com.grab0136c99990dc-ab89-442f-accb-1fd96dd4eff627330015sg.com.dash.www0110000000901628460010com.myfave0128https://myfave.com/qr/6ntdz329360009SG.AIRPAY0119936009180000000468751810007SG.SGQR01121809112DE3C7020701.000703065743700402010503105060400000708202012105204581253037025802SG5920UDDERS UPPER THOMSON6009Singapore63047AEC",
+            textInputType: "PAYMENT_QR",
+          },
+          {
+            label: "merchantName",
+            isOptional: true,
+            value: "",
+            validationRegex: "^[a-zA-Z0-9 ]*$",
+            textInputType: "STRING",
+          },
+        ],
+      },
+    ];
+  });
+
+  it("should update identifiers properly", () => {
+    expect.assertions(1);
+    updateTransactionsPaymentQRIdentifiers(transactions);
+    expect(transactions).toStrictEqual([
+      {
+        category: "category-a",
+        quantity: 1,
+        identifierInputs: [
+          {
+            label: "Payment QR",
+            scanButtonType: "QR",
+            validationRegex: "[\\s\\S]*",
+            value:
+              "00020101021126520008com.grab0136c99990dc-ab89-442f-accb-1fd96dd4eff627330015sg.com.dash.www0110000000901628460010com.myfave0128https://myfave.com/qr/6ntdz329360009SG.AIRPAY0119936009180000000468751810007SG.SGQR01121809112DE3C7020701.000703065743700402010503105060400000708202012105204581253037025802SG5920UDDERS UPPER THOMSON6009Singapore63047AEC",
+            textInputType: "PAYMENT_QR",
+          },
+          {
+            label: "merchantName",
+            isOptional: true,
+            value: "UDDERS UPPER THOMSON",
+            validationRegex: "^[a-zA-Z0-9 ]*$",
+            textInputType: "STRING",
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/src/utils/paymentQRHelper.ts
+++ b/src/utils/paymentQRHelper.ts
@@ -1,3 +1,6 @@
+import { parseAndValidateSGQR } from "@rationally-app/payment-qr-parser";
+import { Transaction } from "../types";
+
 /**
  * Returns the value of the first element in the provided record key.
  * If the provided record key does not exist, `undefined` is returned.
@@ -25,4 +28,45 @@ export const findValueByKey = (
   }
 
   return undefined;
+};
+
+/**
+ * Update transaction identifiers using parsed payment QR payload values.
+ *
+ * Each transaction's identifiers contain identifiers with `textInputType` `PAYMENT_QR`, which
+ * are payment QR payloads that shall be parsed.
+ *
+ * The parsed values are used to update identifiers where (1) `isOptional` is `true`, and (2)
+ * their `label` matches a key in the parsed payment QR payload. Only identifiers in the same
+ * transaction are updated.
+ *
+ * @param transactions Array of transaction data
+ */
+export const updateTransactionsPaymentQRIdentifiers = (
+  transactions: Array<Transaction>
+): void => {
+  transactions.forEach(({ identifierInputs }) => {
+    if (identifierInputs) {
+      const paymentQRPayload = identifierInputs.find(
+        ({ textInputType }) => textInputType === "PAYMENT_QR"
+      )?.value;
+
+      if (paymentQRPayload) {
+        // TODO: Expand support for payment QRs
+        // TODO: Perform preliminary parsing to determine payload type, then perform parsing
+        const paymentQRRecords = parseAndValidateSGQR(
+          paymentQRPayload
+        ) as Record<string, unknown>;
+
+        identifierInputs.forEach(
+          ({ textInputType, isOptional, label, value }, index) => {
+            if (textInputType !== "PAYMENT_QR" && isOptional) {
+              identifierInputs[index].value =
+                findValueByKey(label, paymentQRRecords) ?? value;
+            }
+          }
+        );
+      }
+    }
+  });
 };

--- a/src/utils/paymentQRHelper.ts
+++ b/src/utils/paymentQRHelper.ts
@@ -1,0 +1,28 @@
+/**
+ * Returns the value of the first element in the provided record key.
+ * If the provided record key does not exist, `undefined` is returned.
+ *
+ * @param key Record key to locate
+ * @param record Record containing keys and values
+ * @returns Value in provided record key as `string` if found, otherwise `undefined`
+ */
+export const findValueByKey = (
+  key: string,
+  record: Record<string, unknown>
+): string | undefined => {
+  for (const k in record) {
+    if (k === key) {
+      return record[k] as string;
+    }
+
+    if (record[k] instanceof Object) {
+      const result = findValueByKey(key, record[k] as Record<string, unknown>);
+
+      if (result) {
+        return result;
+      }
+    }
+  }
+
+  return undefined;
+};

--- a/src/utils/paymentQrValidation.ts
+++ b/src/utils/paymentQrValidation.ts
@@ -2,6 +2,7 @@ import { parseAndValidateSGQR } from "@rationally-app/payment-qr-parser";
 
 const paymentQrValidate = (paymentQr: string): boolean => {
   try {
+    // TODO: Expand support for payment QRs
     parseAndValidateSGQR(paymentQr);
   } catch (e) {
     return false;


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Parse-Validate-and-Save-into-s3-Leverage-Sally-app-to-capture-payment-QR-for-merchant-ringfencing-a4f8b184c0114285b4fd2c4bf44f427d) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->

- Utilities for parsing and storing `PAYMENT_QR` and its properties
- Parse`PAYMENT_QR` identifiers and update existing identifiers if they `isOptional` is `true` and their `label`s match parsed payment QR

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
