### PR TITLE
feat(v1): error dialogs for HTTP 400 and 50X errors from GovWallet

### DIFF
--- a/src/common/i18n/translations/en.ts
+++ b/src/common/i18n/translations/en.ts
@@ -500,5 +500,25 @@ export const en: Translations = {
       body: "Eligible identity's account has been deactivated. Inform your in-charge about this issue.",
       primaryActionText: "OK",
     },
+    http500Error: {
+      title: "System error",
+      body: "Internal Server Error. Inform your in-charge about this issue.",
+      primaryActionText: "OK",
+    },
+    http502Error: {
+      title: "System error",
+      body: "Bad Gateway. Inform your in-charge about this issue.",
+      primaryActionText: "OK",
+    },
+    http503Error: {
+      title: "System error",
+      body: "Service Unavailable. Inform your in-charge about this issue.",
+      primaryActionText: "OK",
+    },
+    http504Error: {
+      title: "System error",
+      body: "Gateway Timeout. Inform your in-charge about this issue.",
+      primaryActionText: "OK",
+    },
   },
 };

--- a/src/common/i18n/translations/type.ts
+++ b/src/common/i18n/translations/type.ts
@@ -545,5 +545,25 @@ export type Translations = {
       body?: string;
       primaryActionText: string;
     };
+    http500Error: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+    };
+    http502Error: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+    };
+    http503Error: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+    };
+    http504Error: {
+      title: string;
+      body?: string;
+      primaryActionText: string;
+    };
   };
 };

--- a/src/common/i18n/translations/zh.ts
+++ b/src/common/i18n/translations/zh.ts
@@ -496,5 +496,26 @@ export const zh: Translations = {
       body: "账户已停止使用。请联系您的负责人。",
       primaryActionText: "确定",
     },
+    // TODO: HTTP error translations below will be done at a later date
+    http500Error: {
+      title: "System error",
+      body: "Internal Server Error. Inform your in-charge about this issue.",
+      primaryActionText: "OK",
+    },
+    http502Error: {
+      title: "System error",
+      body: "Bad Gateway. Inform your in-charge about this issue.",
+      primaryActionText: "OK",
+    },
+    http503Error: {
+      title: "System error",
+      body: "Service Unavailable. Inform your in-charge about this issue.",
+      primaryActionText: "OK",
+    },
+    http504Error: {
+      title: "System error",
+      body: "Gateway Timeout. Inform your in-charge about this issue.",
+      primaryActionText: "OK",
+    },
   },
 };

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -195,7 +195,7 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
       return;
     }
 
-    if (govWalletBalanceError) {
+    if (quotaState === "DEFAULT" && govWalletBalanceError) {
       switch (true) {
         case govWalletBalanceError instanceof NetworkError:
           throw govWalletBalanceError; // Let error boundary handle.
@@ -296,6 +296,7 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
     expireSession,
     navigation,
     showErrorAlert,
+    quotaState,
     quotaError,
     clearQuotaError,
     govWalletBalanceError,

--- a/src/hooks/govwallet/useGovWalletBalance/useGovWalletBalance.test.tsx
+++ b/src/hooks/govwallet/useGovWalletBalance/useGovWalletBalance.test.tsx
@@ -7,13 +7,10 @@ import {
   defaultProducts,
 } from "../../../test/helpers/defaults";
 import { CampaignConfig } from "../../../types";
-import {
-  GovWalletBalanceError,
-  useGovWalletBalance,
-} from "./useGovWalletBalance";
+import { useGovWalletBalance } from "./useGovWalletBalance";
 import { ProductContextProvider } from "../../../context/products";
 import { CampaignConfigContextProvider } from "../../../context/campaignConfig";
-import { NetworkError } from "../../../services/helpers";
+import { ErrorWithCodes, NetworkError } from "../../../services/helpers";
 
 jest.mock("../../../services/govwallet/balance");
 const mockGetGovWalletBalance = getGovWalletBalance as jest.Mock;
@@ -179,8 +176,9 @@ describe("govWalletBalanceState states", () => {
     await waitForNextUpdate();
     expect(result.current.govWalletBalanceState).toStrictEqual("INELIGIBLE");
     expect(result.current.govWalletBalanceError).toStrictEqual(
-      new GovWalletBalanceError(
-        "Eligible identity's account has been deactivated. Inform your in-charge about this issue."
+      new ErrorWithCodes(
+        "Eligible identity's account has been deactivated. Inform your in-charge about this issue.",
+        400
       )
     );
     expect(mockGetGovWalletBalance).toHaveBeenCalledTimes(1);

--- a/src/hooks/govwallet/useGovWalletBalance/useGovWalletBalance.test.tsx
+++ b/src/hooks/govwallet/useGovWalletBalance/useGovWalletBalance.test.tsx
@@ -206,4 +206,48 @@ describe("govWalletBalanceState states", () => {
       new NetworkError("Network error")
     );
   });
+
+  it("should return 'DEFAULT' and error if a HTTP 400 error occurred", async () => {
+    expect.assertions(4);
+
+    mockGetGovWalletBalance.mockRejectedValue(
+      new ErrorWithCodes("Invalid customerId", 400, "F00B4R")
+    );
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useGovWalletBalance(ids, key, endpoint),
+      { wrapper }
+    );
+
+    expect(result.current.govWalletBalanceState).toStrictEqual(
+      "FETCHING_BALANCE"
+    );
+    await waitForNextUpdate();
+    expect(result.current.govWalletBalanceState).toStrictEqual("DEFAULT");
+    expect(mockGetGovWalletBalance).toHaveBeenCalledTimes(1);
+    expect(result.current.govWalletBalanceError).toStrictEqual(
+      new ErrorWithCodes("Invalid customerId", 400, "F00B4R")
+    );
+  });
+
+  it("should return 'DEFAULT' and error if a HTTP 500 error occurred", async () => {
+    expect.assertions(4);
+
+    mockGetGovWalletBalance.mockRejectedValue(new ErrorWithCodes("", 500));
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useGovWalletBalance(ids, key, endpoint),
+      { wrapper }
+    );
+
+    expect(result.current.govWalletBalanceState).toStrictEqual(
+      "FETCHING_BALANCE"
+    );
+    await waitForNextUpdate();
+    expect(result.current.govWalletBalanceState).toStrictEqual("DEFAULT");
+    expect(mockGetGovWalletBalance).toHaveBeenCalledTimes(1);
+    expect(result.current.govWalletBalanceError).toStrictEqual(
+      new ErrorWithCodes("", 500)
+    );
+  });
 });

--- a/src/hooks/govwallet/useGovWalletBalance/useGovWalletBalance.tsx
+++ b/src/hooks/govwallet/useGovWalletBalance/useGovWalletBalance.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useContext, useEffect, useState } from "react";
 import { CampaignConfigContext } from "../../../context/campaignConfig";
 import { getGovWalletBalance } from "../../../services/govwallet/balance";
