### PR TITLE
fix: remove leading and trailing spaces in dropdown filter modal search input

### DIFF
--- a/src/components/DropdownFilterModal/DropdownFilterModal.tsx
+++ b/src/components/DropdownFilterModal/DropdownFilterModal.tsx
@@ -149,7 +149,7 @@ export const DropdownFilterModal: FunctionComponent<DropdownFilterModal> = ({
     const newData = dropdownItems.filter((item) => {
       return c13nt(item.value, undefined, item.label)
         .toUpperCase()
-        .includes(text.trim().toUpperCase());
+        .includes(text.trim().replace(/\s+/g, " ").toUpperCase());
     });
     setFilterState(newData);
   };

--- a/src/components/DropdownFilterModal/DropdownFilterModal.tsx
+++ b/src/components/DropdownFilterModal/DropdownFilterModal.tsx
@@ -149,7 +149,7 @@ export const DropdownFilterModal: FunctionComponent<DropdownFilterModal> = ({
     const newData = dropdownItems.filter((item) => {
       return c13nt(item.value, undefined, item.label)
         .toUpperCase()
-        .includes(text.toUpperCase());
+        .includes(text.trim().toUpperCase());
     });
     setFilterState(newData);
   };


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Nationality-Waiver-reason-leading-space-should-filter-off-all-countries-190d7e617bf4436a871cf5a28f5beb32) 

This PR removes leading and trailing spaces in dropdown filter modal search input.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [X] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [X] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
