### PR TITLE
fix: redirection of GS email and webview render issue [SGW-4160]

### DIFF
--- a/src/components/HelpModal/HelpModal.tsx
+++ b/src/components/HelpModal/HelpModal.tsx
@@ -5,7 +5,13 @@ import React, {
   useState,
 } from "react";
 import { WebView, WebViewProps } from "react-native-webview";
-import { View, StyleSheet, TouchableOpacity, Modal } from "react-native";
+import {
+  View,
+  StyleSheet,
+  TouchableOpacity,
+  Modal,
+  Linking,
+} from "react-native";
 import { Feather } from "@expo/vector-icons";
 import { DarkButton } from "../Layout/Buttons/DarkButton";
 import { size, color, borderRadius, fontSize } from "../../common/styles";
@@ -87,8 +93,7 @@ export const HelpModal: FunctionComponent<{
 
   const onPressAskQuestion = (): void => {
     if (webViewRef.current) {
-      const redirectTo = `${SUPPORT_URL}`;
-      webViewRef.current.injectJavaScript(redirectTo);
+      Linking.openURL(SUPPORT_URL);
     }
   };
 

--- a/src/components/HelpModal/HelpModal.tsx
+++ b/src/components/HelpModal/HelpModal.tsx
@@ -19,7 +19,8 @@ import { AppText } from "../Layout/AppText";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
 
-const SUPPORT_URL = "mailto:govsupply_support@tech.gov.sg";
+const FAQ_SUPPORT_URL = "https://www.supply.gov.sg/faqs/supportrelated/";
+const SUPPORT_EMAIL_REF = "mailto:govsupply_support@tech.gov.sg";
 
 const styles = StyleSheet.create({
   bar: {
@@ -93,7 +94,7 @@ export const HelpModal: FunctionComponent<{
 
   const onPressAskQuestion = (): void => {
     if (webViewRef.current) {
-      Linking.openURL(SUPPORT_URL);
+      Linking.openURL(SUPPORT_EMAIL_REF);
     }
   };
 
@@ -146,7 +147,7 @@ export const HelpModal: FunctionComponent<{
         </View>
         <WebView
           ref={webViewRef}
-          source={{ uri: SUPPORT_URL }}
+          source={{ uri: FAQ_SUPPORT_URL }}
           onNavigationStateChange={onNavigationStateChange}
         />
         <View style={[styles.bar, styles.bottomBar]}>

--- a/src/components/HelpModal/HelpModal.tsx
+++ b/src/components/HelpModal/HelpModal.tsx
@@ -87,7 +87,7 @@ export const HelpModal: FunctionComponent<{
 
   const onPressAskQuestion = (): void => {
     if (webViewRef.current) {
-      const redirectTo = `window.location = "${SUPPORT_URL}"`;
+      const redirectTo = `${SUPPORT_URL}`;
       webViewRef.current.injectJavaScript(redirectTo);
     }
   };


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/GovSupply-s-App-Ask-a-question-Webapp-s-Help-Support-Link-to-govsupply_support-tech-gov-sg-a652da071d504e13a8b7ce4a2eda5118) <!-- Remove this link if no relevant Notion link -->

This PR... <!-- A brief description of what your PR does -->
- removes the window.location to direct them to their mail app
- splits `SUPPORT_URL` into `FAQ_SUPPORT_URL` and `SUPPORT_EMAIL_REF`
    -  `FAQ_SUPPORT_URL` is used to render the webpage inside the webview when users click `Help and Support`
    - `SUPPORT_EMAIL_REF` is used in the `onPressAskQuestion` function

<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [x] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [x] I've requested reviews from 1-2 reviewers
