### PR TITLE
fix: amend error message for non-editable identifier text inputs

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -344,6 +344,11 @@ export const en: Translations = {
       body: "Enter or scan a valid code.",
       primaryActionText: "OK",
     },
+    wrongFormatCodeTextDisabled: {
+      title: "Wrong format",
+      body: "Scan a valid code.",
+      primaryActionText: "OK",
+    },
     incompleteWaiveReason: {
       title: "Incomplete entry",
       body: "Enter a valid waive reason.",
@@ -352,6 +357,11 @@ export const en: Translations = {
     incompleteEntryCode: {
       title: "Incomplete entry",
       body: "Enter or scan a valid code.",
+      primaryActionText: "OK",
+    },
+    incompleteEntryCodeTextDisabled: {
+      title: "Incomplete entry",
+      body: "Scan a valid code.",
       primaryActionText: "OK",
     },
     wrongFormatNotValidDeviceCode: {
@@ -470,6 +480,21 @@ export const en: Translations = {
     unsupportedPaymentMethodInPaymentQR: {
       title: "Unsupported payment method",
       body: "Enter or scan a valid code.",
+      primaryActionText: "OK",
+    },
+    deformedPaymentQRTextDisabled: {
+      title: "Deformed payment QR",
+      body: "Scan a valid code.",
+      primaryActionText: "OK",
+    },
+    missingInfoInPaymentQRTextDisabled: {
+      title: "Missing info in payment QR",
+      body: "Scan a valid code.",
+      primaryActionText: "OK",
+    },
+    unsupportedPaymentMethodInPaymentQRTextDisabled: {
+      title: "Unsupported payment method",
+      body: "Scan a valid code.",
       primaryActionText: "OK",
     },
   },

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -361,6 +361,12 @@ export type Translations = {
       primaryActionText: string;
       secondaryActionText?: string;
     };
+    wrongFormatCodeTextDisabled: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+      secondaryActionText?: string;
+    };
     incompleteWaiveReason: {
       title: string;
       body?: string;
@@ -368,6 +374,12 @@ export type Translations = {
       secondaryActionText?: string;
     };
     incompleteEntryCode: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+      secondaryActionText?: string;
+    };
+    incompleteEntryCodeTextDisabled: {
       title: string;
       body?: string;
       primaryActionText: string;
@@ -499,6 +511,21 @@ export type Translations = {
       primaryActionText: string;
     };
     unsupportedPaymentMethodInPaymentQR: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+    };
+    deformedPaymentQRTextDisabled: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+    };
+    missingInfoInPaymentQRTextDisabled: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+    };
+    unsupportedPaymentMethodInPaymentQRTextDisabled: {
       title: string;
       body?: string;
       primaryActionText: string;

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -334,6 +334,11 @@ export const zh: Translations = {
       body: "请输入或扫描有效的编号。",
       primaryActionText: "确定",
     },
+    wrongFormatCodeTextDisabled: {
+      title: "格式错误",
+      body: "请扫描有效的编号。",
+      primaryActionText: "确定",
+    },
     incompleteWaiveReason: {
       title: "资料输入不完整",
       body: "请输入有效的豁免原因。",
@@ -342,6 +347,11 @@ export const zh: Translations = {
     incompleteEntryCode: {
       title: "资料输入不完整",
       body: "请输入或扫描编号。",
+      primaryActionText: "确定",
+    },
+    incompleteEntryCodeTextDisabled: {
+      title: "资料输入不完整",
+      body: "请扫描编号。",
       primaryActionText: "确定",
     },
     wrongFormatNotValidDeviceCode: {
@@ -458,6 +468,21 @@ export const zh: Translations = {
     unsupportedPaymentMethodInPaymentQR: {
       title: "Unsupported payment method",
       body: "请输入或扫描有效的编号。",
+      primaryActionText: "确定",
+    },
+    deformedPaymentQRTextDisabled: {
+      title: "Deformed payment QR",
+      body: "请扫描有效的编号。",
+      primaryActionText: "确定",
+    },
+    missingInfoInPaymentQRTextDisabled: {
+      title: "Missing info in payment QR",
+      body: "请扫描有效的编号。",
+      primaryActionText: "确定",
+    },
+    unsupportedPaymentMethodInPaymentQRTextDisabled: {
+      title: "Unsupported payment method",
+      body: "请扫描有效的编号。",
       primaryActionText: "确定",
     },
   },

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -34,7 +34,12 @@ import { SessionError } from "../../services/helpers";
 import { useQuota } from "../../hooks/useQuota/useQuota";
 import { AuthStoreContext } from "../../context/authStore";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
-import { PaymentQRUnsupportedError } from "../../utils/paymentQrValidation";
+import {
+  PaymentQRUnsupportedError,
+  PaymentQRUnsupportedErrorTextDisabled,
+  PaymentQRMissingInfoErrorDisabled,
+  PaymentQRDeformedErrorTextDisabled,
+} from "../../utils/paymentQrValidation";
 import {
   PaymentQRDeformedError,
   PaymentQRMissingInfoError,
@@ -195,7 +200,10 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
           return;
         case cartError instanceof PaymentQRDeformedError ||
           cartError instanceof PaymentQRMissingInfoError ||
-          cartError instanceof PaymentQRUnsupportedError:
+          cartError instanceof PaymentQRUnsupportedError ||
+          cartError instanceof PaymentQRUnsupportedErrorTextDisabled ||
+          cartError instanceof PaymentQRMissingInfoErrorDisabled ||
+          cartError instanceof PaymentQRDeformedErrorTextDisabled:
           showErrorAlert(cartError, () => clearCartError());
           return;
       }

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -200,22 +200,30 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
           return;
       }
       if (cartState === "DEFAULT" || cartState === "CHECKING_OUT") {
+        const invalidIdentifierInputErrMsg =
+          ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT ||
+          ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED;
+
+        const missingIdentifierInputErrMsg =
+          ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT ||
+          ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT_TEXT_DISABLED;
+
         switch (cartError.message) {
-          case ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT:
+          case missingIdentifierInputErrMsg:
             const missingIdentifierInputError = new Error(
               campaignFeatures?.campaignName === "TT Tokens"
                 ? ERROR_MESSAGE.MISSING_POD_INPUT
                 : campaignFeatures?.campaignName.includes("Vouchers")
                 ? ERROR_MESSAGE.MISSING_VOUCHER_INPUT
-                : ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT
+                : missingIdentifierInputErrMsg
             );
             showErrorAlert(missingIdentifierInputError, () => clearCartError());
             break;
-          case ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT:
+          case invalidIdentifierInputErrMsg:
             const invalidIdentifierInputError = new Error(
               campaignFeatures?.campaignName === "TT Tokens"
                 ? ERROR_MESSAGE.INVALID_POD_INPUT
-                : ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT
+                : invalidIdentifierInputErrMsg
             );
             Sentry.captureException(invalidIdentifierInputError);
             showErrorAlert(invalidIdentifierInputError, () => clearCartError());

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -34,7 +34,11 @@ import { SessionError } from "../../services/helpers";
 import { useQuota } from "../../hooks/useQuota/useQuota";
 import { AuthStoreContext } from "../../context/authStore";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
-import { PaymentQRError } from "../../utils/paymentQrValidation";
+import { PaymentQRUnsupportedError } from "../../utils/paymentQrValidation";
+import {
+  PaymentQRDeformedError,
+  PaymentQRMissingInfoError,
+} from "@rationally-app/payment-qr-parser";
 
 type CustomerQuotaProps = NavigationProps & { navIds: string[] };
 
@@ -189,8 +193,10 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
             navigation.navigate("CampaignLocationsScreen");
           });
           return;
-        case cartError instanceof PaymentQRError:
-          showErrorAlert(cartError, () => clearCartError());
+        case cartError instanceof PaymentQRDeformedError ||
+          cartError instanceof PaymentQRMissingInfoError ||
+          cartError instanceof PaymentQRUnsupportedError:
+          showErrorAlert(new Error(cartError.message), () => clearCartError());
           return;
       }
       if (cartState === "DEFAULT" || cartState === "CHECKING_OUT") {

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -34,16 +34,7 @@ import { SessionError } from "../../services/helpers";
 import { useQuota } from "../../hooks/useQuota/useQuota";
 import { AuthStoreContext } from "../../context/authStore";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
-import {
-  PaymentQRUnsupportedError,
-  PaymentQRUnsupportedErrorTextDisabled,
-  PaymentQRMissingInfoErrorDisabled,
-  PaymentQRDeformedErrorTextDisabled,
-} from "../../utils/paymentQrValidation";
-import {
-  PaymentQRDeformedError,
-  PaymentQRMissingInfoError,
-} from "@rationally-app/payment-qr-parser";
+import { PaymentQRError } from "../../utils/paymentQrValidation";
 
 type CustomerQuotaProps = NavigationProps & { navIds: string[] };
 
@@ -198,12 +189,7 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
             navigation.navigate("CampaignLocationsScreen");
           });
           return;
-        case cartError instanceof PaymentQRDeformedError ||
-          cartError instanceof PaymentQRMissingInfoError ||
-          cartError instanceof PaymentQRUnsupportedError ||
-          cartError instanceof PaymentQRUnsupportedErrorTextDisabled ||
-          cartError instanceof PaymentQRMissingInfoErrorDisabled ||
-          cartError instanceof PaymentQRDeformedErrorTextDisabled:
+        case cartError instanceof PaymentQRError:
           showErrorAlert(cartError, () => clearCartError());
           return;
       }

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -196,7 +196,7 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
         case cartError instanceof PaymentQRDeformedError ||
           cartError instanceof PaymentQRMissingInfoError ||
           cartError instanceof PaymentQRUnsupportedError:
