### PR TITLE
fix: error message when otp is entered incompletely

### DIFF
--- a/src/components/Login/LoginOTPCard.test.tsx
+++ b/src/components/Login/LoginOTPCard.test.tsx
@@ -185,6 +185,50 @@ describe("LoginOTPCard", () => {
       expect(onSuccess).not.toHaveBeenCalled();
     });
 
+    it("when OTP is less than 6 digits", async () => {
+      expect.assertions(6);
+      mockValidateOTP.mockRejectedValue(
+        new auth.OTPWrongError("OTP must be 6 digits", false)
+      );
+
+      const { getByTestId, queryByText } = render(
+        <CreateProvidersWrapper
+          providers={[
+            { provider: AuthStoreContextProvider },
+            { provider: AlertModalContextProvider },
+          ]}
+        >
+          <LoginOTPCard
+            resetStage={resetStage}
+            fullMobileNumber={fullPhoneNumber}
+            operatorToken={operatorToken}
+            endpoint={endpoint}
+            handleRequestOTP={mockHandleRequestOTP}
+            onSuccess={onSuccess}
+          />
+        </CreateProvidersWrapper>
+      );
+
+      const OTPInput = getByTestId(OTPInputId);
+      const submitButton = getByTestId(submitButtonId);
+
+      fireEvent(OTPInput, "onChange", {
+        nativeEvent: { text: "00" },
+      });
+      expect(OTPInput.props["value"]).toEqual("00");
+
+      fireEvent.press(submitButton);
+      expect(queryByText("Submit")).toBeNull();
+      expect(mockValidateOTP).toHaveBeenCalledTimes(1);
+
+      await waitFor(() => {
+        expect(queryByText("Invalid input")).not.toBeNull();
+        expect(queryByText("Enter OTP again.")).not.toBeNull();
+      });
+
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
     it("when OTP has expired", async () => {
       expect.assertions(6);
       mockValidateOTP.mockRejectedValue(

--- a/src/services/auth/index.tsx
+++ b/src/services/auth/index.tsx
@@ -169,6 +169,8 @@ export const liveValidateOTP = async (
       throw new OTPWrongError(e.message, false);
     } else if (e.message === "Wrong OTP entered, last try remaining") {
       throw new OTPWrongError(e.message, true);
+    } else if (e.message === "OTP must be 6 digits") {
+      throw new OTPWrongError(e.message, false);
     } else if (e.message === "OTP expired") {
       throw new OTPExpiredError(e.message);
     } else if (e.message === "OTP cannot be empty") {


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Fix-error-message-when-OTP-is-entered-incompletely-in-SupplyAlly-220f88075377460fb5335d4f6962603a) <!-- Remove this link if no relevant Notion link -->

This PR fix error message when otp is entered incompletely.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [X] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [X] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
