### PR TITLE
feat: handle errors thrown by transactions/paynow

### DIFF
--- a/src/components/AlertModal/AlertModal.tsx
+++ b/src/components/AlertModal/AlertModal.tsx
@@ -96,7 +96,12 @@ export const AlertModal: FunctionComponent<AlertModalProps> = ({
   const { theme } = useTheme();
   const PrimaryButton = alertType === "WARN" ? DangerButton : DarkButton;
   return (
-    <Modal animationType="fade" transparent={true} visible={visible}>
+    <Modal
+      animationType="fade"
+      transparent={true}
+      visible={visible}
+      testID="alertModal"
+    >
       <View style={styles.centeredView}>
         <View style={styles.modalView}>
           {alertType === "ERROR" && <AlertIcon style={styles.alertIcon} />}

--- a/src/components/CustomerQuota/CustomerQuotaScreen.test.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.test.tsx
@@ -18,6 +18,8 @@ import { Sentry } from "../../utils/errorTracking";
 import { defaultFeatures } from "../../test/helpers/defaults";
 import { CreateProvidersWrapper } from "../../test/helpers/providers";
 import "../../common/i18n/i18nMock";
+// import { ErrorWithCodes } from "../../services/helpers";
+// import { AlertModalContextProvider } from "../../context/alert";
 
 jest.mock("../../utils/errorTracking");
 const mockCaptureException = jest.fn();
@@ -574,4 +576,71 @@ describe("CustomerQuotaScreen", () => {
       });
     });
   });
+
+  // describe.only("should update the error", () => {
+  //   describe("when cartState is", () => {
+  //     it("DEFAULT", async () => {
+  //       expect.hasAssertions();
+  //       // expect.assertions(93);
+
+  //       const mockCheckoutCart = jest.fn();
+  //       mockUseCart.mockReturnValue({
+  //         cartState: "DEFAULT",
+  //         cart: mockCart,
+  //         emptyCart: () => null,
+  //         updateCart: () => null,
+  //         checkoutCart: mockCheckoutCart,
+  //         completeCheckout: () => null,
+  //         cartError: new ErrorWithCodes("user error", 400, "ABC"),
+  //         clearCartError: () => null,
+  //         resetCartState: () => null,
+  //       });
+  //       mockUseQuota.mockReturnValue({
+  //         quotaResponse: mockQuotaResponse,
+  //         allQuotaResponse: mockQuotaResponse,
+  //         quotaState: "DEFAULT",
+  //         quotaError: undefined,
+  //         updateQuota: () => null,
+  //         clearQuotaError: () => null,
+  //       });
+
+  //       const { queryByText, queryByTestId } = render(
+  //         <CreateProvidersWrapper
+  //           providers={[
+  //             {
+  //               provider: CampaignConfigContextProvider,
+  //               props: { campaignConfig: allCampaignConfigs.campaignA },
+  //             },
+  //             {
+  //               provider: ProductContextProvider,
+  //               props: { products: mockProduct },
+  //             },
+  //             { provider: AlertModalContextProvider },
+  //           ]}
+  //         >
+  //           <CustomerQuotaScreen
+  //             navigation={mockNavigate}
+  //             navIds={["valid-id"]}
+  //           />
+  //         </CreateProvidersWrapper>
+  //       );
+
+  //       const checkoutButton = queryByTestId("items-selection-checkout-button");
+  //       expect(checkoutButton).not.toBeNull();
+
+  //       expect(queryByText("valid-id")).not.toBeNull();
+  //       expect(queryByText("🧻 Toilet Paper")).not.toBeNull();
+  //       expect(queryByText("🍜 Instant Noodles")).not.toBeNull();
+  //       expect(queryByText("🍫 Chocolate")).not.toBeNull();
+  //       expect(queryByText("Funfair Vouchers")).not.toBeNull();
+
+  //       fireEvent.press(checkoutButton!);
+  //       await waitFor(() => {
+  //         expect(mockCheckoutCart).toHaveBeenCalledTimes(1);
+  //       });
+  //       // expect(queryByTestId("alertModal")).toBeNull();
+  //       expect(queryByTestId("checkout-unsuccessful-title")).not.toBeNull();
+  //     });
+  //   });
+  // });
 });