-          showErrorAlert(new Error(cartError.message), () => clearCartError());
+          showErrorAlert(cartError, () => clearCartError());
           return;
       }
       if (cartState === "DEFAULT" || cartState === "CHECKING_OUT") {

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -27,7 +27,9 @@ export enum ERROR_MESSAGE {
   DUPLICATE_POD_INPUT = "Scan another item that is not tagged to any ID number.",
   MISSING_WAIVER_INPUT = "Enter a valid waiver reason",
   INVALID_IDENTIFIER_INPUT = "Enter or scan a valid code.",
+  INVALID_IDENTIFIER_INPUT_TEXT_DISABLED = "Scan a valid code.",
   MISSING_IDENTIFIER_INPUT = "Enter or scan a code.",
+  MISSING_IDENTIFIER_INPUT_TEXT_DISABLED = "Scan a code.",
   INVALID_VOUCHER_INPUT = "Enter a valid voucher code.",
   MISSING_VOUCHER_INPUT = "Enter a voucher code.",
   INVALID_POD_INPUT = "Scan a valid device code.",
@@ -98,9 +100,11 @@ const getTranslationKeyFromError = (error: Error): string => {
 const messageToTranslationKeyMappings: Record<string, string> = {
   [ERROR_MESSAGE.DUPLICATE_IDENTIFIER_INPUT]: "alreadyUsedCode",
   [ERROR_MESSAGE.DUPLICATE_POD_INPUT]: "alreadyUsedItem",
+  [ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED]: "wrongFormatCode",
   [ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT]: "wrongFormatCode",
   [ERROR_MESSAGE.MISSING_WAIVER_INPUT]: "incompleteWaiveReason",
   [ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT]: "incompleteEntryCode",
+  [ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT_TEXT_DISABLED]: "incompleteEntryCode",
   [ERROR_MESSAGE.MISSING_VOUCHER_INPUT]: "incompleteEntryVoucherCode",
   [ERROR_MESSAGE.INVALID_POD_INPUT]: "wrongFormatNotValidDeviceCode",
   [ERROR_MESSAGE.MISSING_POD_INPUT]: "incompleteEntryScanDeviceCode",
@@ -238,13 +242,27 @@ export const AlertModalContextProvider: FunctionComponent = ({ children }) => {
       dynamicContent?: Record<string, string>
     ): void => {
       const translationKey = getTranslationKeyFromError(error);
+
+      const errDescription = i18n.t(
+        `errorMessages.${translationKey}.body`,
+        dynamicContent
+      );
+
       showAlert({
         alertType: "ERROR",
         title: i18n.t(`errorMessages.${translationKey}.title`) ?? "Error",
-        description: i18n.t(
-          `errorMessages.${translationKey}.body`,
-          dynamicContent
-        ),
+        description:
+          /*
+            Error message (description in i18n) would omit "Enter or" in the 
+            description if text entry is disabled.
+          */
+          error.message ===
+            ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED ||
+          error.message === ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT_TEXT_DISABLED
+            ? errDescription
+                .replace("Enter or ", "")
+                .replace(/(^\w)/g, (m) => m.toUpperCase())
+            : errDescription,
         buttonTexts: {
           primaryActionText:
             i18n.t(`errorMessages.${translationKey}.primaryActionText`) ?? "OK",

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -88,6 +88,10 @@ const errorNameToTranslationKeyMappings: Record<string, string> = {
   PaymentQRDeformedError: "deformedPaymentQR",
   PaymentQRMissingInfoError: "missingInfoInPaymentQR",
   PaymentQRUnsupportedError: "unsupportedPaymentMethodInPaymentQR",
+  PaymentQRDeformedErrorTextDisabled: "deformedPaymentQRTextDisabled",
+  PaymentQRMissingInfoErrorTextDisabled: "missingInfoInPaymentQRTextDisabled",
+  PaymentQRUnsupportedErrorTextDisabled:
+    "unsupportedPaymentMethodInPaymentQRTextDisabled",
 };
 
 const getTranslationKeyFromError = (error: Error): string => {
@@ -100,11 +104,13 @@ const getTranslationKeyFromError = (error: Error): string => {
 const messageToTranslationKeyMappings: Record<string, string> = {
   [ERROR_MESSAGE.DUPLICATE_IDENTIFIER_INPUT]: "alreadyUsedCode",
   [ERROR_MESSAGE.DUPLICATE_POD_INPUT]: "alreadyUsedItem",
-  [ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED]: "wrongFormatCode",
   [ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT]: "wrongFormatCode",
+  [ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED]:
+    "wrongFormatCodeTextDisabled",
   [ERROR_MESSAGE.MISSING_WAIVER_INPUT]: "incompleteWaiveReason",
   [ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT]: "incompleteEntryCode",
-  [ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT_TEXT_DISABLED]: "incompleteEntryCode",
+  [ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT_TEXT_DISABLED]:
+    "incompleteEntryCodeTextDisabled",
   [ERROR_MESSAGE.MISSING_VOUCHER_INPUT]: "incompleteEntryVoucherCode",
   [ERROR_MESSAGE.INVALID_POD_INPUT]: "wrongFormatNotValidDeviceCode",
   [ERROR_MESSAGE.MISSING_POD_INPUT]: "incompleteEntryScanDeviceCode",
@@ -242,27 +248,13 @@ export const AlertModalContextProvider: FunctionComponent = ({ children }) => {
       dynamicContent?: Record<string, string>
     ): void => {
       const translationKey = getTranslationKeyFromError(error);
-
-      const errDescription = i18n.t(
-        `errorMessages.${translationKey}.body`,
-        dynamicContent
-      );
-
       showAlert({
         alertType: "ERROR",
         title: i18n.t(`errorMessages.${translationKey}.title`) ?? "Error",
-        description:
-          /*
-            Error message (description in i18n) would omit "Enter or" in the 
-            description if text entry is disabled.
-          */
-          error.message ===
-            ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED ||
-          error.message === ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT_TEXT_DISABLED
-            ? errDescription
-                .replace("Enter or ", "")
-                .replace(/(^\w)/g, (m) => m.toUpperCase())
-            : errDescription,
+        description: i18n.t(
+          `errorMessages.${translationKey}.body`,
+          dynamicContent
+        ),
         buttonTexts: {
           primaryActionText:
             i18n.t(`errorMessages.${translationKey}.primaryActionText`) ?? "OK",

--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -63,6 +63,12 @@ export enum ERROR_MESSAGE {
   INVALID_MERCHANT_CODE = "Invalid merchant code",
   INVALID_EMAIL_ADDRESS = "Enter valid email address",
   MISSING_DISBURSEMENTS = "Eligible identity does not have quota. Contact your in-charge to resolve this issue.",
+  PAYMENT_QR_DEFORMED = "Payment QR is deformed. Enter or scan a valid code.",
+  PAYMENT_QR_DEFORMED_TEXT_DISABLED = "Payment QR is deformed. Scan a valid code.",
+  PAYMENT_QR_MISSING = "Payment QR is missing. Enter or scan a valid code.",
+  PAYMENT_QR_MISSING_TEXT_DISABLED = "Payment QR is missing. Scan a valid code",
+  PAYMENT_QR_UNSUPPORTED = "Payment QR is unsupported. Enter or scan a valid code.",
+  PAYMENT_QR_UNSUPPORTED_TEXT_DISABLED = "Payment QR is unsupported. Scan a valid code",
 }
 
 const errorNameToTranslationKeyMappings: Record<string, string> = {
@@ -85,13 +91,6 @@ const errorNameToTranslationKeyMappings: Record<string, string> = {
   LimitReachedError: "scanLimitReached",
   NotEligibleError: "notEligible",
   LogoutError: "systemErrorLogoutIssue",
-  PaymentQRDeformedError: "deformedPaymentQR",
-  PaymentQRMissingInfoError: "missingInfoInPaymentQR",
-  PaymentQRUnsupportedError: "unsupportedPaymentMethodInPaymentQR",
-  PaymentQRDeformedErrorTextDisabled: "deformedPaymentQRTextDisabled",
-  PaymentQRMissingInfoErrorTextDisabled: "missingInfoInPaymentQRTextDisabled",
-  PaymentQRUnsupportedErrorTextDisabled:
-    "unsupportedPaymentMethodInPaymentQRTextDisabled",
 };
 
 const getTranslationKeyFromError = (error: Error): string => {
@@ -144,6 +143,15 @@ const messageToTranslationKeyMappings: Record<string, string> = {
   [ERROR_MESSAGE.INVALID_MERCHANT_CODE]: "invalidMerchantCode",
   [ERROR_MESSAGE.INVALID_EMAIL_ADDRESS]: "wrongFormatEmailAddress",
   [ERROR_MESSAGE.MISSING_DISBURSEMENTS]: "missingDisbursements",
+  [ERROR_MESSAGE.PAYMENT_QR_DEFORMED]: "deformedPaymentQR",
+  [ERROR_MESSAGE.PAYMENT_QR_DEFORMED_TEXT_DISABLED]:
+    "deformedPaymentQRTextDisabled",
+  [ERROR_MESSAGE.PAYMENT_QR_MISSING]: "missingInfoInPaymentQR",
+  [ERROR_MESSAGE.PAYMENT_QR_MISSING_TEXT_DISABLED]:
+    "missingInfoInPaymentQRTextDisabled",
+  [ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED]: "unsupportedPaymentMethodInPaymentQR",
+  [ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED_TEXT_DISABLED]:
+    "unsupportedPaymentMethodInPaymentQRTextDisabled",
   [CONFIRMATION_MESSAGE.PAYMENT_COLLECTION]:
     CONFIRMATION_MESSAGE.PAYMENT_COLLECTION,
   [CONFIRMATION_MESSAGE.CONFIRM_LOGOUT]: CONFIRMATION_MESSAGE.CONFIRM_LOGOUT,

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -102,6 +102,9 @@ const mergeWithCart = (
             ...(textInput.type ? { textInputType: textInput.type } : {}),
             ...(scanButton.type ? { scanButtonType: scanButton.type } : {}),
             ...(validationRegex ? { validationRegex } : {}),
+            ...(textInput.disabled
+              ? { isTextInputDisabled: textInput.disabled }
+              : {}),
           })
         ) || [];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,7 @@ export const IdentifierInput = t.intersection([
     scanButtonType: ScanButtonType,
     validationRegex: t.string,
     isOptional: t.boolean,
+    isTextInputDisabled: t.boolean,
   }),
 ]);
 

--- a/src/utils/paymentQrValidation.test.ts
+++ b/src/utils/paymentQrValidation.test.ts
@@ -1,10 +1,14 @@
 import {
+  PaymentQRDeformedError,
+  PaymentQRMissingInfoError,
   sgqrInvalidRazerPay,
   sgqrInvalidSupportedMerchantAccount,
   sgqrNETSQRPayload,
 } from "@rationally-app/payment-qr-parser";
 import { ERROR_MESSAGE } from "../context/alert";
-import isValidPaymentQR, { PaymentQRError } from "./paymentQrValidation";
+import isValidPaymentQR, {
+  PaymentQRUnsupportedError,
+} from "./paymentQrValidation";
 
 describe("isValidPaymentQR Test", () => {
   it("should parse SGQR payload properly", () => {
@@ -19,10 +23,12 @@ describe("tests for errors thrown during isValidPaymentQR", () => {
     expect.assertions(2);
     const deformedPaymentQRPayload = "deformedPayload";
     expect(() => isValidPaymentQR(deformedPaymentQRPayload)).toThrow(
-      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED)
+      new PaymentQRDeformedError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED)
     );
     expect(() => isValidPaymentQR(deformedPaymentQRPayload, true)).toThrow(
-      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED_TEXT_DISABLED)
+      new PaymentQRDeformedError(
+        ERROR_MESSAGE.PAYMENT_QR_DEFORMED_TEXT_DISABLED
+      )
     );
   });
 
@@ -33,10 +39,12 @@ describe("tests for errors thrown during isValidPaymentQR", () => {
       sgqrNETSQRPayload.length - 1
     );
     expect(() => isValidPaymentQR(invalidSGQRPayload)).toThrow(
-      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED)
+      new PaymentQRDeformedError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED)
     );
     expect(() => isValidPaymentQR(invalidSGQRPayload, true)).toThrow(
-      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED_TEXT_DISABLED)
+      new PaymentQRDeformedError(
+        ERROR_MESSAGE.PAYMENT_QR_DEFORMED_TEXT_DISABLED
+      )
     );
   });
 
@@ -44,10 +52,12 @@ describe("tests for errors thrown during isValidPaymentQR", () => {
     expect.assertions(2);
     const missingInfoSGQRPayload = sgqrInvalidSupportedMerchantAccount;
     expect(() => isValidPaymentQR(missingInfoSGQRPayload)).toThrow(
-      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_MISSING)
+      new PaymentQRMissingInfoError(ERROR_MESSAGE.PAYMENT_QR_MISSING)
     );
     expect(() => isValidPaymentQR(missingInfoSGQRPayload, true)).toThrow(
-      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_MISSING_TEXT_DISABLED)
+      new PaymentQRMissingInfoError(
+        ERROR_MESSAGE.PAYMENT_QR_MISSING_TEXT_DISABLED
+      )
     );
   });
 
@@ -55,10 +65,12 @@ describe("tests for errors thrown during isValidPaymentQR", () => {
     expect.assertions(2);
     const payloadWithoutNETS = sgqrInvalidRazerPay;
     expect(() => isValidPaymentQR(payloadWithoutNETS)).toThrow(
-      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED)
+      new PaymentQRUnsupportedError(ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED)
     );
     expect(() => isValidPaymentQR(payloadWithoutNETS, true)).toThrow(
-      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED_TEXT_DISABLED)
+      new PaymentQRUnsupportedError(
+        ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED_TEXT_DISABLED
+      )
     );
   });
 });

--- a/src/utils/paymentQrValidation.test.ts
+++ b/src/utils/paymentQrValidation.test.ts
@@ -1,14 +1,10 @@
 import {
-  PaymentQRDeformedError,
-  PaymentQRMissingInfoError,
   sgqrInvalidRazerPay,
   sgqrInvalidSupportedMerchantAccount,
   sgqrNETSQRPayload,
 } from "@rationally-app/payment-qr-parser";
 import { ERROR_MESSAGE } from "../context/alert";
-import isValidPaymentQR, {
-  PaymentQRUnsupportedError,
-} from "./paymentQrValidation";
+import isValidPaymentQR, { PaymentQRError } from "./paymentQrValidation";
 
 describe("isValidPaymentQR Test", () => {
   it("should parse SGQR payload properly", () => {
@@ -20,37 +16,49 @@ describe("isValidPaymentQR Test", () => {
 
 describe("tests for errors thrown during isValidPaymentQR", () => {
   it("should throw error when parsing deformed payment QR payload", () => {
-    expect.assertions(1);
+    expect.assertions(2);
     const deformedPaymentQRPayload = "deformedPayload";
     expect(() => isValidPaymentQR(deformedPaymentQRPayload)).toThrow(
-      new PaymentQRDeformedError(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT)
+      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED)
+    );
+    expect(() => isValidPaymentQR(deformedPaymentQRPayload, true)).toThrow(
+      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED_TEXT_DISABLED)
     );
   });
 
   it("should throw error when parsing invalid SGQR payload", () => {
-    expect.assertions(1);
+    expect.assertions(2);
     const invalidSGQRPayload = sgqrNETSQRPayload.substring(
       0,
       sgqrNETSQRPayload.length - 1
     );
     expect(() => isValidPaymentQR(invalidSGQRPayload)).toThrow(
-      new PaymentQRDeformedError(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT)
+      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED)
+    );
+    expect(() => isValidPaymentQR(invalidSGQRPayload, true)).toThrow(
+      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED_TEXT_DISABLED)
     );
   });
 
   it("should throw error when parsing SGQR payload with missing info", () => {
-    expect.assertions(1);
+    expect.assertions(2);
     const missingInfoSGQRPayload = sgqrInvalidSupportedMerchantAccount;
     expect(() => isValidPaymentQR(missingInfoSGQRPayload)).toThrow(
-      new PaymentQRMissingInfoError(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT)
+      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_MISSING)
+    );
+    expect(() => isValidPaymentQR(missingInfoSGQRPayload, true)).toThrow(
+      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_MISSING_TEXT_DISABLED)
     );
   });
 
   it("should throw error when parsing payment QR payload without NETS", () => {
-    expect.assertions(1);
+    expect.assertions(2);
     const payloadWithoutNETS = sgqrInvalidRazerPay;
     expect(() => isValidPaymentQR(payloadWithoutNETS)).toThrow(
-      new PaymentQRUnsupportedError(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT)
+      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED)
+    );
+    expect(() => isValidPaymentQR(payloadWithoutNETS, true)).toThrow(
+      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED_TEXT_DISABLED)
     );
   });
 });

--- a/src/utils/paymentQrValidation.ts
+++ b/src/utils/paymentQrValidation.ts
@@ -1,19 +1,13 @@
 import {
   parsePaymentQR,
+  PaymentQRDeformedError,
   PaymentQRMissingInfoError,
 } from "@rationally-app/payment-qr-parser";
 import { pick } from "lodash";
 import { ERROR_MESSAGE } from "../context/alert";
 import { Sentry } from "./errorTracking";
 
-export class PaymentQRError extends Error {
-  constructor(message?: string) {
-    super(message);
-    this.name = "PaymentQRError";
-  }
-}
-
-class PaymentQRUnsupportedError extends Error {
+export class PaymentQRUnsupportedError extends Error {
   constructor(message?: string) {
     super(message);
     this.name = "PaymentQRUnsupportedError";
@@ -51,19 +45,19 @@ const isValidPaymentQR = (
     });
     Sentry.captureException(e);
     if (e instanceof PaymentQRUnsupportedError) {
-      throw new PaymentQRError(
+      throw new PaymentQRUnsupportedError(
         isTextInputDisabled
           ? ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED_TEXT_DISABLED
           : ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED
       );
     } else if (e instanceof PaymentQRMissingInfoError) {
-      throw new PaymentQRError(
+      throw new PaymentQRMissingInfoError(
         isTextInputDisabled
           ? ERROR_MESSAGE.PAYMENT_QR_MISSING_TEXT_DISABLED
           : ERROR_MESSAGE.PAYMENT_QR_MISSING
       );
     }
-    throw new PaymentQRError(
+    throw new PaymentQRDeformedError(
       isTextInputDisabled
         ? ERROR_MESSAGE.PAYMENT_QR_DEFORMED_TEXT_DISABLED
         : ERROR_MESSAGE.PAYMENT_QR_DEFORMED

--- a/src/utils/paymentQrValidation.ts
+++ b/src/utils/paymentQrValidation.ts
@@ -1,37 +1,22 @@
 import {
   parsePaymentQR,
   PaymentQRMissingInfoError,
-  PaymentQRDeformedError,
 } from "@rationally-app/payment-qr-parser";
 import { pick } from "lodash";
 import { ERROR_MESSAGE } from "../context/alert";
 import { Sentry } from "./errorTracking";
 
-export class PaymentQRUnsupportedError extends Error {
+export class PaymentQRError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "PaymentQRError";
+  }
+}
+
+class PaymentQRUnsupportedError extends Error {
   constructor(message?: string) {
     super(message);
     this.name = "PaymentQRUnsupportedError";
-  }
-}
-
-export class PaymentQRUnsupportedErrorTextDisabled extends Error {
-  constructor(message?: string) {
-    super(message);
-    this.name = "PaymentQRUnsupportedErrorTextDisabled";
-  }
-}
-
-export class PaymentQRMissingInfoErrorDisabled extends Error {
-  constructor(message?: string) {
-    super(message);
-    this.name = "PaymentQRMissingInfoErrorDisabled";
-  }
-}
-
-export class PaymentQRDeformedErrorTextDisabled extends Error {
-  constructor(message?: string) {
-    super(message);
-    this.name = "PaymentQRDeformedErrorTextDisabled";
   }
 }
 
@@ -65,26 +50,24 @@ const isValidPaymentQR = (
       message: payload,
     });
     Sentry.captureException(e);
-
     if (e instanceof PaymentQRUnsupportedError) {
-      throw isTextInputDisabled
-        ? new PaymentQRUnsupportedErrorTextDisabled(
-            ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED
-          )
-        : new PaymentQRUnsupportedError(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
+      throw new PaymentQRError(
+        isTextInputDisabled
+          ? ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED_TEXT_DISABLED
+          : ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED
+      );
     } else if (e instanceof PaymentQRMissingInfoError) {
-      throw isTextInputDisabled
-        ? new PaymentQRMissingInfoErrorDisabled(
-            ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED
-          )
-        : new PaymentQRMissingInfoError(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
+      throw new PaymentQRError(
+        isTextInputDisabled
+          ? ERROR_MESSAGE.PAYMENT_QR_MISSING_TEXT_DISABLED
+          : ERROR_MESSAGE.PAYMENT_QR_MISSING
+      );
     }
-
-    throw isTextInputDisabled
-      ? new PaymentQRDeformedErrorTextDisabled(
-          ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED
-        )
-      : new PaymentQRDeformedError(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
+    throw new PaymentQRError(
+      isTextInputDisabled
+        ? ERROR_MESSAGE.PAYMENT_QR_DEFORMED_TEXT_DISABLED
+        : ERROR_MESSAGE.PAYMENT_QR_DEFORMED
+    );
   }
 };
 

--- a/src/utils/paymentQrValidation.ts
+++ b/src/utils/paymentQrValidation.ts
@@ -14,7 +14,31 @@ export class PaymentQRUnsupportedError extends Error {
   }
 }
 
-const isValidPaymentQR = (payload: string): boolean => {
+export class PaymentQRUnsupportedErrorTextDisabled extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "PaymentQRUnsupportedErrorTextDisabled";
+  }
+}
+
+export class PaymentQRMissingInfoErrorDisabled extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "PaymentQRMissingInfoErrorDisabled";
+  }
+}
+
+export class PaymentQRDeformedErrorTextDisabled extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "PaymentQRDeformedErrorTextDisabled";
+  }
+}
+
+const isValidPaymentQR = (
+  payload: string,
+  isTextInputDisabled?: boolean
+): boolean => {
   try {
     const paymentQR = parsePaymentQR(payload, {
       source: "PAYMENT_QR_IS_VALID",
@@ -43,15 +67,24 @@ const isValidPaymentQR = (payload: string): boolean => {
     Sentry.captureException(e);
 
     if (e instanceof PaymentQRUnsupportedError) {
-      throw new PaymentQRUnsupportedError(
-        ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT
-      );
+      throw isTextInputDisabled
+        ? new PaymentQRUnsupportedErrorTextDisabled(
+            ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED
+          )
+        : new PaymentQRUnsupportedError(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
     } else if (e instanceof PaymentQRMissingInfoError) {
-      throw new PaymentQRMissingInfoError(
-        ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT
-      );
+      throw isTextInputDisabled
+        ? new PaymentQRMissingInfoErrorDisabled(
+            ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED
+          )
+        : new PaymentQRMissingInfoError(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
     }
-    throw new PaymentQRDeformedError(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
+
+    throw isTextInputDisabled
+      ? new PaymentQRDeformedErrorTextDisabled(
+          ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED
+        )
+      : new PaymentQRDeformedError(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
   }
 };
 

--- a/src/utils/validateIdentifierInputs.test.ts
+++ b/src/utils/validateIdentifierInputs.test.ts
@@ -1,10 +1,12 @@
 import {
+  PaymentQRDeformedError,
+  PaymentQRMissingInfoError,
   sgqrInvalidRazerPay,
   sgqrInvalidSupportedMerchantAccount,
   sgqrNETSQRPayload,
 } from "@rationally-app/payment-qr-parser";
 import { ERROR_MESSAGE } from "../context/alert";
-import { PaymentQRError } from "./paymentQrValidation";
+import { PaymentQRUnsupportedError } from "./paymentQrValidation";
 import { validateIdentifierInputs } from "./validateIdentifierInputs";
 
 describe("validateIdentifierInputs", () => {
@@ -376,7 +378,9 @@ describe("tests for validateIdentifierInputs for PAYMENT_QR identifier", () => {
           value: sgqrInvalidRazerPay,
         },
       ])
-    ).toThrow(new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED));
+    ).toThrow(
+      new PaymentQRUnsupportedError(ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED)
+    );
 
     expect(() =>
       validateIdentifierInputs([
@@ -390,7 +394,9 @@ describe("tests for validateIdentifierInputs for PAYMENT_QR identifier", () => {
         },
       ])
     ).toThrow(
-      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED_TEXT_DISABLED)
+      new PaymentQRUnsupportedError(
+        ERROR_MESSAGE.PAYMENT_QR_UNSUPPORTED_TEXT_DISABLED
+      )
     );
   });
 
@@ -406,7 +412,7 @@ describe("tests for validateIdentifierInputs for PAYMENT_QR identifier", () => {
           value: "deformedPayload",
         },
       ])
-    ).toThrow(new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED));
+    ).toThrow(new PaymentQRDeformedError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED));
     expect(() =>
       validateIdentifierInputs([
         {
@@ -419,7 +425,9 @@ describe("tests for validateIdentifierInputs for PAYMENT_QR identifier", () => {
         },
       ])
     ).toThrow(
-      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED_TEXT_DISABLED)
+      new PaymentQRDeformedError(
+        ERROR_MESSAGE.PAYMENT_QR_DEFORMED_TEXT_DISABLED
+      )
     );
   });
 
