### PR TITLE
fix: add expiry check toggle to `parsePaymentQR`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2874,11 +2874,11 @@
       "integrity": "sha512-fMZGowUxJFDaaJ9Ntxi0qNi4J2BUms3DffOADoMkVf+A650BFL2nARpv0vdwzGa+kxkAyU/ot95fTWZoJm4YJA=="
     },
     "@rationally-app/payment-qr-parser": {
-      "version": "1.7.0",
-      "resolved": "https://npm.pkg.github.com/download/@rationally-app/payment-qr-parser/1.7.0/24811c7e7c4eaaec94ecb68cf720420ecae2b7dd9b96a97a1659f92d86b0b07f",
-      "integrity": "sha512-Yt40NKCUpCeYdK5UKqZUDt9Vrg90ycMBg6R0nK1lbj3e56L7MuuOkzvNso8cWsojZclOsNIwqCXuZwJ+iLw+mg==",
+      "version": "2.1.4",
+      "resolved": "https://npm.pkg.github.com/download/@rationally-app/payment-qr-parser/2.1.4/c9a347effc0053a7d40adc086f43c43558e01c300b6d2cf2e471685cc513e82f",
+      "integrity": "sha512-s9pHLtZCVipeJ1xlkKm0Qk6YePZEFr1SYXKnzuKwWm6lHREcTuImnkX9qiZSZ3HSTxgSkX7//svxjYEkytcFcA==",
       "requires": {
-        "ajv": "^8.8.2",
+        "ajv": "^8.9.0",
         "date-fns": "^2.28.0",
         "date-fns-tz": "^1.2.2",
         "debug": "^4.3.3"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@rationally-app/nric-validator": "^1.1.3",
-    "@rationally-app/payment-qr-parser": "^1.7.0",
+    "@rationally-app/payment-qr-parser": "^2.1.4",
     "@react-native-async-storage/async-storage": "^1.15.5",
     "date-fns": "^2.21.1",
     "expo": "^42.0.0",

--- a/src/utils/paymentQRHelper.ts
+++ b/src/utils/paymentQRHelper.ts
@@ -62,7 +62,10 @@ export const getUpdatedTransactionsPaymentQRIdentifiers = (
 
       if (paymentQRPayload) {
         // We can safely parse payment QR here since it has been validated upstream
-        const paymentQR = parsePaymentQR(paymentQRPayload) as PaymentQR;
+        const paymentQR = parsePaymentQR(paymentQRPayload, {
+          source: "PAYMENT_QR_IDENTIFIERS_UPDATE",
+          checkExpiry: false,
+        }) as PaymentQR;
         paymentQR.merchantAccountInformation = pick(
           paymentQR.merchantAccountInformation,
           ["nets"]

--- a/src/utils/paymentQrValidation.ts
+++ b/src/utils/paymentQrValidation.ts
@@ -16,7 +16,10 @@ export class PaymentQRUnsupportedError extends Error {
 
 const isValidPaymentQR = (payload: string): boolean => {
   try {
-    const paymentQR = parsePaymentQR(payload);
+    const paymentQR = parsePaymentQR(payload, {
+      source: "PAYMENT_QR_IS_VALID",
+      checkExpiry: false,
+    });
     const supportedPaymentMerchantAccounts = pick(
       paymentQR.merchantAccountInformation,
       ["nets"]


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Parse-Validate-and-Save-into-s3-Leverage-Sally-app-to-capture-payment-QR-for-merchant-ringfencing-a4f8b184c0114285b4fd2c4bf44f427d#25d7316c1b124cb8b35b50c69691e7cd) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->

- Updates `@rationally-app/payment-qr-parser` from `1.7.0` to `2.1.4`
- Adds `checkExpiry` toggle to `parsePaymentQR` to prevent checking of expiry dates in `@rationally-app/payment-qr-parser`, since it does not play nice with Android

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
