### PR TITLE
fix: add sessionExpired error msg and map it to sessionError in alertContext

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -218,6 +218,11 @@ export const en: Translations = {
       body: "Only use your QR code during the validity period.",
       primaryActionText: "OK",
     },
+    expiredSession: {
+      title: "Expired",
+      body: "Login again with the QR code provided by your in-charge",
+      primaryActionText: "OK",
+    },
     expiredOTP: {
       title: "Expired",
       body: "Get a new OTP and try again.",

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -218,6 +218,12 @@ export type Translations = {
       primaryActionText: string;
       secondaryActionText?: string;
     };
+    expiredSession: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+      secondaryActionText?: string;
+    };
     expiredOTP: {
       title: string;
       body?: string;

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -210,6 +210,11 @@ export const zh: Translations = {
       body: "仅限于在有效期内使用您的QR码。",
       primaryActionText: "确定",
     },
+    expiredSession: {
+      title: "过期",
+      body: "请扫描您的负责人提供的QR码再次登录。",
+      primaryActionText: "确定",
+    },
     expiredOTP: {
       title: "过期",
       body: "获取新的一次性密码后再试一次。",

--- a/src/components/DailyStatistics/DailyStatisticsScreen.tsx
+++ b/src/components/DailyStatistics/DailyStatisticsScreen.tsx
@@ -94,9 +94,7 @@ const DailyStatisticsScreen: FunctionComponent<NavigationProps> = ({
 
   useEffect(() => {
     if (error) {
-      showErrorAlert(new Error(ERROR_MESSAGE.SERVER_ERROR), () =>
-        navigateHome(navigation)
-      );
+      showErrorAlert(error, () => navigateHome(navigation));
     }
   }, [error, navigation, showErrorAlert]);
 

--- a/src/components/DailyStatistics/DailyStatisticsScreen.tsx
+++ b/src/components/DailyStatistics/DailyStatisticsScreen.tsx
@@ -22,7 +22,7 @@ import { KeyboardAvoidingScrollView } from "../Layout/KeyboardAvoidingScrollView
 import { TransactionHistoryCard } from "./TransactionHistoryCard";
 import { StatisticsHeader } from "./StatisticsHeader";
 import { addDays, subDays, getTime, isSameDay } from "date-fns";
-import { AlertModalContext, ERROR_MESSAGE } from "../../context/alert";
+import { AlertModalContext } from "../../context/alert";
 import { navigateHome } from "../../common/navigation";
 import { NavigationProps } from "../../types";
 import { useDailyStatistics } from "../../hooks/useDailyStatistics/useDailyStatistics";

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -65,7 +65,7 @@ export enum ERROR_MESSAGE {
 
 const errorNameToTranslationKeyMappings: Record<string, string> = {
   CampaignConfigError: "systemErrorConnectivityIssues",
-  SessionError: "expiredQR",
+  SessionError: "expiredSession",
   PastTransactionError: "systemErrorServerIssues",
   QuotaError: "systemErrorConnectivityIssues",
   LockError: "systemErrorConnectivityIssues",

--- a/src/hooks/useDailyStatistics/useDailyStatistics.tsx
+++ b/src/hooks/useDailyStatistics/useDailyStatistics.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useEffect } from "react";
+import { useState, useContext, useEffect, useCallback } from "react";
 import { usePrevious } from "../usePrevious";
 import { CampaignConfigContext } from "../../context/campaignConfig";
 import { getDailyStatistics } from "../../services/statistics";
@@ -17,6 +17,7 @@ export type StatisticsHook = {
   }[];
   error?: Error;
   loading: boolean;
+  clearDailyStatisticsError: () => void;
 };
 
 export const useDailyStatistics = (
@@ -40,6 +41,11 @@ export const useDailyStatistics = (
   const { policies } = useContext(CampaignConfigContext);
   const prevTimestamp = usePrevious(currentTimestamp);
   const translationProps = useTranslate();
+
+  const clearDailyStatisticsError = useCallback(
+    (): void => setError(undefined),
+    []
+  );
 
   useEffect(() => {
     const fetchDailyStatistics = async (): Promise<void> => {
@@ -95,5 +101,6 @@ export const useDailyStatistics = (
     transactionHistory,
     error,
     loading,
+    clearDailyStatisticsError,
   };
 };

--- a/src/services/statistics/index.tsx
+++ b/src/services/statistics/index.tsx
@@ -1,6 +1,6 @@
 import { IS_MOCK } from "../../config";
 import { DailyStatisticsResult } from "../../types";
-import { fetchWithValidator, ValidationError } from "../helpers";
+import { fetchWithValidator, ValidationError, SessionError } from "../helpers";
 import { Sentry } from "../../utils/errorTracking";
 import { subDays, addDays, getTime, isSameDay } from "date-fns";
 
@@ -148,6 +148,8 @@ export const liveGetStatistics = async (
   } catch (e) {
     if (e instanceof ValidationError) {
       Sentry.captureException(e);
+    } else if (e instanceof SessionError) {
+      throw e;
     }
 
     throw new StatisticsError(e.message);


### PR DESCRIPTION
Given someone else uses your QR to login, when you try to enter an NRIC to check for quota, you will see an expired modal. This can be confusing because it's not expired, but rather, the code has already been used by someone else. [Notion link](https://www.notion.so/sally-wallet/Session-errors-should-be-broken-down-further-bfb7d69e5a9747ce8ef8c3383733843c)

This PR adds sessionExpired [error msg](https://www.notion.so/sally-wallet/Error-Message-c8d8b16fec154e738f7274026616b0a7) and map it to sessionError in alert. 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [X] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [X] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [X] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