--- a/src/components/CustomerQuota/CustomerQuotaScreen.test.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.test.tsx
@@ -18,8 +18,6 @@ import { Sentry } from "../../utils/errorTracking";
 import { defaultFeatures } from "../../test/helpers/defaults";
 import { CreateProvidersWrapper } from "../../test/helpers/providers";
 import "../../common/i18n/i18nMock";
-// import { ErrorWithCodes } from "../../services/helpers";
-// import { AlertModalContextProvider } from "../../context/alert";
 
 jest.mock("../../utils/errorTracking");
 const mockCaptureException = jest.fn();
@@ -576,71 +574,4 @@ describe("CustomerQuotaScreen", () => {
       });
     });
   });
-
-  // describe.only("should update the error", () => {
-  //   describe("when cartState is", () => {
-  //     it("DEFAULT", async () => {
-  //       expect.hasAssertions();
-  //       // expect.assertions(93);
-
-  //       const mockCheckoutCart = jest.fn();
-  //       mockUseCart.mockReturnValue({
-  //         cartState: "DEFAULT",
-  //         cart: mockCart,
-  //         emptyCart: () => null,
-  //         updateCart: () => null,
-  //         checkoutCart: mockCheckoutCart,
-  //         completeCheckout: () => null,
-  //         cartError: new ErrorWithCodes("user error", 400, "ABC"),
-  //         clearCartError: () => null,
-  //         resetCartState: () => null,
-  //       });
-  //       mockUseQuota.mockReturnValue({
-  //         quotaResponse: mockQuotaResponse,
-  //         allQuotaResponse: mockQuotaResponse,
-  //         quotaState: "DEFAULT",
-  //         quotaError: undefined,
-  //         updateQuota: () => null,
-  //         clearQuotaError: () => null,
-  //       });
-
-  //       const { queryByText, queryByTestId } = render(
-  //         <CreateProvidersWrapper
-  //           providers={[
-  //             {
-  //               provider: CampaignConfigContextProvider,
-  //               props: { campaignConfig: allCampaignConfigs.campaignA },
-  //             },
-  //             {
-  //               provider: ProductContextProvider,
-  //               props: { products: mockProduct },
-  //             },
-  //             { provider: AlertModalContextProvider },
-  //           ]}
-  //         >
-  //           <CustomerQuotaScreen
-  //             navigation={mockNavigate}
-  //             navIds={["valid-id"]}
-  //           />
-  //         </CreateProvidersWrapper>
-  //       );
-
-  //       const checkoutButton = queryByTestId("items-selection-checkout-button");
-  //       expect(checkoutButton).not.toBeNull();
-
-  //       expect(queryByText("valid-id")).not.toBeNull();
-  //       expect(queryByText("🧻 Toilet Paper")).not.toBeNull();
-  //       expect(queryByText("🍜 Instant Noodles")).not.toBeNull();
-  //       expect(queryByText("🍫 Chocolate")).not.toBeNull();
-  //       expect(queryByText("Funfair Vouchers")).not.toBeNull();
-
-  //       fireEvent.press(checkoutButton!);
-  //       await waitFor(() => {
-  //         expect(mockCheckoutCart).toHaveBeenCalledTimes(1);
-  //       });
-  //       // expect(queryByTestId("alertModal")).toBeNull();
-  //       expect(queryByTestId("checkout-unsuccessful-title")).not.toBeNull();
-  //     });
-  //   });
-  // });
 });

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -30,7 +30,11 @@ import { KeyboardAvoidingScrollView } from "../Layout/KeyboardAvoidingScrollView
 import { CampaignConfigContext } from "../../context/campaignConfig";
 import { AlertModalContext, ERROR_MESSAGE } from "../../context/alert";
 import { navigateHome, replaceRoute } from "../../common/navigation";
