### PR TITLE
feat: add configurable timeout in seconds for PayNow

### DIFF
--- a/src/services/helpers.ts
+++ b/src/services/helpers.ts
@@ -47,7 +47,8 @@ export async function fetchWithValidator<T, O, I>(
   validator: Type<T, O, I>,
   requestInfo: RequestInfo,
   init?: RequestInit,
-  includeCodes = false
+  includeCodes = false,
+  timeoutInSeconds?: number
 ): Promise<T> {
   let response: Response;
   /*
@@ -65,7 +66,7 @@ export async function fetchWithValidator<T, O, I>(
       : new AbortController();
     response = await Promise.race<Response>([
       fetch(requestInfo, { ...init, signal: controller.signal }),
-      timeoutAfter(10).then((timeoutError) => {
+      timeoutAfter(timeoutInSeconds ?? 10).then((timeoutError) => {
         controller.abort();
         throw timeoutError;
       }),

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -316,7 +316,7 @@ export const livePostTransaction = async ({
         }),
       },
       includeErrorCodes,
-      isPayNowTransaction ?? 45 // timeout in seconds
+      isPayNowTransaction ? 45 : 10 // timeout in seconds
     );
     return response;
   } catch (e) {

--- a/src/services/quota/index.tsx
+++ b/src/services/quota/index.tsx
@@ -315,7 +315,8 @@ export const livePostTransaction = async ({
           transaction: transactions,
         }),
       },
-      includeErrorCodes
+      includeErrorCodes,
+      isPayNowTransaction ?? 45 // timeout in seconds
     );
     return response;
   } catch (e) {


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Aligning-timeouts-in-PayNow-API-calls-between-SupplyAlly-and-GovWallet-fac6ac4a0aa44b06aed8360e3395c224) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- configurable timeout for PayNow create endpoint on Sally
- change timeout to 45 

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
