### PR TITLE
style: remove border for continue to app button on soft block screen [SGW-3617]

### DIFF
--- a/src/components/Login/BlockUser.tsx
+++ b/src/components/Login/BlockUser.tsx
@@ -4,7 +4,7 @@ import React, {
   SetStateAction,
   useEffect,
 } from "react";
-import { View, StyleSheet, Image, Text } from "react-native";
+import { View, StyleSheet, Image } from "react-native";
 import { size } from "../../common/styles";
 import { Credits } from "../Credits";
 import { Sentry } from "../../utils/errorTracking";

--- a/src/components/Login/BlockUser.tsx
+++ b/src/components/Login/BlockUser.tsx
@@ -4,14 +4,16 @@ import React, {
   SetStateAction,
   useEffect,
 } from "react";
-import { View, StyleSheet, Image } from "react-native";
+import { View, StyleSheet, Image, Text } from "react-native";
 import { size } from "../../common/styles";
 import { Credits } from "../Credits";
 import { Sentry } from "../../utils/errorTracking";
 import * as Linking from "expo-linking";
-import { DarkButton, SecondaryButton } from "../Layout/Buttons";
+import { DarkButton } from "../Layout/Buttons";
 import { AppText } from "../Layout/AppText";
 import { useTranslate } from "../../hooks/useTranslate/useTranslate";
+import { BaseButton } from "../Layout/Buttons/BaseButton";
+import { useTheme } from "../../context/theme";
 
 const styles = StyleSheet.create({
   asset: {
@@ -87,6 +89,7 @@ export const BlockUser: FunctionComponent<BlockUserProps> = ({
   const handleWebNavigation = (): void => {
     Linking.openURL("https://app.supply.gov.sg");
   };
+  const { theme } = useTheme();
 
   return (
     <>
@@ -110,12 +113,21 @@ export const BlockUser: FunctionComponent<BlockUserProps> = ({
           />
         </View>
         <View style={styles.continueOnAppButton}>
-          <SecondaryButton
+          <BaseButton
             fullWidth={true}
-            text="Continue on App"
             onPress={() => setShouldBlock(false)}
             accessibilityLabel="continue-app"
-          />
+          >
+            <AppText
+              style={{
+                color: theme.secondaryButton.enabled.textColor,
+                fontFamily: "brand-bold",
+                textAlign: "center",
+              }}
+            >
+              Continue on App
+            </AppText>
+          </BaseButton>
         </View>
         <Credits style={styles.credits} />
       </View>


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/OTA-Block-GovSupply-Mobile-Application-for-usage-Stage-1-only-3ecd085cfd3347d7920846a7739cff00?d=7b93b8c98ca64e23a014bc0696216912#b77a63e08ff54ea6be261533cacb3e26) 

This PR... <!-- A brief description of what your PR does -->
- fixes desk check but removing border of Continue to App button on soft blocking screen 

<img width="400" alt="Screenshot 2024-06-19 at 5 50 29 PM" src="https://github.com/rationally-app/mobile-application/assets/43963814/34b685e4-2409-487e-9102-2ff583717de4">


<!-- This checklist is just a guideline.-->
<!-- If any of the following does not apply to your PR, please leave them unchecked and explain in the PR description -->

- [ ] I've kept this PR as small as possible (~600 lines) by splitting it into PRs with manageable chunks of code
- [ ] I've requested reviews from 1-2 reviewers
- [ ] I've added [accessibility IDs](https://www.notion.so/dc5f4ce910f7431c84344ac79344e9f5?v=d487366816834dd4ab8dc12e0b5928f3) to my components
- [ ] I've added/updated unit/integration tests
- [ ] I've added/updated [e2e tests](https://www.notion.so/e2e-Documentation-a096d3e0bf75485e85ad692af8371ef3) for at least the happy flow
- [ ] I've added [Chinese translations for i18n setup](https://www.notion.so/Translations-Dev-Guide-8c1da838982a4f59a386ec96ac6780c8)
- [ ] I've added documentation in README/[Notion](https://www.notion.so/82b92fb1007640328dab9582c0a3694e?v=3b6ce48202cf40ad8450553799b13146)
