### PR TITLE
fix: remove misleading sentry logs and amend error messages for non-editable fields

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -331,7 +331,7 @@ export const en: Translations = {
     },
     alreadyUsedCode: {
       title: "Already Used",
-      body: "Enter or scan a unique code.",
+      body: "Scan a unique code.",
       primaryActionText: "OK",
     },
     alreadyUsedItem: {
@@ -341,7 +341,7 @@ export const en: Translations = {
     },
     wrongFormatCode: {
       title: "Wrong format",
-      body: "Enter or scan a valid code.",
+      body: "Scan a valid code.",
       primaryActionText: "OK",
     },
     incompleteWaiveReason: {
@@ -351,7 +351,7 @@ export const en: Translations = {
     },
     incompleteEntryCode: {
       title: "Incomplete entry",
-      body: "Enter or scan a valid code.",
+      body: "Scan a code.",
       primaryActionText: "OK",
     },
     wrongFormatNotValidDeviceCode: {
@@ -459,17 +459,17 @@ export const en: Translations = {
     },
     deformedPaymentQR: {
       title: "Deformed payment QR",
-      body: "Enter or scan a valid code.",
+      body: "Scan a valid code.",
       primaryActionText: "OK",
     },
     missingInfoInPaymentQR: {
       title: "Missing info in payment QR",
-      body: "Enter or scan a valid code.",
+      body: "Scan a code.",
       primaryActionText: "OK",
     },
     unsupportedPaymentMethodInPaymentQR: {
       title: "Unsupported payment method",
-      body: "Enter or scan a valid code.",
+      body: "Scan a valid code.",
       primaryActionText: "OK",
     },
   },

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -321,7 +321,7 @@ export const zh: Translations = {
     },
     alreadyUsedCode: {
       title: "已使用",
-      body: "请输入独特的编号。",
+      body: "请扫描独特的编号。",
       primaryActionText: "确定",
     },
     alreadyUsedItem: {
@@ -331,7 +331,7 @@ export const zh: Translations = {
     },
     wrongFormatCode: {
       title: "格式错误",
-      body: "请输入或扫描有效的编号。",
+      body: "请扫描有效的编号。",
       primaryActionText: "确定",
     },
     incompleteWaiveReason: {
@@ -341,7 +341,7 @@ export const zh: Translations = {
     },
     incompleteEntryCode: {
       title: "资料输入不完整",
-      body: "请输入或扫描编号。",
+      body: "请扫描编号。",
       primaryActionText: "确定",
     },
     wrongFormatNotValidDeviceCode: {
@@ -447,17 +447,17 @@ export const zh: Translations = {
     },
     deformedPaymentQR: {
       title: "Deformed payment QR",
-      body: "请输入或扫描有效的编号。",
+      body: "请扫描有效的编号。",
       primaryActionText: "确定",
     },
     missingInfoInPaymentQR: {
       title: "Missing info in payment QR",
-      body: "请输入或扫描有效的编号。",
+      body: "请扫描编号。",
       primaryActionText: "确定",
     },
     unsupportedPaymentMethodInPaymentQR: {
       title: "Unsupported payment method",
-      body: "请输入或扫描有效的编号。",
+      body: "请扫描有效的编号。",
       primaryActionText: "确定",
     },
   },

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -23,17 +23,17 @@ export enum CONFIRMATION_MESSAGE {
 }
 
 export enum ERROR_MESSAGE {
-  DUPLICATE_IDENTIFIER_INPUT = "Enter or scan a different code.",
+  DUPLICATE_IDENTIFIER_INPUT = "Scan a different code.",
   DUPLICATE_POD_INPUT = "Scan another item that is not tagged to any ID number.",
   MISSING_WAIVER_INPUT = "Enter a valid waiver reason",
-  INVALID_IDENTIFIER_INPUT = "Enter or scan a valid code.",
-  MISSING_IDENTIFIER_INPUT = "Enter or scan a code.",
+  INVALID_IDENTIFIER_INPUT = "Scan a valid code.",
+  MISSING_IDENTIFIER_INPUT = "Scan a code.",
   INVALID_VOUCHER_INPUT = "Enter a valid voucher code.",
   MISSING_VOUCHER_INPUT = "Enter a voucher code.",
   INVALID_POD_INPUT = "Scan a valid device code.",
   MISSING_POD_INPUT = "Scan a device code.",
   INVALID_POD_IDENTIFIER = "Scan item again or get a new item from your in-charge.",
-  ALREADY_USED_POD_IDENTIFIER = "Enter or scan an unique code.",
+  ALREADY_USED_POD_IDENTIFIER = "Scan an unique code.",
   INVALID_PHONE_NUMBER = "Enter a valid contact number.",
   INVALID_COUNTRY_CODE = "Enter a valid country code.",
   INVALID_PHONE_AND_COUNTRY_CODE = "Enter a valid country code and contact number.",
@@ -248,9 +248,6 @@ export const AlertModalContextProvider: FunctionComponent = ({ children }) => {
         buttonTexts: {
           primaryActionText:
             i18n.t(`errorMessages.${translationKey}.primaryActionText`) ?? "OK",
-          secondaryActionText: i18n.t(
-            `errorMessages.${translationKey}.secondaryActionText`
-          ),
         },
         visible: true,
         onOk: !!onClickPrimaryAction ? onClickPrimaryAction : () => {},
@@ -278,9 +275,6 @@ export const AlertModalContextProvider: FunctionComponent = ({ children }) => {
         buttonTexts: {
           primaryActionText: i18n.t(
             `errorMessages.${translationKey}.primaryActionText`
-          ),
-          secondaryActionText: i18n.t(
-            `errorMessages.${translationKey}.secondaryActionText`
           ),
         },
         visible: true,

--- a/src/hooks/useCart/useCart.test.tsx
+++ b/src/hooks/useCart/useCart.test.tsx
@@ -908,7 +908,7 @@ describe("useCart", () => {
       ]);
     });
 
-    it("should set cartError with message 'Enter or scan a code' when there are multiple identifiers and at least one is empty", async () => {
+    it("should set cartError with message 'Scan a code' when there are multiple identifiers and at least one is empty", async () => {
       expect.assertions(3);
       const ids = ["ID1"];
       const { result } = renderHook(
@@ -936,7 +936,9 @@ describe("useCart", () => {
         result.current.checkoutCart();
       });
 
-      expect(result.current.cartError?.message).toBe("Enter or scan a code.");
+      expect(result.current.cartError?.message).toBe(
+        ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT
+      );
       expect(result.current.cartState).toBe("DEFAULT");
       expect(result.current.cart).toStrictEqual([
         {
@@ -971,7 +973,7 @@ describe("useCart", () => {
       ]);
     });
 
-    it("should set cartError with message 'Enter or scan a code' when there is one identifier and it is empty", async () => {
+    it("should set cartError with message 'Scan a code' when there is one identifier and it is empty", async () => {
       expect.assertions(3);
 
       const ids = ["ID1"];
@@ -1007,7 +1009,9 @@ describe("useCart", () => {
         result.current.checkoutCart();
       });
 
-      expect(result.current.cartError?.message).toBe("Enter or scan a code.");
+      expect(result.current.cartError?.message).toBe(
+        ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT
+      );
       expect(result.current.cartState).toBe("DEFAULT");
       expect(result.current.cart).toStrictEqual([
         {
@@ -1028,7 +1032,7 @@ describe("useCart", () => {
       ]);
     });
 
-    it("should set cartError with message 'Enter or scan a different code.' when identifier values are identical in the same category", async () => {
+    it("should set cartError with message 'Scan a different code.' when identifier values are identical in the same category", async () => {
       expect.assertions(3);
       const ids = ["ID1"];
       const { result } = renderHook(
@@ -1057,7 +1061,7 @@ describe("useCart", () => {
       });
 
       expect(result.current.cartError?.message).toBe(
-        "Enter or scan a different code."
+        ERROR_MESSAGE.DUPLICATE_IDENTIFIER_INPUT
       );
       expect(result.current.cartState).toBe("DEFAULT");
       expect(result.current.cart).toStrictEqual([
@@ -1093,7 +1097,7 @@ describe("useCart", () => {
       ]);
     });
 
-    it("should set cartError with message 'Enter or scan a different code.' when some identifier values are identical across different categories", async () => {
+    it("should set cartError with message 'Scan a different code.' when some identifier values are identical across different categories", async () => {
       expect.assertions(3);
       const ids = ["ID1"];
       const { result } = renderHook(
@@ -1136,7 +1140,7 @@ describe("useCart", () => {
       });
 
       expect(result.current.cartError?.message).toBe(
-        "Enter or scan a different code."
+        ERROR_MESSAGE.DUPLICATE_IDENTIFIER_INPUT
       );
       expect(result.current.cartState).toBe("DEFAULT");
       expect(result.current.cart).toStrictEqual([
@@ -1310,7 +1314,7 @@ describe("useCart", () => {
       });
 
       expect(result.current.cartError?.message).toBe(
-        "Enter or scan a valid code."
+        ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT
       );
       expect(result.current.cartState).toBe("DEFAULT");
       expect(result.current.cart).toStrictEqual([

--- a/src/utils/validateIdentifierInputs.test.ts
+++ b/src/utils/validateIdentifierInputs.test.ts
@@ -146,7 +146,7 @@ describe("validateIdentifierInputs", () => {
           textInputType: "NUMBER",
         },
       ])
-    ).toThrow("Enter or scan a valid code.");
+    ).toThrow(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
     expect(() =>
       validateIdentifierInputs([
         {
@@ -156,7 +156,7 @@ describe("validateIdentifierInputs", () => {
           textInputType: "STRING",
         },
       ])
-    ).toThrow("Enter or scan a valid code.");
+    ).toThrow(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
   });
 
   it("should throw error if at least one of the identifiers is an invalid number", () => {
@@ -169,7 +169,7 @@ describe("validateIdentifierInputs", () => {
           textInputType: "NUMBER",
         },
       ])
-    ).toThrow("Enter or scan a valid code.");
+    ).toThrow(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
     expect(() =>
       validateIdentifierInputs([
         {
@@ -178,7 +178,7 @@ describe("validateIdentifierInputs", () => {
           textInputType: "NUMBER",
         },
       ])
-    ).toThrow("Enter or scan a valid code.");
+    ).toThrow(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
   });
 
   it("should throw error if at least one of the identifiers is an invalid phone number", () => {
@@ -213,7 +213,7 @@ describe("validateIdentifierInputs", () => {
           textInputType: "STRING",
         },
       ])
-    ).toThrow("Enter or scan a code.");
+    ).toThrow(ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT);
     expect(() =>
       validateIdentifierInputs([
         {
@@ -227,7 +227,7 @@ describe("validateIdentifierInputs", () => {
           textInputType: "STRING",
         },
       ])
-    ).toThrow("Enter or scan a code.");
+    ).toThrow(ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT);
   });
 
   it("should throw error if there are duplicate values", () => {
@@ -250,7 +250,7 @@ describe("validateIdentifierInputs", () => {
           textInputType: "STRING",
         },
       ])
-    ).toThrow("Enter or scan a different code.");
+    ).toThrow(ERROR_MESSAGE.DUPLICATE_IDENTIFIER_INPUT);
   });
 
   it("should throw the specific error if the textInputType is payment receipt", () => {
@@ -313,7 +313,7 @@ describe("validateIdentifierInputs", () => {
           validationRegex: "[\\s\\S]*",
         },
       ])
-    ).toThrow("Enter or scan a valid code.");
+    ).toThrow("Scan a valid code.");
   });
 });
 


### PR DESCRIPTION
Notion Links
(1) [remove-misleading-sentry-logs](https://www.notion.so/sally-wallet/Remove-misleading-Sentry-logs-A-missing-translation-of-scope-errorMessages-X-secondaryActionText--c8debc4e7b59415e8a6ba0e198db42a3)
(2) [amend-error-message-for-non-editable-field](https://www.notion.so/sally-wallet/Amend-error-message-for-non-editable-field-from-Enter-or-scan-a-valid-code-to-Scan-a-valid-code-d76a6a7033964d46921fa8e6ff9d0e84)

This PR remove misleading sentry logs and amend error messages for non-editable fields.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [X] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [X] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [X] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [X] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
