### PR TITLE
fix: update payNow transaction toggle to useCart

### DIFF
--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -345,6 +345,7 @@ export const useCart = (
           transactions,
           endpoint,
           apiVersion: features?.apiVersion,
+          isPayNowTransaction: features?.isPayNowTransaction,
         });
         setCheckoutResult(transactionResponse);
         setCartState("PURCHASED");
@@ -386,6 +387,7 @@ export const useCart = (
     authKey,
     endpoint,
     features?.apiVersion,
+    features?.isPayNowTransaction,
     optionalIdentifierLabels,
   ]);
 

--- a/src/hooks/useVoucher/useVoucher.tsx
+++ b/src/hooks/useVoucher/useVoucher.tsx
@@ -3,7 +3,6 @@ import { validateMerchantCode } from "../../utils/validateMerchantCode";
 import { Voucher, PostTransactionResult, Transaction } from "../../types";
 import { postTransaction } from "../../services/quota";
 import { IdentificationContext } from "../../context/identification";
-import { CampaignConfigContext } from "../../context/campaignConfig";
 
 type CheckoutVouchersState =
   | "DEFAULT"
@@ -49,7 +48,6 @@ export const useVoucher = (authKey: string, endpoint: string): VoucherHook => {
     [vouchers]
   );
 
-  const { features } = useContext(CampaignConfigContext);
   const checkoutVouchers: VoucherHook["checkoutVouchers"] = useCallback(
     (merchantCode) => {
       setCheckoutVouchersState("CONSUMING_VOUCHER");
@@ -81,7 +79,6 @@ export const useVoucher = (authKey: string, endpoint: string): VoucherHook => {
             key: authKey,
             transactions,
             endpoint,
-            isPayNowTransaction: features?.isPayNowTransaction,
           });
           setCheckoutResult(transactionResponse);
           setCheckoutVouchersState("RESULT_RETURNED");
@@ -92,7 +89,7 @@ export const useVoucher = (authKey: string, endpoint: string): VoucherHook => {
 
       checkout();
     },
-    [authKey, endpoint, features?.isPayNowTransaction, selectedIdType, vouchers]
+    [authKey, endpoint, selectedIdType, vouchers]
   );
 
   return {


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Allow-Sally-to-call-GovWallet-v2-customer-paynow-create-in-MINDEF-environment-Status-200-202-5ce0554fc6d4488caebc26cf2df5fec4)

This PR fixes the isPayNowTransaction toggle to be triggered from the right hook.

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [ ] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
