### PR TITLE
Chore: nav types refactoring

### DIFF
--- a/src/components/CampaignInitialisation/CampaignInitialisationScreen.tsx
+++ b/src/components/CampaignInitialisation/CampaignInitialisationScreen.tsx
@@ -8,7 +8,13 @@ import React, {
 import { Sentry } from "../../utils/errorTracking";
 import { StyleSheet, View } from "react-native";
 import { size } from "../../common/styles";
-import { AuthCredentials, RootStackParamList } from "../../types";
+import {
+  AuthCredentials,
+  CampaignInitialisationScreenNavigationProps,
+  Drawers,
+  Screens,
+  Stacks,
+} from "../../types";
 import { UpdateByRestartingAlert } from "./UpdateByRestartingAlert";
 import { UpdateFromAppStoreAlert } from "./UpdateFromAppStoreAlert";
 import { LoadingView } from "../Loading";
@@ -22,7 +28,6 @@ import { checkVersion } from "./utils";
 import { NetworkError, SessionError } from "../../services/helpers";
 import { AuthStoreContext } from "../../context/authStore";
 import { IdentificationContext } from "../../context/identification";
-import { StackScreenProps } from "@react-navigation/stack";
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -47,15 +52,9 @@ export class UpdateError extends Error {
   }
 }
 
