### PR TITLE
feat(v1): handle http 50x errors from GovWallet properly in SupplyAlly

### DIFF
--- a/src/context/alert.tsx
+++ b/src/context/alert.tsx
@@ -280,27 +280,27 @@ export const AlertModalContextProvider: FunctionComponent = ({ children }) => {
       /**
        * Defining error dialog properties for ErrorWithCodes.
        *
-       * For HTTP 400 errors, the title is the error code, and
-       * the description is the error message.
-       *
        * For HTTP 50X errors, the properties are located in their respective
        * translation keys (e.g. errorMessages.http500Error).
+       *
+       * For all other HTTP errors, the title is the error code, and
+       * the description is the error message.
        */
       if (!title && !description && error instanceof ErrorWithCodes) {
-        translationKey = `http${error.statusCode}Error`;
+        const { message, statusCode, errorCode } = error;
 
-        title =
-          error.errorCode ??
-          i18n.t(`errorMessages.${translationKey}.title`) ??
-          "Error";
+        translationKey = `http${statusCode}Error`;
 
-        description =
-          error.message ??
-          i18n.t(`errorMessages.${translationKey}.description`);
-
-        primaryButtonText = i18n.t(
-          `errorMessages.${translationKey}.primaryButtonText`
-        );
+        if (statusCode >= 500) {
+          title = i18n.t(`errorMessages.${translationKey}.title`);
+          description = i18n.t(`errorMessages.${translationKey}.body`);
+          primaryButtonText = i18n.t(
+            `errorMessages.${translationKey}.primaryActionText`
+          );
+        } else {
+          title = errorCode ?? "Error";
+          description = message;
+        }
       }
 
       showAlert({


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Error-handling-when-Sally-calls-GovWallet-v2-customer-account-get-for-MINDEF-SAFRA-campaign-f442fe104e0b49bd931998d034b5755e?v=532cc4d27b0641d69c5f34e3f6f0ab78) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->

### Error dialogs

- Only use translation keys if HTTP 50X error is found.
- Use error `errorCode` and `message` if any other HTTP error is found.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