@@ -435,7 +443,7 @@ describe("tests for validateIdentifierInputs for PAYMENT_QR identifier", () => {
           value: sgqrNETSQRPayload.substring(0, sgqrNETSQRPayload.length - 1),
         },
       ])
-    ).toThrow(new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED));
+    ).toThrow(new PaymentQRDeformedError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED));
 
     expect(() =>
       validateIdentifierInputs([
@@ -449,7 +457,9 @@ describe("tests for validateIdentifierInputs for PAYMENT_QR identifier", () => {
         },
       ])
     ).toThrow(
-      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_DEFORMED_TEXT_DISABLED)
+      new PaymentQRDeformedError(
+        ERROR_MESSAGE.PAYMENT_QR_DEFORMED_TEXT_DISABLED
+      )
     );
   });
 
@@ -465,7 +475,7 @@ describe("tests for validateIdentifierInputs for PAYMENT_QR identifier", () => {
           value: sgqrInvalidSupportedMerchantAccount,
         },
       ])
-    ).toThrow(new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_MISSING));
+    ).toThrow(new PaymentQRMissingInfoError(ERROR_MESSAGE.PAYMENT_QR_MISSING));
 
     expect(() =>
       validateIdentifierInputs([
@@ -479,7 +489,9 @@ describe("tests for validateIdentifierInputs for PAYMENT_QR identifier", () => {
         },
       ])
     ).toThrow(
-      new PaymentQRError(ERROR_MESSAGE.PAYMENT_QR_MISSING_TEXT_DISABLED)
+      new PaymentQRMissingInfoError(
+        ERROR_MESSAGE.PAYMENT_QR_MISSING_TEXT_DISABLED
+      )
     );
   });
 });