-import { NetworkError, SessionError } from "../../services/helpers";
+import {
+  ErrorWithCodes,
+  NetworkError,
+  SessionError,
+} from "../../services/helpers";
 import { useQuota } from "../../hooks/useQuota/useQuota";
 import { AuthStoreContext } from "../../context/authStore";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
@@ -226,6 +230,11 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
           cartError instanceof PaymentQRMissingInfoError ||
           cartError instanceof PaymentQRUnsupportedError:
           showErrorAlert(cartError, () => clearCartError());
+          return;
+        case cartError instanceof ErrorWithCodes:
+          showErrorAlert(cartError, () => {
+            navigation.navigate("CollectCustomerDetailsScreen");
+          });
           return;
       }
       if (cartState === "DEFAULT" || cartState === "CHECKING_OUT") {

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -191,7 +191,7 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
           clearQuotaError();
           expireSession();
           showErrorAlert(quotaError, () => {
-            navigation.navigate("CampaignLocationsScreen");
+            navigation.goBack();
           });
           return;
       }

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -191,7 +191,7 @@ export const CustomerQuotaScreen: FunctionComponent<CustomerQuotaProps> = ({
           clearQuotaError();
           expireSession();
           showErrorAlert(quotaError, () => {
-            navigation.goBack();
+            navigation.navigate("CampaignLocationsScreen");
           });
           return;
       }

--- a/src/hooks/useCart/useCart.tsx
+++ b/src/hooks/useCart/useCart.tsx
@@ -17,7 +17,11 @@ import {
   tagOptionalIdentifierInput,
 } from "../../utils/utilsIdentifierInput";
 import { ERROR_MESSAGE } from "../../context/alert";
-import { SessionError, NetworkError } from "../../services/helpers";
+import {
+  SessionError,
+  NetworkError,
+  ErrorWithCodes,
+} from "../../services/helpers";
 import { IdentificationContext } from "../../context/identification";
 import { ProductContext, ProductContextValue } from "../../context/products";
 import { usePrevious } from "../usePrevious";
@@ -351,7 +355,11 @@ export const useCart = (
         setCartState("PURCHASED");
       } catch (e) {
         setCartState("DEFAULT");
-        if (e instanceof NetworkError) {
+        if (
+          e instanceof NetworkError ||
+          e instanceof SessionError ||
+          e instanceof ErrorWithCodes
+        ) {
           setCartError(e);
         } else if (e.message === "Requested lock is already taken") {
           setCartError(new Error(ERROR_MESSAGE.LOCK_ERROR));
@@ -372,8 +380,6 @@ export const useCart = (
           e.message === "Invalid Purchase Request: Item already used"
         ) {
           setCartError(new Error(ERROR_MESSAGE.ALREADY_USED_POD_IDENTIFIER));
-        } else if (e instanceof SessionError) {
-          setCartError(e);
         } else {
           setCartError(new Error(ERROR_MESSAGE.SERVER_ERROR));
         }

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -313,7 +313,8 @@ export const livePostTransaction = async ({
           identificationFlag,
           transaction: transactions,
         }),
-      }
+      },
+      true
     );
     return response;
   } catch (e) {

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -42,7 +42,7 @@ export class PastTransactionError extends Error {
   }
 }
 
