### PR TITLE
fix: add timeout when fetching data

### DIFF
--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -38,9 +38,12 @@ export async function fetchWithValidator<T, O, I>(
 ): Promise<T> {
   let response: Response;
   try {
+    const controller = new AbortController();
+    const signal = controller.signal;
     response = await Promise.race<Response>([
-      fetch(requestInfo, init),
+      fetch(requestInfo, { ...init, signal }),
       timeoutAfter(10).then((timeoutError) => {
+        controller.abort();
         throw timeoutError;
       }),
     ]);

--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -46,6 +46,7 @@ export async function fetchWithValidator<T, O, I>(
     const controller = typeof AbortController
       ? {
           signal: undefined,
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
           abort: () => {},
         }
       : new AbortController();


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Handling-FE-Errors-when-Offline-b296a4620ca04f469c3d144346ba9670) <!-- Remove this link if no relevant Notion link -->

This PR add timeout when fetching data to fix infinite loading screen when offline.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [X] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [X] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