--- a/src/utils/validateIdentifierInputs.ts
+++ b/src/utils/validateIdentifierInputs.ts
@@ -24,13 +24,22 @@ export const validateIdentifierInputs = (
     validationRegex,
     textInputType,
     isOptional,
+    isTextInputDisabled,
   } of identifierInputs) {
     if (isOptional && !value) {
       return true;
     }
 
+    const invalidIdentifierInputErr = isTextInputDisabled
+      ? ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED
+      : ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT;
+
+    const missingIdentifierInputErr = isTextInputDisabled
+      ? ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT_TEXT_DISABLED
+      : ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT;
+
     if (textInputType === "NUMBER" && isNaN(Number(value))) {
-      throw new Error(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
+      throw new Error(invalidIdentifierInputErr);
     }
     if (!value) {
       if (textInputType === "SINGLE_CHOICE") {
@@ -38,7 +47,7 @@ export const validateIdentifierInputs = (
       } else if (textInputType === "PAYMENT_RECEIPT") {
         throw new Error(ERROR_MESSAGE.INVALID_PAYMENT_RECEIPT_NUMBER);
       }
-      throw new Error(ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT);
+      throw new Error(missingIdentifierInputErr);
     }
 
     if (
@@ -58,7 +67,7 @@ export const validateIdentifierInputs = (
     ) {
       throw new Error(ERROR_MESSAGE.INVALID_PHONE_AND_COUNTRY_CODE);
     } else if (!isMatchRegex(value, validationRegex)) {
-      throw new Error(ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT);
+      throw new Error(invalidIdentifierInputErr);
     }
 
     if (textInputType === "PHONE_NUMBER" && !fullPhoneNumberValidator(value)) {
@@ -69,6 +78,7 @@ export const validateIdentifierInputs = (
       try {
         isValidPaymentQR(value);
       } catch (e) {
+        e.message = invalidIdentifierInputErr;
         throw e;
       }
     }

--- a/src/utils/validateIdentifierInputs.ts
+++ b/src/utils/validateIdentifierInputs.ts
@@ -76,9 +76,8 @@ export const validateIdentifierInputs = (
 
     if (textInputType === "PAYMENT_QR") {
       try {
-        isValidPaymentQR(value);
+        isValidPaymentQR(value, isTextInputDisabled);
       } catch (e) {
-        e.message = invalidIdentifierInputErr;
         throw e;
       }
     }

--- a/src/utils/validateIdentifierInputs.ts
+++ b/src/utils/validateIdentifierInputs.ts
@@ -30,16 +30,16 @@ export const validateIdentifierInputs = (
       return true;
     }
 
-    const invalidIdentifierInputErr = isTextInputDisabled
+    const invalidIdentifierInputErrMsg = isTextInputDisabled
       ? ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT_TEXT_DISABLED
       : ERROR_MESSAGE.INVALID_IDENTIFIER_INPUT;
 
-    const missingIdentifierInputErr = isTextInputDisabled
+    const missingIdentifierInputErrMsg = isTextInputDisabled
       ? ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT_TEXT_DISABLED
       : ERROR_MESSAGE.MISSING_IDENTIFIER_INPUT;
 
     if (textInputType === "NUMBER" && isNaN(Number(value))) {
-      throw new Error(invalidIdentifierInputErr);
+      throw new Error(invalidIdentifierInputErrMsg);
     }
     if (!value) {
       if (textInputType === "SINGLE_CHOICE") {
@@ -47,7 +47,7 @@ export const validateIdentifierInputs = (
       } else if (textInputType === "PAYMENT_RECEIPT") {
         throw new Error(ERROR_MESSAGE.INVALID_PAYMENT_RECEIPT_NUMBER);
       }
-      throw new Error(missingIdentifierInputErr);
+      throw new Error(missingIdentifierInputErrMsg);
     }
 
     if (
@@ -67,7 +67,7 @@ export const validateIdentifierInputs = (
     ) {
       throw new Error(ERROR_MESSAGE.INVALID_PHONE_AND_COUNTRY_CODE);
     } else if (!isMatchRegex(value, validationRegex)) {
-      throw new Error(invalidIdentifierInputErr);
+      throw new Error(invalidIdentifierInputErrMsg);
     }
 
     if (textInputType === "PHONE_NUMBER" && !fullPhoneNumberValidator(value)) {


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Amend-error-message-for-non-editable-field-from-Enter-or-scan-a-valid-code-to-Scan-a-valid-code-d76a6a7033964d46921fa8e6ff9d0e84)

This PR remove "Enter or" from the error message for non-editable identifier text inputs.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [X] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [X] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [x] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