-interface PostTransaction {
+export interface PostTransaction {
   ids: string[];
   identificationFlag: IdentificationFlag;
   transactions: Transaction[];

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -323,6 +323,9 @@ export const livePostTransaction = async ({
       Sentry.captureException(e);
     } else if (e instanceof SessionError) {
       throw e;
+    } else if (isPayNowTransaction) {
+      // this is to let all errors bubble upwards
+      throw e;
     }
     throw new PostTransactionError(e.message);
   }

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -297,6 +297,7 @@ export const livePostTransaction = async ({
   // format version with forward slash, to be added into endpoint, i.e. /v1
   const version = apiVersion ? `/${apiVersion}` : "";
   const suffix = isPayNowTransaction ? "paynow" : "";
+  const includeErrorCodes = isPayNowTransaction ?? false;
 
   try {
     const response = await fetchWithValidator(
@@ -314,7 +315,7 @@ export const livePostTransaction = async ({
           transaction: transactions,
         }),
       },
-      true
+      includeErrorCodes
     );
     return response;
   } catch (e) {

--- a/src/services/quota/postTransaction.test.ts
+++ b/src/services/quota/postTransaction.test.ts
@@ -148,7 +148,29 @@ describe("postTransaction", () => {
     ).rejects.toThrow(PostTransactionError);
   });
 
-  it("should throw error if there were issues fetching", async () => {
+  it("should throw error if there were issues with querying the endpoint", async () => {
+    expect.assertions(1);
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    await expect(postTransaction(postTransactionParams)).rejects.toThrow(
+      NetworkError
+    );
+  });
+
+  it("should throw error if there was an issue with authentication", async () => {
+    expect.assertions(1);
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: () =>
+        Promise.resolve({ message: "Invalid authentication token provided" }),
+    });
+
+    await expect(postTransaction(postTransactionParams)).rejects.toThrow(
+      SessionError
+    );
+  });
+});
+
     expect.assertions(1);
     mockFetch.mockRejectedValueOnce(new Error("Network error"));
 

--- a/src/services/quota/postTransaction.test.ts
+++ b/src/services/quota/postTransaction.test.ts
@@ -1,0 +1,159 @@
+import {
+  postTransaction,
+  PostTransactionError,
+  PostTransaction,
+} from "./index";
+import { Sentry } from "../../utils/errorTracking";
+import { defaultSelectedIdType } from "../../context/identification";
+import { PostTransactionResult } from "../../types";
+
+jest.mock("../../utils/errorTracking");
+const mockCaptureException = jest.fn();
+(Sentry.captureException as jest.Mock).mockImplementation(mockCaptureException);
+
+const mockFetch = jest.fn();
+jest.spyOn(global, "fetch").mockImplementation(mockFetch);
+
+const timestamp = new Date(2020, 3, 1);
+const identificationFlag = defaultSelectedIdType;
+const key = "KEY";
+const endpoint = "https://myendpoint.com";
+
+describe("postTransaction", () => {
+  let transactionsToCheckout;
+  let postTransactionParams: PostTransaction;
+
+  let mockPostTransactionApiResponse: {
+    transactions: {
+      transaction: {
+        category: string;
+        quantity: number;
+        identifierInputs: never[];
+      }[];
+      timestamp: number;
+    }[];
+  };
+  let mockPostTransactionResult: PostTransactionResult;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockCaptureException.mockReset();
+
+    transactionsToCheckout = [
+      { category: "product-1", quantity: 1, identifierInputs: [] },
+    ];
+
+    postTransactionParams = {
+      ids: ["S0000000J"],
+      identificationFlag,
+      transactions: transactionsToCheckout,
+      key,
+      endpoint,
+    };
+
+    mockPostTransactionApiResponse = {
+      transactions: [
+        {
+          transaction: transactionsToCheckout,
+          timestamp: timestamp.getTime(),
+        },
+      ],
+    };
+
+    mockPostTransactionResult = {
+      transactions: [
+        {
+          transaction: transactionsToCheckout,
+          timestamp,
+        },
+      ],
+    };
+  });
+
+  it("should return the correct success result", async () => {
+    expect.assertions(1);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockPostTransactionApiResponse),
+    });
+    const result = await postTransaction(postTransactionParams);
+    expect(result).toStrictEqual(mockPostTransactionResult);
+  });
+
+  it("should return the correct success result even with additional version param", async () => {
+    expect.assertions(1);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockPostTransactionApiResponse),
+    });
+    const result = await postTransaction({
+      ...postTransactionParams,
+      apiVersion: "v2",
+    });
+    expect(result).toStrictEqual(mockPostTransactionResult);
+  });
+
+  it("should throw error if no ID was provided", async () => {
+    expect.assertions(1);
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ message: "No ID was provided" }),
+    });
+
+    await expect(
+      postTransaction({ ...postTransactionParams, ids: [] })
+    ).rejects.toThrow(PostTransactionError);
+  });
+
+  it("should throw error if result is malformed", async () => {
+    expect.assertions(1);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          t: mockPostTransactionResult.transactions,
+        }),
+    });
+
+    await expect(postTransaction(postTransactionParams)).rejects.toThrow(
+      PostTransactionError
+    );
+  });
+
+  it("should capture exception through sentry if result is malformed", async () => {
+    expect.assertions(2);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          t: mockPostTransactionResult.transactions,
+        }),
+    });
+
+    await expect(postTransaction(postTransactionParams)).rejects.toThrow(
+      PostTransactionError
+    );
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("should throw error if quota could not be retrieved", async () => {
+    expect.assertions(1);
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: () => Promise.resolve({ message: "Invalid customer ID" }),
+    });
+
+    await expect(
+      postTransaction({ ...postTransactionParams, ids: ["invalid-id"] })
+    ).rejects.toThrow(PostTransactionError);
+  });
+
+  it("should throw error if there were issues fetching", async () => {
+    expect.assertions(1);
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    await expect(postTransaction(postTransactionParams)).rejects.toThrow(
+      "Network error"
+    );
+  });
+});

