### PR TITLE
build: change lint step to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/deploy_branch_preview.yml
+++ b/.github/workflows/deploy_branch_preview.yml
@@ -18,7 +18,11 @@ jobs:
       - name: check if PR title follows conventional commits specs
         uses: amannn/action-semantic-pull-request@v3.4.2
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_SUPPLYALLY_BOT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+          # using github token for external/dependabot PR,
+          # personal access tokens in secrets will not be accessible in
+          # pipeline for external user PRs
+
   test:
     name: Lint & Test
     runs-on: ubuntu-18.04
@@ -36,8 +40,8 @@ jobs:
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-	
-            ${{ runner.os }}-build-	
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: Install Packages
         run: |


### PR DESCRIPTION
changing the lint action to use default GITHUB_TOKEN as it is sufficient for it, no need to provide it with our bot token