### PR TITLE
style: margin top for ios to exit help & support

### DIFF
--- a/src/components/HelpModal/HelpModal.tsx
+++ b/src/components/HelpModal/HelpModal.tsx
@@ -130,7 +130,7 @@ export const HelpModal: FunctionComponent<{
       onRequestClose={onRequestClose}
       animationType="slide"
     >
-      <SafeAreaView style={{ flex: 1 }}>
+      <SafeAreaView style={{ flex: 1, marginTop: size(4) }}>
         <View style={[styles.bar, styles.topBar]}>
           <AppText style={styles.pageTitle}>
             {i18nt("navigationDrawer", "helpSupport")}


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/07-GovSupply-mobile-app-Redirect-Need-help-Help-Support-from-Zendesk-to-Isomer-landing-si-e964496535d74e4b99efb6df6a1742ba?d=67ec4aa6290f4de3a7f186236cedbcd3) <!-- Remove this link if no relevant Notion link -->

This PR adds... <!-- A brief description of what your PR does -->
- top margin, ensuring that we can click the exit icon (cross) in the help and support page 
**BEFORE**
![IMG_0018](https://github.com/rationally-app/mobile-application/assets/43963814/e3578882-9000-4a45-a2bc-d408c4fd650a)
**AFTER**
![IMG_0016](https://github.com/rationally-app/mobile-application/assets/43963814/69910532-1186-4031-a764-bb67baa767fe)

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [ ] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