--- a/src/services/quota/quota.test.ts
+++ b/src/services/quota/quota.test.ts
@@ -192,7 +192,7 @@ describe("quota", () => {
         key,
         endpoint
       );
-      expect(quota).toEqual(mockGetQuotaResultSingleId);
+      expect(quota).toStrictEqual(mockGetQuotaResultSingleId);
     });
 
     it("should return the quota of an ID if version is passed in", async () => {
@@ -208,7 +208,7 @@ describe("quota", () => {
         endpoint,
         "v2" // version from features
       );
-      expect(quota).toEqual(mockGetQuotaResultSingleId);
+      expect(quota).toStrictEqual(mockGetQuotaResultSingleId);
     });
 
     it("should return the combined quota of multiple IDs", async () => {
@@ -223,7 +223,7 @@ describe("quota", () => {
         key,
         endpoint
       );
-      expect(quota).toEqual(mockGetQuotaResponseMultipleId);
+      expect(quota).toStrictEqual(mockGetQuotaResponseMultipleId);
     });
 
     it("should throw error if no ID was provided", async () => {
@@ -304,7 +304,7 @@ describe("quota", () => {
         key,
         endpoint
       );
-      expect(pastTransactionsResult).toEqual(mockPastTransactionsResult);
+      expect(pastTransactionsResult).toStrictEqual(mockPastTransactionsResult);
     });
 
     it("should return past transactions with additional version param", async () => {
@@ -322,7 +322,7 @@ describe("quota", () => {
         false,
         "v2"
       );
-      expect(pastTransactionsResult).toEqual(mockPastTransactionsResult);
+      expect(pastTransactionsResult).toStrictEqual(mockPastTransactionsResult);
     });
 
     it("should throw error if no ID was provided", async () => {
@@ -386,7 +386,7 @@ describe("quota", () => {
           method: "POST",
         }
       );
-      expect(pastTransactionsResult).toEqual(
+      expect(pastTransactionsResult).toStrictEqual(
         mockPastTransactionsWithSameCategoryResult
       );
     });

--- a/src/services/quota/quota.test.ts
+++ b/src/services/quota/quota.test.ts
@@ -1,8 +1,6 @@
 import {
   getQuota,
-  postTransaction,
   QuotaError,
-  PostTransactionError,
   getPastTransactions,
   PastTransactionError,
 } from "./index";
@@ -145,32 +143,6 @@ const mockGetQuotaResponseMultipleId = {
     ...t,
     quantity: Number.MAX_SAFE_INTEGER,
   })),
-};
-
-const postTransactionParams = {
-  ids: ["S0000000J"],
-  identificationFlag,
-  transactions: [{ category: "product-1", quantity: 2, identifiers: [] }],
-  key,
-  endpoint,
-};
-
-const mockPostTransactionResponse = {
-  transactions: [
-    {
-      transaction: transactions,
-      timestamp: timestamp.getTime(),
-    },
-  ],
-};
-
-const mockPostTransactionResult = {
-  transactions: [
-    {
-      transaction: transactions,
-      timestamp,
-    },
-  ],
 };
 
 const mockPastTransactionsResponse = {
@@ -316,95 +288,6 @@ describe("quota", () => {
       await expect(
         getQuota(["S0000000J"], identificationFlag, key, endpoint)
       ).rejects.toThrow("Network error");
-    });
-  });
-
-  describe("postTransaction", () => {
-    it("should return the correct success result", async () => {
-      expect.assertions(1);
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockPostTransactionResponse),
-      });
-      const result = await postTransaction(postTransactionParams);
-      expect(result).toEqual(mockPostTransactionResult);
-    });
-
-    it("should return the correct success result even with additional version param", async () => {
-      expect.assertions(1);
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockPostTransactionResponse),
-      });
-      const result = await postTransaction({
-        ...postTransactionParams,
-        apiVersion: "v2",
-      });
-      expect(result).toEqual(mockPostTransactionResult);
-    });
-
-    it("should throw error if no ID was provided", async () => {
-      expect.assertions(1);
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        json: () => Promise.resolve({ message: "No ID was provided" }),
-      });
-
-      await expect(
-        postTransaction({ ...postTransactionParams, ids: [] })
-      ).rejects.toThrow(PostTransactionError);
-    });
-
-    it("should throw error if result is malformed", async () => {
-      expect.assertions(1);
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            t: mockPostTransactionResult.transactions,
-          }),
-      });
-
-      await expect(postTransaction(postTransactionParams)).rejects.toThrow(
-        PostTransactionError
-      );
-    });
-
-    it("should capture exception through sentry if result is malformed", async () => {
-      expect.assertions(2);
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            t: mockPostTransactionResult.transactions,
-          }),
-      });
-
-      await expect(postTransaction(postTransactionParams)).rejects.toThrow(
-        PostTransactionError
-      );
-      expect(mockCaptureException).toHaveBeenCalledTimes(1);
-    });
-
-    it("should throw error if quota could not be retrieved", async () => {
-      expect.assertions(1);
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        json: () => Promise.resolve({ message: "Invalid customer ID" }),
-      });
-
-      await expect(
-        postTransaction({ ...postTransactionParams, ids: ["invalid-id"] })
-      ).rejects.toThrow(PostTransactionError);
-    });
-
-    it("should throw error if there were issues fetching", async () => {
-      expect.assertions(1);
-      mockFetch.mockRejectedValueOnce(new Error("Network error"));
-
-      await expect(postTransaction(postTransactionParams)).rejects.toThrow(
-        "Network error"
-      );
     });
   });
 


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Handling-timeout-when-Sally-calls-GovWallet-v2-customer-paynow-create-in-MINDEF-environment-Status--df04eb7102994ec9bf743f6147422717) <!-- Remove this link if no relevant Notion link -->

This PR adds
- ability to throw out errors received from `/transactions/paynow` under services
- refactoring of all tests for `postTransactions` out to its own file
- add tests to test that the GovWallet errors are thrown out properly
- updates `_completeCheckout` in `useCart` so that we set the ErrorWithCodes as is
- add tests to ensure that useCart is showing the new errors properly

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [x] I've added/updated unit/integration tests
~- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow~
I've asked around and it seems that we have trouble writing the e2e tests, so I am not able to do this at the moment.