+import { ErrorWithCodes } from "../../../services/helpers";
 
 export type GovWalletBalanceState =
   | "DEFAULT"
@@ -15,13 +16,6 @@ export type GovWalletBalanceHook = {
   updateGovWalletBalance: () => void;
   clearGovWalletBalanceError: () => void;
 };
-
-export class GovWalletBalanceError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "GovWalletBalanceError";
-  }
-}
 
 /**
  * A React Hook that checks the GovWallet balance of specified IDs.
@@ -47,8 +41,7 @@ export const useGovWalletBalance = (
    */
   const [govWalletBalanceInCents, setGovWalletBalanceInCents] =
     useState<number>(0);
-  const [govWalletBalanceError, setGovWalletBalanceError] =
-    useState<GovWalletBalanceError>();
+  const [govWalletBalanceError, setGovWalletBalanceError] = useState<Error>();
 
   const clearGovWalletBalanceError = useCallback(
     (): void => setGovWalletBalanceError(undefined),
@@ -85,8 +78,9 @@ export const useGovWalletBalance = (
 
           if (!areAllAccountsActivated) {
             setGovWalletBalanceError(
-              new GovWalletBalanceError(
-                "Eligible identity's account has been deactivated. Inform your in-charge about this issue."
+              new ErrorWithCodes(
+                "Eligible identity's account has been deactivated. Inform your in-charge about this issue.",
+                400
               )
             );
             setGovWalletBalanceState("INELIGIBLE");

--- a/src/services/govwallet/balance/balance.test.tsx
+++ b/src/services/govwallet/balance/balance.test.tsx
@@ -1,7 +1,12 @@
-import { getGovWalletBalance, GovWalletBalanceError } from ".";
+import { getGovWalletBalance } from ".";
 import { GovWalletAccountDetail, GovWalletBalance } from "../../../types";
 import { Sentry } from "../../../utils/errorTracking";
-import { NetworkError, SessionError } from "../../helpers";
+import {
+  ErrorWithCodes,
+  NetworkError,
+  SessionError,
+  ValidationError,
+} from "../../helpers";
 
 const mockFetch = jest.fn();
 jest.spyOn(global, "fetch").mockImplementation(mockFetch);
@@ -53,7 +58,7 @@ describe("Getting GovWallet Balance", () => {
     expect.assertions(1);
 
     await expect(getGovWalletBalance("", authKey, endpoint)).rejects.toThrow(
-      GovWalletBalanceError
+      ErrorWithCodes
     );
   });
 
@@ -94,7 +99,7 @@ describe("Getting GovWallet Balance", () => {
 
     await expect(
       getGovWalletBalance(customerId, authKey, endpoint)
-    ).rejects.toThrow(GovWalletBalanceError);
+    ).rejects.toThrow(ValidationError);
 
     expect(mockCaptureException).toHaveBeenCalledTimes(1);
   });
@@ -109,7 +114,7 @@ describe("Getting GovWallet Balance", () => {
 
     await expect(
       getGovWalletBalance(customerId, authKey, endpoint)
-    ).rejects.toThrow(GovWalletBalanceError);
+    ).rejects.toThrow(Error);
 
     await expect(
       getGovWalletBalance(customerId, authKey, endpoint)

--- a/src/services/govwallet/balance/index.tsx
+++ b/src/services/govwallet/balance/index.tsx
@@ -72,7 +72,7 @@ const liveGetGovWalletBalance = async (
       Sentry.captureException(error);
     }
 
-    throw new GovWalletBalanceError(error.message);
+    throw e;
   }
 };
 

--- a/src/services/govwallet/balance/index.tsx
+++ b/src/services/govwallet/balance/index.tsx
@@ -59,7 +59,8 @@ const liveGetGovWalletBalance = async (
         body: JSON.stringify({
           id,
         }),
-      }
+      },
+      true
     );
 
     return response;

--- a/src/services/govwallet/balance/index.tsx
+++ b/src/services/govwallet/balance/index.tsx
@@ -1,19 +1,13 @@
 import { GovWalletBalance } from "../../../types";
 import { IS_MOCK } from "../../../config";
 import {
+  ErrorWithCodes,
   fetchWithValidator,
   NetworkError,
   SessionError,
   ValidationError,
 } from "../../helpers";
 import { Sentry } from "../../../utils/errorTracking";
-
-export class GovWalletBalanceError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "GovWalletBalanceError";
-  }
-}
 
 const mockGetGovWalletBalance = async (
   id: string,
@@ -49,7 +43,7 @@ const liveGetGovWalletBalance = async (
   let response: GovWalletBalance;
 
   if (id.length <= 0) {
-    throw new GovWalletBalanceError("No ID was provided");
+    throw new ErrorWithCodes("No ID was provided", 400);
   }
 
   try {

--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -23,22 +23,14 @@ export class NetworkError extends Error {
   }
 }
 
-export class ErrorWithStatusCode extends Error {
+export class ErrorWithCodes extends Error {
   statusCode: number;
+  errorCode?: string;
 
-  constructor(message: string, statusCode: number) {
+  constructor(message: string, statusCode: number, errorCode?: string) {
     super(message);
-    this.name = "ErrorWithCode";
+    this.name = "ErrorWithCodes";
     this.statusCode = statusCode;
-  }
-}
-
-export class ErrorWithErrorCode extends ErrorWithStatusCode {
-  errorCode: string;
-
-  constructor(message: string, statusCode: number, errorCode: string) {
-    super(message, statusCode);
-    this.name = "ErrorWithCode";
     this.errorCode = errorCode;
   }
 }
@@ -91,12 +83,8 @@ export async function fetchWithValidator<T, O, I>(
       throw new SessionError(json.message);
     }
 
-    if (json.errorCode) {
-      throw new ErrorWithErrorCode(message, statusCode, json.errorCode);
-    }
-
-    if (statusCode) {
-      throw new ErrorWithStatusCode(message, statusCode);
+    if (json.errorCode || statusCode) {
+      throw new ErrorWithCodes(message, statusCode, json.errorCode);
     }
 
     throw new Error(message);

--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -46,7 +46,8 @@ const timeoutAfter = (seconds: number): Promise<Error> => {
 export async function fetchWithValidator<T, O, I>(
   validator: Type<T, O, I>,
   requestInfo: RequestInfo,
-  init?: RequestInit
+  init?: RequestInit,
+  includeCodes = false
 ): Promise<T> {
   let response: Response;
   /*
@@ -83,7 +84,7 @@ export async function fetchWithValidator<T, O, I>(
       throw new SessionError(json.message);
     }
 
-    if (json.errorCode || statusCode) {
+    if (includeCodes && (json.errorCode || statusCode)) {
       throw new ErrorWithCodes(message, statusCode, json.errorCode);
     }
 

--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -27,7 +27,7 @@ export class ErrorWithCodes extends Error {
   statusCode: number;
   errorCode?: string;
 
-  constructor(message: string, statusCode: number, errorCode?: string) {
+  constructor(message: string, statusCode = 500, errorCode?: string) {
     super(message);
     this.name = "ErrorWithCodes";
     this.statusCode = statusCode;


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Error-handling-when-Sally-calls-GovWallet-v2-customer-account-get-for-MINDEF-SAFRA-campaign-f442fe104e0b49bd931998d034b5755e?v=532cc4d27b0641d69c5f34e3f6f0ab78) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->

- Only show GovWallet balance error dialogs if there are no quota related errors.
- Add new error class `ErrorWithCodes`, which includes `statusCode` and `errorCode` on top of other `Error` properties to facilitate displaying of error dialogs.
- Various type changes from `GovWalletBalanceError` to `ErrorWithCodes`.
- Add translations for HTTP 50X errors. In particular, HTTP 500, 502, 503, and 504.
- Ability to display `ErrorWithCodes` errors
  - HTTP 400 errors will be displayed with title as their error code, and description as error message.
  - HTTP 50X errors will be display with title as "System error", and description as "<HTTP 50X Name>. Inform your in-charge about this issue.".

**Note**: There are no Chinese translations for the HTTP errors for now. This will be handled in a separate story.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [x] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [x] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