-type Props = StackScreenProps<
-  RootStackParamList,
-  "CampaignInitialisationScreen"
->;
-
-export const CampaignInitialisationScreen: FunctionComponent<Props> = ({
-  navigation,
-  route,
-}) => {
+export const CampaignInitialisationScreen: FunctionComponent<
+  CampaignInitialisationScreenNavigationProps
+> = ({ navigation, route }) => {
   useEffect(() => {
     Sentry.addBreadcrumb({
       category: "navigation",
@@ -114,8 +113,8 @@ export const CampaignInitialisationScreen: FunctionComponent<Props> = ({
           expiry: new Date().getTime(),
         });
         showErrorAlert(updateCampaignConfigError, () =>
-          navigation.navigate("DrawerNavigator", {
-            screen: "CampaignLocationsScreen",
+          navigation.navigate(Drawers.MainDrawer, {
+            screen: Screens.CampaignLocationsScreen,
             params: {
               shouldAutoLoad: true,
             },
@@ -141,23 +140,35 @@ export const CampaignInitialisationScreen: FunctionComponent<Props> = ({
     // Reset IdentificationContext when adding or switching between campaigns
     resetSelectedIdType();
 
+    console.log(
+      "HELLO navigation - CampaignInitialisationScreen",
+      authCredentials.operatorToken,
+      authCredentials.endpoint
+    );
     if (campaignConfig?.features?.flowType) {
       switch (campaignConfig?.features?.flowType) {
         case "DEFAULT":
-          navigation.navigate("DrawerNavigator", {
-            screen: "CustomerQuotaStack",
+          navigation.navigate(Drawers.MainDrawer, {
+            screen: Stacks.CustomerQuotaStack,
             params: {
-              operatorToken: authCredentials.operatorToken,
-              endpoint: authCredentials.endpoint,
+              screen: Screens.CollectCustomerDetailsScreen,
+              params: {
+                operatorToken: authCredentials.operatorToken,
+                endpoint: authCredentials.endpoint,
+              },
             },
           });
+
           break;
         case "MERCHANT":
-          navigation.navigate("DrawerNavigator", {
-            screen: "MerchantPayoutStack",
+          navigation.navigate(Drawers.MainDrawer, {
+            screen: Stacks.MerchantPayoutStack,
             params: {
-              operatorToken: authCredentials.operatorToken,
-              endpoint: authCredentials.endpoint,
+              screen: Screens.MerchantPayoutScreen,
+              params: {
+                operatorToken: authCredentials.operatorToken,
+                endpoint: authCredentials.endpoint,
+              },
             },
           });
           break;

--- a/src/components/CampaignInitialisation/CampaignInitialisationScreen.tsx
+++ b/src/components/CampaignInitialisation/CampaignInitialisationScreen.tsx
@@ -140,11 +140,6 @@ export const CampaignInitialisationScreen: FunctionComponent<
     // Reset IdentificationContext when adding or switching between campaigns
     resetSelectedIdType();
 
-    console.log(
-      "HELLO navigation - CampaignInitialisationScreen",
-      authCredentials.operatorToken,
-      authCredentials.endpoint
-    );
     if (campaignConfig?.features?.flowType) {
       switch (campaignConfig?.features?.flowType) {
         case "DEFAULT":

--- a/src/components/CampaignLocations/CampaignLocationsScreen.tsx
+++ b/src/components/CampaignLocations/CampaignLocationsScreen.tsx
@@ -20,8 +20,8 @@ import { AuthStoreContext } from "../../context/authStore";
 import { CampaignLocationsListItem } from "./CampaignLocationsListItem";
 import {
   AuthCredentials,
-  RootStackParamList,
-  RootDrawerParamList,
+  CampaignLocationsScreenNavigationProps,
+  Screens,
 } from "../../types";
 import { Sentry } from "../../utils/errorTracking";
 import { CampaignConfigsStoreContext } from "../../context/campaignConfigsStore";
@@ -31,9 +31,6 @@ import { Card } from "../Layout/Card";
 import { AppText } from "../Layout/AppText";
 import { sortBy } from "lodash";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
-import { DrawerScreenProps } from "@react-navigation/drawer";
-import { StackScreenProps } from "@react-navigation/stack";
-import { CompositeScreenProps } from "@react-navigation/core";
 import { useConfigContext } from "../../context/config";
 
 const styles = StyleSheet.create({
@@ -66,10 +63,7 @@ const styles = StyleSheet.create({
 });
 
 export const CampaignLocationsScreen: FunctionComponent<
-  CompositeScreenProps<
-    DrawerScreenProps<RootDrawerParamList, "CampaignLocationsScreen">,
-    StackScreenProps<RootStackParamList>
-  >
+  CampaignLocationsScreenNavigationProps
 > = ({ navigation, route }) => {
   useEffect(() => {
     Sentry.addBreadcrumb({
@@ -83,7 +77,7 @@ export const CampaignLocationsScreen: FunctionComponent<
    * Determines whether the app should automatically load a campaign if there
    * is only one existing campaign
    */
-  const shouldAutoLoad: boolean = route?.params?.shouldAutoLoad ?? true;
+  const shouldAutoLoad: boolean = route?.params?.shouldAutoLoad ?? true; // true by default
 
   const messageContent = useContext(ImportantMessageContentContext);
   const showHelpModal = useContext(HelpModalContext);
@@ -109,18 +103,15 @@ export const CampaignLocationsScreen: FunctionComponent<
         icon: "map-marker-plus",
         label: i18nt("navigationDrawer", "addCampaign"),
         onPress: () => {
-          navigation.navigate("LoginScreen");
+          navigation.navigate(Screens.LoginScreen);
         },
       },
       {
         icon: "map-search",
         label: i18nt("navigationDrawer", "changeChampaign"),
         onPress: () => {
-          navigation.navigate({
-            key: "CampaignLocationsScreen",
-            params: {
-              shouldAutoLoad,
-            },
+          navigation.navigate(Screens.CampaignLocationsScreen, {
+            shouldAutoLoad,
           });
         },
       },
@@ -136,9 +127,8 @@ export const CampaignLocationsScreen: FunctionComponent<
 
   const navigateToCampaignLocation = useCallback(
     (authCredentials: AuthCredentials): void => {
-      navigation.navigate({
-        key: "CampaignInitialisationScreen",
-        params: { authCredentials },
+      navigation.navigate(Screens.CampaignInitialisationScreen, {
+        authCredentials,
       });
     },
     [navigation]
@@ -156,7 +146,7 @@ export const CampaignLocationsScreen: FunctionComponent<
         navigateToCampaignLocation(Object.values(authCredentials)[0]);
       } else if (numCampaignLocations === 0) {
         // Automatically go to the Login Screen to add a campaign
-        navigation.navigate("LoginScreen");
+        navigation.navigate(Screens.LoginScreen);
       }
     }
   }, [

--- a/src/components/CustomerAppeal/CustomerAppealScreen.test.tsx
+++ b/src/components/CustomerAppeal/CustomerAppealScreen.test.tsx
@@ -119,20 +119,23 @@ describe("CustomerAppealScreen", () => {
 
     fireEvent.press(reasonOne!);
     expect(mockedDispatch).toHaveBeenCalledTimes(1);
-    expect(mockStackedActionsPush).toHaveBeenCalledWith("CustomerQuotaProxy", {
-      id: ["valid-id"],
-      products: [
-        {
-          category: "toilet-paper",
-          categoryType: "APPEAL",
-          name: "Toilet Paper",
-          order: 1,
-          quantity: {
-            period: 7,
-            limit: 2,
+    expect(mockStackedActionsPush).toHaveBeenCalledWith(
+      "Customer Quota Proxy",
+      {
+        id: ["valid-id"],
+        products: [
+          {
+            category: "toilet-paper",
+            categoryType: "APPEAL",
+            name: "Toilet Paper",
+            order: 1,
+            quantity: {
+              period: 7,
+              limit: 2,
+            },
           },
-        },
-      ],
-    });
+        ],
+      }
+    );
   });
 });

--- a/src/components/CustomerAppeal/CustomerAppealScreen.tsx
+++ b/src/components/CustomerAppeal/CustomerAppealScreen.tsx
@@ -7,7 +7,7 @@ import React, {
 } from "react";
 import { transform } from "lodash";
 import { StyleSheet, View } from "react-native";
-import { CustomerAppealScreenNavigationProps } from "../../types";
+import { CustomerAppealScreenNavigationProps, Screens } from "../../types";
 import { size } from "../../common/styles";
 import { AppHeader } from "../Layout/AppHeader";
 import { TopBackground } from "../Layout/TopBackground";
@@ -75,7 +75,7 @@ export const CustomerAppealScreen: FunctionComponent<
     navigation.dispatch(
       CommonActions.reset({
         index: 0,
-        routes: [{ name: "CollectCustomerDetailsScreen" }],
+        routes: [{ name: Screens.CollectCustomerDetailsScreen }],
       })
     );
   }, [navigation]);
@@ -174,12 +174,8 @@ export const CustomerAppealScreen: FunctionComponent<
       );
       return;
     }
-    // pushRoute(navigation, "CustomerQuotaProxy", {
-    //   id: ids,
-    //   products: [appealProduct],
-    // });
     navigation.dispatch(
-      StackActions.push("CustomerQuotaProxy", {
+      StackActions.push(Screens.CustomerQuotaProxy, {
         id: ids,
         products: [appealProduct],
       })

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.test.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.test.tsx
@@ -120,10 +120,13 @@ describe("CollectCustomerDetailsScreen", () => {
       fireEvent.press(checkButton!);
       expect(mockValidateAndCleanId).toHaveBeenCalledTimes(1);
 
-      expect(mockNavigate.navigate).toHaveBeenCalledWith("CustomerQuotaProxy", {
-        id: "valid-id",
-        products: [defaultProducts[0]],
-      });
+      expect(mockNavigate.navigate).toHaveBeenCalledWith(
+        "Customer Quota Proxy",
+        {
+          id: "valid-id",
+          products: [defaultProducts[0]],
+        }
+      );
     });
 
     it("should throw error when input id is invalid", async () => {
@@ -227,10 +230,13 @@ describe("CollectCustomerDetailsScreen", () => {
       fireEvent.press(checkButton!);
       expect(mockValidateAndCleanId).toHaveBeenCalledTimes(1);
 
-      expect(mockNavigate.navigate).toHaveBeenCalledWith("CustomerQuotaProxy", {
-        id: "valid-alternate-id",
-        products: [defaultProducts[0]],
-      });
+      expect(mockNavigate.navigate).toHaveBeenCalledWith(
+        "Customer Quota Proxy",
+        {
+          id: "valid-alternate-id",
+          products: [defaultProducts[0]],
+        }
+      );
     });
 
     it("should throw error when alternate id is invalid", async () => {

--- a/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
+++ b/src/components/CustomerDetails/CollectCustomerDetailsScreen.tsx
@@ -40,6 +40,7 @@ import { InputPassportSection } from "./InputPassportSection";
 import {
   CollectCustomerDetailsScreenNavigationProps,
   IdentificationFlag,
+  Screens,
 } from "../../types";
 import {
   IdentificationContext,
@@ -190,9 +191,9 @@ export const CollectCustomerDetailsScreen: FunctionComponent<
       );
 
       setShouldShowCamera(false);
-      navigation.navigate("CustomerQuotaProxy", {
+      navigation.navigate(Screens.CustomerQuotaProxy, {
         id,
-        products: defaultProducts,
+        products: defaultProducts, // TODO potentially handling undefined for `products` key
       });
       setIdInput("");
     } catch (e) {
@@ -251,7 +252,7 @@ export const CollectCustomerDetailsScreen: FunctionComponent<
   };
 
   const onPressStatistics = (): void => {
-    navigation.navigate("DailyStatisticsScreen");
+    navigation.navigate(Screens.DailyStatisticsScreen);
   };
 
   const getBarcodeType = (): any[] => {

--- a/src/components/CustomerDetails/InputIdSection.tsx
+++ b/src/components/CustomerDetails/InputIdSection.tsx
@@ -83,7 +83,7 @@ export const InputIdSection: FunctionComponent<InputIdSection> = ({
             value={idInput}
             onChange={({ nativeEvent: { text } }) => setIdInput(text)}
             onSubmitEditing={submitId}
-            autoCompleteType="off"
+            autoComplete="off"
             autoCorrect={false}
             keyboardType={keyboardType}
             accessibilityLabel="identity-details"

--- a/src/components/CustomerQuota/CustomerQuotaProxy.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaProxy.tsx
@@ -8,14 +8,9 @@ export const CustomerQuotaProxy: FunctionComponent<
 > = ({ navigation, route }) => {
   // coming from NRIC screen, it will be a string
   // coming from appeal, it can be an array if group appeal is supported
-  console.log("CustomerQuotaProxy, route.params", route.params);
   const navId = route.params?.id;
   const navIds: string[] = Array.isArray(navId) ? navId : [navId];
-
-  console.log("CustomerQuotaProxy, navIds", navIds);
-
   const selectedProducts: CampaignPolicy[] = route.params?.products;
-  console.log("CustomerQuotaProxy, CampaignPolicy[]", selectedProducts);
 
   return (
     <ProductContextProvider products={selectedProducts}>

--- a/src/components/CustomerQuota/CustomerQuotaScreen.tsx
+++ b/src/components/CustomerQuota/CustomerQuotaScreen.tsx
@@ -6,7 +6,11 @@ import React, {
   useContext,
 } from "react";
 import { View, StyleSheet, ActivityIndicator, BackHandler } from "react-native";
-import { CustomerQuotaScreenNavigationProps } from "../../types";
+import {
+  CustomerQuotaScreenNavigationProps,
+  Drawers,
+  Screens,
+} from "../../types";
 import { color, size } from "../../common/styles";
 import { AuthContext } from "../../context/auth";
 import { AppHeader } from "../Layout/AppHeader";
@@ -133,7 +137,7 @@ export const CustomerQuotaScreen: FunctionComponent<Props> = ({
   }, [cartState]);
 
   const onCancel = useCallback((): void => {
-    navigation.navigate("CollectCustomerDetailsScreen");
+    navigation.navigate(Screens.CollectCustomerDetailsScreen);
   }, [navigation]);
 
   const onBack = useCallback((): void => {
@@ -145,11 +149,11 @@ export const CustomerQuotaScreen: FunctionComponent<Props> = ({
   }, []);
 
   const onAppeal = useCallback((): void => {
-    navigation.navigate("CustomerAppealScreen", { ids });
+    navigation.navigate(Screens.CustomerAppealScreen, { ids });
   }, [ids, navigation]);
 
   const onNextId = useCallback((): void => {
-    navigation.navigate("CollectCustomerDetailsScreen");
+    navigation.navigate(Screens.CollectCustomerDetailsScreen);
   }, [navigation]);
 
   useEffect(() => {
@@ -157,8 +161,8 @@ export const CustomerQuotaScreen: FunctionComponent<Props> = ({
 
     const onBackPress = (): boolean => {
       navigation.navigate({
-        name: "DrawerNavigator",
-        key: "CollectCustomerDetailsScreen",
+        name: Drawers.MainDrawer,
+        key: Screens.CollectCustomerDetailsScreen,
       });
       return true;
     };
@@ -195,7 +199,7 @@ export const CustomerQuotaScreen: FunctionComponent<Props> = ({
           clearQuotaError();
           expireSession();
           showErrorAlert(quotaError, () => {
-            navigation.navigate("CampaignLocationsScreen", {
+            navigation.navigate(Screens.CampaignLocationsScreen, {
               shouldAutoLoad: true,
             });
           });
@@ -213,7 +217,7 @@ export const CustomerQuotaScreen: FunctionComponent<Props> = ({
           clearGovWalletBalanceError();
           expireSession();
           showErrorAlert(govWalletBalanceError, () => {
-            navigation.navigate("CampaignLocationsScreen", {
+            navigation.navigate(Screens.CampaignLocationsScreen, {
               shouldAutoLoad: true,
             });
           });
@@ -229,7 +233,7 @@ export const CustomerQuotaScreen: FunctionComponent<Props> = ({
           clearCartError();
           expireSession();
           showErrorAlert(cartError, () => {
-            navigation.navigate("CampaignLocationsScreen", {
+            navigation.navigate(Screens.CampaignLocationsScreen, {
               shouldAutoLoad: true,
             });
           });
@@ -244,7 +248,7 @@ export const CustomerQuotaScreen: FunctionComponent<Props> = ({
         case cartError instanceof ErrorWithCodes:
           showErrorAlert(cartError, () => {
             navigation.navigate({
-              key: "CollectCustomerDetailsScreen",
+              key: Screens.CollectCustomerDetailsScreen,
             });
           });
           return;
@@ -292,7 +296,9 @@ export const CustomerQuotaScreen: FunctionComponent<Props> = ({
           case ERROR_MESSAGE.LOCK_ERROR:
             clearCartError();
             showErrorAlert(cartError, () => {
-              navigation.navigate({ key: "CampaignLocationsScreen" });
+              navigation.navigate(Screens.CampaignLocationsScreen, {
+                shouldAutoLoad: true,
+              });
             });
             break;
           case ERROR_MESSAGE.INVALID_QUANTITY:

--- a/src/components/DailyStatistics/DailyStatisticsScreen.tsx
+++ b/src/components/DailyStatistics/DailyStatisticsScreen.tsx
@@ -24,7 +24,7 @@ import { TransactionHistoryCard } from "./TransactionHistoryCard";
 import { StatisticsHeader } from "./StatisticsHeader";
 import { addDays, subDays, getTime, isSameDay } from "date-fns";
 import { AlertModalContext } from "../../context/alert";
-import { DailyStatisticsScreenProps } from "../../types";
+import { DailyStatisticsScreenProps, Screens } from "../../types";
 import { useDailyStatistics } from "../../hooks/useDailyStatistics/useDailyStatistics";
 import { useTheme } from "../../context/theme";
 import { NetworkError, SessionError } from "../../services/helpers";
@@ -116,18 +116,17 @@ const DailyStatisticsScreen: FunctionComponent<DailyStatisticsScreenProps> = ({
           clearDailyStatisticsError();
           expireSession();
           showErrorAlert(error, () => {
-            navigation.navigate("CampaignLocationsScreen", {
+            navigation.navigate(Screens.CampaignLocationsScreen, {
               shouldAutoLoad: false,
             });
           });
           return;
       }
       showErrorAlert(error, () => {
-        // navigateHome(navigation)
         navigation.dispatch(
           CommonActions.reset({
             index: 0,
-            routes: [{ name: "CollectCustomerDetailsScreen" }],
+            routes: [{ name: Screens.CollectCustomerDetailsScreen }],
           })
         );
       });

--- a/src/components/DailyStatistics/StatisticsHeader.tsx
+++ b/src/components/DailyStatistics/StatisticsHeader.tsx
@@ -4,7 +4,7 @@ import { View, StyleSheet, TouchableOpacity, Keyboard } from "react-native";
 import { AppMode } from "../../context/config";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { DrawerActions } from "@react-navigation/native";
-import { DailyStatisticsScreenProps } from "../../types";
+import { DailyStatisticsScreenProps, Screens } from "../../types";
 import { AppText } from "../Layout/AppText";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
 import { useTheme } from "../../context/theme";
@@ -55,7 +55,7 @@ export const StatisticsHeaderComponent: FunctionComponent<StatisticsHeader> = ({
   };
 
   const onPressBack = (): void => {
-    navigation.navigate("CollectCustomerDetailsScreen");
+    navigation.navigate(Screens.CollectCustomerDetailsScreen);
   };
 
   const { theme } = useTheme();

--- a/src/components/Login/LoginContainer.test.tsx
+++ b/src/components/Login/LoginContainer.test.tsx
@@ -200,7 +200,7 @@ describe("LoginContainer", () => {
       endpoint
     );
     expect(mockNavigation.navigate).toHaveBeenCalledWith(
-      "CampaignInitialisationScreen",
+      "Campaign Initialisation Screen",
       {
         authCredentials: {
           operatorToken: key,

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -258,7 +258,6 @@ export const InitialisationContainer: FunctionComponent<
           operatorToken: key,
         });
         setIsLoading(false);
-        console.log('setLoginStage("MOBILE_NUMBER")');
         setLoginStage("MOBILE_NUMBER");
       } catch (e) {
         const error = new Error(`onBarCodeScanned ${e}`);

--- a/src/components/Login/LoginContainer.tsx
+++ b/src/components/Login/LoginContainer.tsx
@@ -13,7 +13,12 @@ import {
   Vibration,
   BackHandler,
 } from "react-native";
-import { AuthCredentials, RootStackParamList } from "../../types";
+import {
+  AuthCredentials,
+  Drawers,
+  InitialisationContainerNavigationProps,
+  Screens,
+} from "../../types";
 import { DangerButton } from "../Layout/Buttons/DangerButton";
 import { size, borderRadius, color } from "../../common/styles";
 import { TopBackground } from "../Layout/TopBackground";
@@ -51,7 +56,6 @@ import { AuthStoreContext } from "../../context/authStore";
 import { Feather } from "@expo/vector-icons";
 import { createFullNumber } from "../../utils/validatePhoneNumbers";
 import { NetworkError } from "../../services/helpers";
-import { StackScreenProps } from "@react-navigation/stack";
 
 const TIME_HELD_TO_CHANGE_APP_MODE = 5 * 1000;
 
@@ -98,14 +102,9 @@ const CloseButton: FunctionComponent<{
   </View>
 );
 
-type Props = StackScreenProps<
-  RootStackParamList,
-  "CampaignInitialisationScreen"
->;
-
-export const InitialisationContainer: FunctionComponent<Props> = ({
-  navigation,
-}) => {
+export const InitialisationContainer: FunctionComponent<
+  InitialisationContainerNavigationProps
+> = ({ navigation }) => {
   useEffect(() => {
     Sentry.addBreadcrumb({
       category: "navigation",
@@ -179,8 +178,8 @@ export const InitialisationContainer: FunctionComponent<Props> = ({
   };
 
   const onPressClose = (): void => {
-    navigation.navigate("DrawerNavigator", {
-      screen: "CampaignLocationsScreen",
+    navigation.navigate(Drawers.MainDrawer, {
+      screen: Screens.CampaignLocationsScreen,
       params: {
         shouldAutoLoad: true,
       },
@@ -189,7 +188,9 @@ export const InitialisationContainer: FunctionComponent<Props> = ({
 
   const onSuccess = (authCredentials: AuthCredentials): void => {
     setConfigValue("fullMobileNumber", { countryCode, mobileNumber });
-    navigation.navigate("CampaignInitialisationScreen", { authCredentials });
+    navigation.navigate(Screens.CampaignInitialisationScreen, {
+      authCredentials,
+    });
   };
 
   useEffect(() => {

--- a/src/components/Logout/LogoutScreen.test.tsx
+++ b/src/components/Logout/LogoutScreen.test.tsx
@@ -7,7 +7,7 @@ import { AppMode, ConfigContext } from "../../context/config";
 import { ImportantMessageSetterContext } from "../../context/importantMessage";
 import { callLogout, LogoutError } from "../../services/auth";
 import { NetworkError } from "../../services/helpers";
-import { AuthCredentials } from "../../types";
+import { AuthCredentials, Drawers, Screens } from "../../types";
 import { Sentry } from "../../utils/errorTracking";
 import { ErrorBoundary } from "../ErrorBoundary/ErrorBoundary";
 import { LogoutScreen } from "./LogoutScreen";
@@ -158,7 +158,7 @@ describe("LogoutScreen", () => {
 
       await waitFor(() => expect(mockNavigate).toHaveBeenCalledTimes(1));
 
-      expect(mockNavigate).toHaveBeenCalledWith("LoginScreen");
+      expect(mockNavigate).toHaveBeenCalledWith(Screens.LoginScreen);
       expect(mockClearAuthCredentials).toHaveBeenCalledTimes(1);
       expect(mockClearCampaignConfigs).toHaveBeenCalledTimes(1);
     });
@@ -239,8 +239,8 @@ describe("LogoutScreen", () => {
 
         await waitFor(() => expect(mockNavigate).toHaveBeenCalledTimes(1));
 
-        expect(mockNavigate).toHaveBeenCalledWith("DrawerNavigator", {
-          screen: "CampaignLocationsScreen",
+        expect(mockNavigate).toHaveBeenCalledWith(Drawers.MainDrawer, {
+          screen: Screens.CampaignLocationsScreen,
           params: {
             shouldAutoLoad: false,
           },

--- a/src/components/Logout/LogoutScreen.tsx
+++ b/src/components/Logout/LogoutScreen.tsx
@@ -1,4 +1,3 @@
-import { StackScreenProps } from "@react-navigation/stack";
 import React, {
   FunctionComponent,
   useContext,
@@ -14,7 +13,7 @@ import { ConfigContext } from "../../context/config";
 import { ImportantMessageSetterContext } from "../../context/importantMessage";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
 import { callLogout, LogoutError } from "../../services/auth";
-import { RootStackParamList } from "../../types";
+import { Drawers, LogoutScreenNavigationProps, Screens } from "../../types";
 import { Sentry } from "../../utils/errorTracking";
 import { allSettled } from "../../utils/promiseAllSettled";
 import { AppText } from "../Layout/AppText";
@@ -33,9 +32,9 @@ const styles = StyleSheet.create({
   },
 });
 
-type Props = StackScreenProps<RootStackParamList, "LogoutScreen">;
-
-export const LogoutScreen: FunctionComponent<Props> = ({ navigation }) => {
+export const LogoutScreen: FunctionComponent<LogoutScreenNavigationProps> = ({
+  navigation,
+}) => {
   useEffect(() => {
     Sentry.addBreadcrumb({
       category: "navigation",
@@ -75,8 +74,8 @@ export const LogoutScreen: FunctionComponent<Props> = ({ navigation }) => {
         const error: Error = errorResults[0].reason;
         if (error instanceof LogoutError) {
           showErrorAlert(error);
-          navigation.navigate("DrawerNavigator", {
-            screen: "CampaignLocationsScreen",
+          navigation.navigate(Drawers.MainDrawer, {
+            screen: Screens.CampaignLocationsScreen,
             params: {
               shouldAutoLoad: false,
             },
@@ -93,7 +92,7 @@ export const LogoutScreen: FunctionComponent<Props> = ({ navigation }) => {
 
         setConfigValue("fullMobileNumber", undefined);
         setMessageContent(null);
-        navigation.navigate("LoginScreen");
+        navigation.navigate(Screens.LoginScreen);
       }
     };
     if (!isLoggingOut) {

--- a/src/components/MerchantPayout/MerchantPayoutScreen.tsx
+++ b/src/components/MerchantPayout/MerchantPayoutScreen.tsx
@@ -13,7 +13,6 @@ import {
   Keyboard,
 } from "react-native";
 import { size, color } from "../../common/styles";
-import { NavigationFocusInjectedProps } from "react-navigation";
 import { useIsFocused } from "@react-navigation/native";
 import { TopBackground } from "../Layout/TopBackground";
 import { useConfigContext } from "../../context/config";
@@ -47,6 +46,7 @@ import {
 import { AuthStoreContext } from "../../context/authStore";
 import { LimitReachedError } from "../../utils/validateVoucherCode";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
+import { MerchantPayoutScreenNavigationProps, Screens } from "../../types";
 
 const styles = StyleSheet.create({
   content: {
@@ -75,7 +75,7 @@ const styles = StyleSheet.create({
 });
 
 export const MerchantPayoutScreen: FunctionComponent<
-  NavigationFocusInjectedProps
+  MerchantPayoutScreenNavigationProps
 > = ({ navigation }) => {
   const isFocused = useIsFocused();
   const messageContent = useContext(ImportantMessageContentContext);
@@ -182,7 +182,9 @@ export const MerchantPayoutScreen: FunctionComponent<
     } else if (validityError instanceof SessionError) {
       expireSession();
       showErrorAlert(validityError, () => {
-        navigation.navigate("CampaignLocationsScreen");
+        navigation.navigate(Screens.CampaignLocationsScreen, {
+          shouldAutoLoad: true,
+        });
       });
     }
   }, [expireSession, navigation, showErrorAlert, validityError, onModalExit]);
@@ -200,7 +202,7 @@ export const MerchantPayoutScreen: FunctionComponent<
   // Detect submission of merchant code
   useEffect(() => {
     if (checkoutVouchersState === "RESULT_RETURNED" && checkoutResult) {
-      navigation.navigate("PayoutFeedbackScreen", {
+      navigation.navigate(Screens.PayoutFeedbackScreen, {
         merchantCode,
         checkoutResult,
       });

--- a/src/components/PayoutFeedback/PayoutFeedbackScreen.tsx
+++ b/src/components/PayoutFeedback/PayoutFeedbackScreen.tsx
@@ -1,8 +1,9 @@
 import React, { FunctionComponent, useContext } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import {
-  MerchantPayoutStackParamList,
+  PayoutFeedbackScreenNavigationProps,
   PostTransactionResult,
+  Screens,
 } from "../../types";
 import { size, color, fontSize, borderRadius } from "../../common/styles";
 import { AppHeader } from "../Layout/AppHeader";
@@ -20,7 +21,6 @@ import { Card } from "../Layout/Card";
 import { sharedStyles } from "../CustomerQuota/CheckoutSuccess/sharedStyles";
 import { sharedStyles as sharedCardStyles } from "../CustomerQuota/sharedStyles";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
-import { StackScreenProps } from "@react-navigation/stack";
 
 const styles = StyleSheet.create({
   content: {
@@ -75,14 +75,10 @@ const styles = StyleSheet.create({
     marginTop: size(5),
   },
 });
-type Props = StackScreenProps<
-  MerchantPayoutStackParamList,
-  "PayoutFeedbackScreen"
->;
-export const PayoutFeedbackScreen: FunctionComponent<Props> = ({
-  navigation,
-  route,
-}) => {
+
+export const PayoutFeedbackScreen: FunctionComponent<
+  PayoutFeedbackScreenNavigationProps
+> = ({ navigation, route }) => {
   const messageContent = useContext(ImportantMessageContentContext);
   const { config } = useConfigContext();
   const showHelpModal = useContext(HelpModalContext);
@@ -184,7 +180,7 @@ export const PayoutFeedbackScreen: FunctionComponent<Props> = ({
             fullWidth={true}
             text={i18nt("merchantFlowScreen", "nextMerchant")}
             onPress={() => {
-              navigation.navigate("MerchantPayoutScreen", {});
+              navigation.navigate(Screens.MerchantPayoutScreen);
             }}
           />
         </View>

--- a/src/navigation/Content.tsx
+++ b/src/navigation/Content.tsx
@@ -25,7 +25,7 @@ import { CampaignInitialisationScreen } from "../components/CampaignInitialisati
 import { CampaignLocationsScreen } from "../components/CampaignLocations/CampaignLocationsScreen";
 import { updateI18nLocale } from "../common/i18n/i18nSetup";
 import { LogoutScreen } from "../components/Logout/LogoutScreen";
-import { RootStackParamList } from "../types";
+import { Drawers, RootStackParams, Screens, Stacks } from "../types";
 import { isRootedExperimentalAsync } from "expo-device";
 
 export class RootedDeviceDetectedError extends Error {
@@ -50,20 +50,23 @@ function DrawerNavigator(): JSX.Element {
       screenOptions={drawerNavigatorScreenOptions}
     >
       <Drawer.Screen
-        name="CampaignLocationsScreen"
+        name={Screens.CampaignLocationsScreen}
         component={CampaignLocationsScreen}
       />
-      <Drawer.Screen name="CustomerQuotaStack" component={CustomerQuotaStack} />
       <Drawer.Screen
-        name="MerchantPayoutStack"
+        name={Stacks.CustomerQuotaStack}
+        component={CustomerQuotaStack}
+      />
+      <Drawer.Screen
+        name={Stacks.MerchantPayoutStack}
         component={MerchantPayoutStack}
       />
     </Drawer.Navigator>
   );
 }
-const Stack = createStackNavigator<RootStackParamList>();
+const Stack = createStackNavigator<RootStackParams>();
 // TODO consider using NativeStack
-// const Stack = createNativeStackNavigator<RootStackParamList>();
+// const Stack = createNativeStackNavigator<RootStackParams>();
 // https://reactnavigation.org/docs/native-stack-navigator
 const screenOptions: StackNavigationOptions = {
   ...TransitionPresets.SlideFromRightIOS,
@@ -112,16 +115,22 @@ export const Content = (): ReactElement => {
         <NavigationContainer ref={navigatorRef} linking={linking}>
           <Stack.Navigator
             id="RootStack"
-            initialRouteName={"LoginScreen"}
+            initialRouteName={Screens.LoginScreen}
             screenOptions={screenOptions}
           >
-            <Stack.Screen name="LoginScreen" component={LoginScreen} />
+            <Stack.Screen name={Screens.LoginScreen} component={LoginScreen} />
             <Stack.Screen
-              name="CampaignInitialisationScreen"
+              name={Screens.CampaignInitialisationScreen}
               component={CampaignInitialisationScreen}
             />
-            <Stack.Screen name="LogoutScreen" component={LogoutScreen} />
-            <Stack.Screen name="DrawerNavigator" component={DrawerNavigator} />
+            <Stack.Screen
+              name={Screens.LogoutScreen}
+              component={LogoutScreen}
+            />
+            <Stack.Screen
+              name={Drawers.MainDrawer}
+              component={DrawerNavigator}
+            />
           </Stack.Navigator>
         </NavigationContainer>
       </View>

--- a/src/navigation/CustomerQuotaStack/index.tsx
+++ b/src/navigation/CustomerQuotaStack/index.tsx
@@ -2,7 +2,6 @@ import {
   createStackNavigator,
   TransitionPresets,
   StackNavigationOptions,
-  StackScreenProps,
 } from "@react-navigation/stack";
 
 import CollectCustomerDetailsScreen from "./CollectCustomerDetailsScreen";
@@ -15,14 +14,13 @@ import { AuthContextProvider } from "../../context/auth";
 import { CampaignConfigContextProvider } from "../../context/campaignConfig";
 import DailyStatisticsScreen from "./DailyStatisticsScreen";
 import { useTheme } from "../../context/theme";
-import { CustomerQuotaStackParamList } from "../../types";
+import {
+  CustomerQuotaStackParams,
+  CustomerQuotaStackScreenProps,
+  Screens,
+} from "../../types";
 
-type Props = StackScreenProps<
-  CustomerQuotaStackParamList,
-  "CustomerQuotaProxy"
->;
-
-const Stack = createStackNavigator<CustomerQuotaStackParamList>();
+const Stack = createStackNavigator<CustomerQuotaStackParams>();
 
 const screenOptions: StackNavigationOptions = {
   cardStyle: { backgroundColor: "#F5F5F5" },
@@ -31,12 +29,13 @@ const screenOptions: StackNavigationOptions = {
   headerShown: false,
 };
 
-const CustomerQuotaStack: FunctionComponent<Props> = ({
+const CustomerQuotaStack: FunctionComponent<CustomerQuotaStackScreenProps> = ({
   navigation,
   route,
 }) => {
-  const operatorToken = route.params?.operatorToken;
-  const endpoint = route.params?.endpoint;
+  const operatorToken =
+    route.params?.operatorToken || route.params?.params?.operatorToken;
+  const endpoint = route.params?.endpoint || route.params?.params?.endpoint;
 
   const key = `${operatorToken}${endpoint}`;
 
@@ -47,7 +46,9 @@ const CustomerQuotaStack: FunctionComponent<Props> = ({
   const { setTheme } = useTheme();
   useEffect(() => {
     if (!hasDataFromStore) {
-      navigation.getParent()?.navigate("CampaignLocationsScreen");
+      navigation.navigate(Screens.CampaignLocationsScreen, {
+        shouldAutoLoad: true,
+      });
     }
   }, [hasDataFromStore, navigation]);
 
@@ -61,22 +62,24 @@ const CustomerQuotaStack: FunctionComponent<Props> = ({
   return hasDataFromStore ? (
     <AuthContextProvider authCredentials={authCredentials[key]!}>
       <CampaignConfigContextProvider campaignConfig={allCampaignConfigs[key]!}>
-        {/* <Stack navigation={navigation} /> */}
-        <Stack.Navigator screenOptions={screenOptions}>
+        <Stack.Navigator
+          initialRouteName={Screens.CollectCustomerDetailsScreen}
+          screenOptions={screenOptions}
+        >
           <Stack.Screen
-            name="CollectCustomerDetailsScreen"
+            name={Screens.CollectCustomerDetailsScreen}
             component={CollectCustomerDetailsScreen}
           />
           <Stack.Screen
-            name="CustomerQuotaProxy"
+            name={Screens.CustomerQuotaProxy}
             component={CustomerQuotaProxy}
           />
           <Stack.Screen
-            name="CustomerAppealScreen"
+            name={Screens.CustomerAppealScreen}
             component={CustomerAppealScreen}
           />
           <Stack.Screen
-            name="DailyStatisticsScreen"
+            name={Screens.DailyStatisticsScreen}
             component={DailyStatisticsScreen}
           />
         </Stack.Navigator>

--- a/src/navigation/MerchantPayoutStack/index.tsx
+++ b/src/navigation/MerchantPayoutStack/index.tsx
@@ -2,7 +2,6 @@ import {
   createStackNavigator,
   TransitionPresets,
   StackNavigationOptions,
-  StackScreenProps,
 } from "@react-navigation/stack";
 import MerchantPayoutScreen from "./MerchantPayoutScreen";
 import PayoutFeedbackScreen from "./PayoutFeedbackScreen";
@@ -11,11 +10,13 @@ import { AuthStoreContext } from "../../context/authStore";
 import { CampaignConfigsStoreContext } from "../../context/campaignConfigsStore";
 import { AuthContextProvider } from "../../context/auth";
 import { CampaignConfigContextProvider } from "../../context/campaignConfig";
-import { MerchantPayoutStackParamList, RootDrawerParamList } from "../../types";
-import { CompositeScreenProps } from "@react-navigation/native";
-import { DrawerScreenProps } from "@react-navigation/drawer";
+import {
+  MerchantPayoutStackScreenProps,
+  MerchantPayoutStackParams,
+  Screens,
+} from "../../types";
 
-const Stack = createStackNavigator<MerchantPayoutStackParamList>();
+const Stack = createStackNavigator<MerchantPayoutStackParams>();
 
 const screenOptions: StackNavigationOptions = {
   ...TransitionPresets.SlideFromRightIOS,
@@ -23,16 +24,12 @@ const screenOptions: StackNavigationOptions = {
   headerShown: false,
 };
 
-type Props = CompositeScreenProps<
-  StackScreenProps<MerchantPayoutStackParamList, "MerchantPayoutScreen">,
-  DrawerScreenProps<RootDrawerParamList>
->;
-const MerchantPayoutStack: FunctionComponent<Props> = ({
-  navigation,
-  route,
-}) => {
-  const operatorToken = route.params.operatorToken;
-  const endpoint = route.params.endpoint;
+const MerchantPayoutStack: FunctionComponent<
+  MerchantPayoutStackScreenProps
+> = ({ navigation, route }) => {
+  const operatorToken =
+    route.params?.operatorToken || route.params?.params?.operatorToken;
+  const endpoint = route.params?.endpoint || route.params?.params?.endpoint;
 
   const key = `${operatorToken}${endpoint}`;
 
@@ -42,24 +39,25 @@ const MerchantPayoutStack: FunctionComponent<Props> = ({
 
   useEffect(() => {
     if (!hasDataFromStore) {
-      navigation.getParent()?.navigate("CampaignLocationsScreen");
+      navigation.navigate(Screens.CampaignLocationsScreen, {
+        shouldAutoLoad: true,
+      });
     }
   }, [hasDataFromStore, navigation]);
 
   return hasDataFromStore ? (
     <AuthContextProvider authCredentials={authCredentials[key]!}>
       <CampaignConfigContextProvider campaignConfig={allCampaignConfigs[key]!}>
-        {/* <Stack navigation={navigation} /> */}
         <Stack.Navigator
+          initialRouteName={Screens.MerchantPayoutScreen}
           screenOptions={screenOptions}
-          initialRouteName="MerchantPayoutScreen"
         >
           <Stack.Screen
-            name="MerchantPayoutScreen"
+            name={Screens.MerchantPayoutScreen}
             component={MerchantPayoutScreen}
           />
           <Stack.Screen
-            name="PayoutFeedbackScreen"
+            name={Screens.PayoutFeedbackScreen}
             component={PayoutFeedbackScreen}
           />
         </Stack.Navigator>

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,112 +8,220 @@ import {
   CompositeNavigationProp,
   CompositeScreenProps,
   NavigatorScreenParams,
+  RouteProp,
 } from "@react-navigation/native";
 import { StackNavigationProp, StackScreenProps } from "@react-navigation/stack";
 
-export type RootDrawerParamList = {
-  CampaignLocationsScreen: {
-    shouldAutoLoad: boolean;
-  };
-  CustomerQuotaStack: CustomerQuotaStackParamList;
-  MerchantPayoutStack: MerchantPayoutStackParamList;
+/* == Start of Navigation Types ==
+  - TODO consider splitting this portion to navigation/types.ts
+  - use enum to define Screen and Stack names
+*/
+
+export enum Screens {
+  CampaignInitialisationScreen = "Campaign Initialisation Screen",
+  LoginScreen = "Login Screen",
+  LogoutScreen = "Logout Screen",
+  CampaignLocationsScreen = "Campaign Locations Screen",
+
+  MerchantPayoutScreen = "Merchant Payout Screen",
+  PayoutFeedbackScreen = "Payout Feedback Screen",
+
+  CollectCustomerDetailsScreen = "Collect Customer Details Screen",
+  CustomerQuotaProxy = "Customer Quota Proxy",
+  CustomerQuotaScreen = "Customer Quota Screen",
+  CustomerAppealScreen = "Customer Appeal Screen",
+  DailyStatisticsScreen = "Daily Statistics Screen",
+}
+
+export enum Stacks {
+  DrawerNavigator = "Drawer Navigator",
+  CustomerQuotaStack = "Customer Quota Stack",
+  MerchantPayoutStack = "Merchant Payout Stack",
+}
+
+export enum Drawers {
+  MainDrawer = "Main Drawer",
+}
+
+/*
+  - Usage of Computed Property https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#computed_property_names
+  - NavigatorScreenParams allow us to navigate() through nested navigators
+*/
+export type RootStackParams = {
+  [Screens.CampaignInitialisationScreen]: CampaignInitialisationScreenParams;
+  [Screens.LoginScreen]: undefined;
+  [Drawers.MainDrawer]: NavigatorScreenParams<MainDrawerParams>;
+  [Screens.LogoutScreen]: undefined;
 };
 
-export type RootStackParamList = {
-  CampaignInitialisationScreen: {
-    authCredentials: AuthCredentials;
-  };
-  LoginScreen: undefined;
-  DrawerNavigator: NavigatorScreenParams<RootDrawerParamList>;
-  LogoutScreen: undefined;
+export type MainDrawerParams = {
+  [Screens.CampaignLocationsScreen]: CampaignLocationScreenParams;
+  [Stacks.CustomerQuotaStack]: NavigatorScreenParams<CustomerQuotaStackParams>;
+  [Stacks.MerchantPayoutStack]: NavigatorScreenParams<MerchantPayoutStackParams>;
 };
 
-export type MerchantPayoutStackParamList = {
-  MerchantPayoutScreen: {
-    operatorToken: string;
-    endpoint: string;
-  };
-  PayoutFeedbackScreen: {
+export type MerchantPayoutStackParams = {
+  [Screens.MerchantPayoutScreen]:
+    | {
+        operatorToken: string;
+        endpoint: string;
+      }
+    | undefined;
+  [Screens.PayoutFeedbackScreen]: {
     checkoutResult: PostTransactionResult;
     merchantCode: string;
   };
 };
 
-export type CustomerQuotaStackParamList = {
-  CollectCustomerDetailsScreen: undefined;
-  CustomerQuotaProxy: {
-    operatorToken: string;
-    endpoint: string;
+export type CustomerQuotaStackParams = {
+  [Screens.CollectCustomerDetailsScreen]:
+    | {
+        operatorToken: string;
+        endpoint: string;
+      }
+    | undefined;
+  [Screens.CustomerQuotaProxy]: {
     id: string;
     products: CampaignPolicy[];
   };
-  CustomerQuotaScreen: {
-    navIds: string[];
-  };
-  CustomerAppealScreen: {
-    ids: string[];
-  };
-  DailyStatisticsScreen: undefined;
+  [Screens.CustomerQuotaScreen]: { navIds: string[] };
+  [Screens.CustomerAppealScreen]: { ids: string[] };
+  [Screens.DailyStatisticsScreen]: undefined;
 };
 
-export type DrawerNavigationProps = CompositeScreenProps<
-  DrawerScreenProps<RootDrawerParamList>,
-  StackScreenProps<RootStackParamList>
+export type CampaignInitialisationScreenParams = {
+  authCredentials: AuthCredentials;
+};
+
+export type CampaignLocationScreenParams = {
+  shouldAutoLoad: boolean;
+};
+
+// === RootStack ===
+
+export type CampaignInitialisationScreenNavigationProps = StackScreenProps<
+  RootStackParams,
+  Screens.CampaignInitialisationScreen
 >;
 
-export type CustomerQuotaStackNavigationProp = CompositeNavigationProp<
+export type InitialisationContainerNavigationProps = StackScreenProps<
+  RootStackParams,
+  Screens.LoginScreen
+>;
+
+export type LogoutScreenNavigationProps = StackScreenProps<
+  RootStackParams,
+  Screens.LoginScreen
+>;
+
+// === MainDrawer ===
+// --- CampaignLocationsScreen ---
+
+export type CampaignLocationsScreenNavigationProps = CompositeScreenProps<
+  DrawerScreenProps<MainDrawerParams, Screens.CampaignLocationsScreen>,
+  StackScreenProps<RootStackParams>
+>;
+
+// --- CustomerQuotaStack ---
+export type CustomerQuotaStackNavigationProps = CompositeNavigationProp<
   StackNavigationProp<
-    CustomerQuotaStackParamList,
-    keyof CustomerQuotaStackParamList
+    CustomerQuotaStackParams,
+    Screens.CollectCustomerDetailsScreen
   >,
   CompositeNavigationProp<
-    DrawerNavigationProp<RootDrawerParamList>,
-    StackNavigationProp<RootStackParamList>
+    DrawerNavigationProp<MainDrawerParams>,
+    StackNavigationProp<RootStackParams>
   >
 >;
 
+export type CustomerQuotaStackScreenProps = {
+  navigation: CustomerQuotaStackNavigationProps;
+  route: RouteProp<
+    CustomerQuotaStackParams,
+    Screens.CollectCustomerDetailsScreen
+  > & {
+    params: { params: { operatorToken: string; endpoint: string } };
+  };
+};
+
 export type CollectCustomerDetailsScreenNavigationProps = CompositeScreenProps<
-  StackScreenProps<CustomerQuotaStackParamList, "CollectCustomerDetailsScreen">,
+  StackScreenProps<
+    CustomerQuotaStackParams,
+    Screens.CollectCustomerDetailsScreen
+  >,
   CompositeScreenProps<
-    DrawerScreenProps<RootDrawerParamList>,
-    StackScreenProps<RootStackParamList>
+    DrawerScreenProps<MainDrawerParams>,
+    StackScreenProps<RootStackParams>
   >
 >;
 
 export type CustomerQuotaProxyNavigationProps = CompositeScreenProps<
-  StackScreenProps<CustomerQuotaStackParamList, "CustomerQuotaProxy">,
+  StackScreenProps<CustomerQuotaStackParams, Screens.CustomerQuotaProxy>,
   CompositeScreenProps<
-    DrawerScreenProps<RootDrawerParamList>,
-    StackScreenProps<RootStackParamList>
+    DrawerScreenProps<MainDrawerParams>,
+    StackScreenProps<RootStackParams>
   >
 >;
 
 export type CustomerQuotaScreenNavigationProps = CompositeScreenProps<
-  | StackScreenProps<CustomerQuotaStackParamList, "CustomerQuotaScreen">
-  | StackScreenProps<CustomerQuotaStackParamList, "CustomerQuotaProxy">,
+  | StackScreenProps<CustomerQuotaStackParams, Screens.CustomerQuotaScreen>
+  | StackScreenProps<CustomerQuotaStackParams, Screens.CustomerQuotaProxy>,
   CompositeScreenProps<
-    DrawerScreenProps<RootDrawerParamList>,
-    StackScreenProps<RootStackParamList>
+    DrawerScreenProps<MainDrawerParams>,
+    StackScreenProps<RootStackParams>
   >
 >;
 
 export type CustomerAppealScreenNavigationProps = CompositeScreenProps<
-  StackScreenProps<CustomerQuotaStackParamList, "CustomerAppealScreen">,
+  StackScreenProps<CustomerQuotaStackParams, Screens.CustomerAppealScreen>,
   CompositeScreenProps<
-    DrawerScreenProps<RootDrawerParamList>,
-    StackScreenProps<RootStackParamList>
+    DrawerScreenProps<MainDrawerParams>,
+    StackScreenProps<RootStackParams>
   >
 >;
 
 export type DailyStatisticsScreenProps = CompositeScreenProps<
-  StackScreenProps<CustomerQuotaStackParamList, "DailyStatisticsScreen">,
+  StackScreenProps<CustomerQuotaStackParams, Screens.DailyStatisticsScreen>,
   CompositeScreenProps<
-    DrawerScreenProps<RootDrawerParamList>,
-    StackScreenProps<RootStackParamList>
+    DrawerScreenProps<MainDrawerParams>,
+    StackScreenProps<RootStackParams>
   >
 >;
 
-//
+// --- MerchantPayoutStack ---
+export type MerchantPayoutStackNavigationProps = CompositeNavigationProp<
+  StackNavigationProp<MerchantPayoutStackParams, Screens.MerchantPayoutScreen>,
+  CompositeNavigationProp<
+    DrawerNavigationProp<MainDrawerParams>,
+    StackNavigationProp<RootStackParams>
+  >
+>;
+
+export type MerchantPayoutStackScreenProps = {
+  navigation: MerchantPayoutStackNavigationProps;
+  route: RouteProp<MerchantPayoutStackParams, Screens.MerchantPayoutScreen> & {
+    params: { params: { operatorToken: string; endpoint: string } };
+  };
+};
+
+export type MerchantPayoutScreenNavigationProps = CompositeScreenProps<
+  StackScreenProps<MerchantPayoutStackParams, Screens.MerchantPayoutScreen>,
+  CompositeScreenProps<
+    DrawerScreenProps<MainDrawerParams>,
+    StackScreenProps<RootStackParams>
+  >
+>;
+
+export type PayoutFeedbackScreenNavigationProps = CompositeScreenProps<
+  StackScreenProps<MerchantPayoutStackParams, Screens.PayoutFeedbackScreen>,
+  CompositeScreenProps<
+    DrawerScreenProps<MainDrawerParams>,
+    StackScreenProps<RootStackParams>
+  >
+>;
+
+/* == End of Navigation Types == */
+
 export type AuthCredentials = {
   operatorToken: string;
   endpoint: string;


### PR DESCRIPTION
[Expo Upgrade](https://www.notion.so/sally-wallet/Chore-Upgrade-Expo-SDK-to-45-explore-Mobile-E2E-on-local-PR-env-86cee57ced264f6fbfb5cc8650ed8a1e) <!-- Remove this link if no relevant Notion link -->

This PR adds...
- type refactoring for expo-45-upgrade
- work in progress - yet to figure a way to navigate and pass params into `CustomerQuotaStack`. 
   - usually navigate is to screen..?
   - prob same issue for `MerchantPayoutStack`

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [ ] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
